### PR TITLE
docs: capability review — Aontu as a systems ground truth for agents

### DIFF
--- a/docs/capability-review/g1-constraint-algebra.md
+++ b/docs/capability-review/g1-constraint-algebra.md
@@ -1,0 +1,543 @@
+# G1: A real constraint algebra
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands the
+G1 entry in the review index: the vocabulary of constraint atoms, their
+lattice algebra, canonical syntax for bounds, the two-band
+architecture, residuation semantics, and the number-representation
+defect. Sibling documents own adjacent surfaces — see
+[Boundary](#boundary-what-we-will-not-do).*
+
+## Problem
+
+Today "type safety through unification" cashes out as five scalar
+kinds (`string`, `number`, `integer`, `boolean`, `top`), literal
+equality, disjunction-enums, and closedness. That is not enough to
+reject the most common class of wrong output an agent produces:
+values that are *type-safe but wrong*. Consider the best a
+definition can do today:
+
+```aon
+# service.aon — the best that five kinds can do
+service: {
+  name: string       # "My Service!!" passes
+  replicas: integer  # -3 passes
+  port: integer      # 99999 passes
+}
+```
+
+Every commented value unifies cleanly and generates. The definition
+cannot state, let alone enforce, that names are DNS labels, replica
+counts are bounded, and ports fit in sixteen bits. What the author
+wants to write — and cannot — is:
+
+```aon
+# service.aon — not expressible today
+service: {
+  name: string & re("^[a-z][a-z0-9-]{0,62}$")
+  replicas: integer & min(0) & max(50)
+  port: integer & min(1) & max(65535)
+}
+```
+
+`min`, `max`, and `re` are not in the parser's `funcMap`
+(`ts/src/lang.ts`), so each becomes an `unknown_function` error. The
+CUE spelling fares no better: `a: number > 0` is a parse error
+(verified live for the review), and the operator characters `-` `*`
+`/` `%` are deliberately reserved — `test/spec/op-chars.tsv` pins
+`6/2` and `6%2` as plain text and `6-2` and `6*2` as parse errors.
+
+A second thing an author cannot write is a cross-field invariant,
+even though the reference machinery for it already exists:
+
+```aon
+# scaling.aon — refs exist, but no atom can consume one as a bound
+scaling: {
+  floor: 2
+  ceiling: 10
+  target: integer & min($.scaling.floor) & max($.scaling.ceiling)
+}
+```
+
+`$.scaling.floor` is an ordinary Aontu reference
+(`test/spec/ref.tsv`), but there is no constraint value for it to
+parameterise.
+
+Third, there is wrong behaviour the spec suite itself pins: both
+implementations use IEEE-754 double number semantics, so
+`test/spec/scalar.tsv` row `hex-big` asserts that
+`a:0xffffffffffffffff` generates `18446744073709552000` — the true
+value is 18446744073709551615. An int64-scale quantity (memory
+bytes, a large ID) is silently corrupted by the ground truth that
+is supposed to guarantee it. This document decides and bounds that
+defect.
+
+Finally, the deepest reason this gap leads the review's sequencing:
+only a *symbolic* algebra can detect that a composed schema is
+self-contradictory before any data arrives. If one team's file says
+`port: min(1024)` and another's says `port: max(80)`, interval
+intersection decides the meet is empty at schema-composition time.
+Evaluate-only systems (CEL, KCL check blocks, Nickel contracts) can
+never do this — they discover the contradiction only when a
+candidate value happens to arrive. Everything downstream — the
+[G2](g2-validation-verb.md) `vet` verb,
+[G3](g3-subsumption-evolution.md) subsumption queries, JSON Schema
+export, witness generation — is bounded by what the lattice can
+express.
+
+## Current state
+
+What exists is a well-shaped kernel with the constraint stratum
+missing:
+
+- **Kinds.** `ts/src/val/ScalarKindVal.ts` implements four of the
+  five kinds as lattice values (`top` lives apart, in
+  `ts/src/val/TopVal.ts`): kind & matching scalar → scalar, kind &
+  kind narrows (`number & integer` → `integer`), mismatch → nil.
+  This is the one-row-deep version of exactly the behaviour
+  constraint atoms need.
+- **Conjunct normalisation.** `ConjunctVal.norm`
+  (`ts/src/val/ConjunctVal.ts`) flattens nested conjuncts and sorts
+  terms by `cjo` to make unification order-independent. Current
+  bands: `PrefVal` 30000, `RefVal` 32500, `DisjunctVal` 35000,
+  `ConjunctVal` 40000, default 99999 (`ts/src/val/Val.ts`). Terms
+  fold pairwise left to right; an empty conjunct evaporates to
+  `top`. This is where residual atoms must cluster and collapse.
+- **Disjunct trials.** `ts/src/val/DisjunctVal.ts` trials each
+  member against the peer in an error-scoped context
+  (`ctx._trialMode`, the `TRIAL_NIL` sentinel); erroring members are
+  dropped, duplicates removed via `same()`. A comment at ~line 263
+  admits the known generation defect: `({x:1}|{y:2})&{z:3}` folds
+  members incorrectly.
+- **One operator, deferring correctly.** `PlusOpVal` over
+  `OpBaseVal` (`ts/src/val/PlusOpVal.ts`, `ts/src/val/OpBaseVal.ts`)
+  computes only when both operands are concrete; otherwise it
+  re-wraps itself in a conjunct and is retried on later fixpoint
+  passes (bounded by `maxcc = 9` in `ts/src/unify.ts`).
+  `FuncBaseVal` (`ts/src/val/FuncBaseVal.ts`) has the same defer
+  branch. These are embryonic, ad-hoc residuation — the design
+  below formalises them.
+- **Functions as the extension idiom.** The parser's `funcMap`
+  (`ts/src/lang.ts`) holds exactly 12 builtins — `upper`, `lower`,
+  `copy`, `key`, `type`, `hide`, `move`, `path`, `pref`, `close`,
+  `open`, `super` — mirrored in `go/func.go`. Function canon renders
+  `name(args)` reparseably (`FuncBaseVal.canon`). `ExpectVal`
+  (`ts/src/val/ExpectVal.ts`) is *internal* spread-required
+  machinery, not a user-facing predicate — the design cannot lean
+  on a user-visible `expect()`.
+- **Located errors.** `NilVal.make` (`ts/src/val/NilVal.ts`) carries
+  a primary and secondary site, later-in-source first — the natural
+  carrier for "constraint at site A rejected value at site B".
+- **Numbers.** Both implementations pin IEEE-754 double semantics;
+  `go/scalar.go` reimplements JS `Number.toString` formatting so
+  canon output is byte-identical.
+
+Structurally blocking: there is no `Val` kind that can represent a
+residual scalar predicate; there is no regex anywhere in the
+language; the grammar has no comparison tokens and deliberately
+reserves the characters that would supply them; and generation
+treats every non-concrete value as an error per-Val, so each new
+residual kind must define its own gen behaviour.
+
+## Prior art
+
+- **CUE bounds** are the worked-out reference semantics: `>x`,
+  `>=x`, `<x`, `<=x`, `!=x` over numbers and strings, `=~`/`!~`
+  regexes; bounds unify symbolically (`>5 & >8` simplifies to `>8`)
+  and residual bounds print in exported form. Costs observed in
+  CUE's history: a token surface that raised the learning floor
+  (Dagger dropped CUE as its users' top complaint), and evaluator
+  interactions with defaults and closedness that forced a multi-year
+  rewrite. CUE's issue history also supplies a demand-ordered
+  backlog: bounds and regex first, then length/count, then
+  time/format validators, then custom-message wrappers.
+- **Liquid types** (Rondon, Kawaguchi, Jhala, PLDI 2008) teach the
+  central lesson: the winning setting of the expressiveness dial is
+  predicates whose conjunction, emptiness, and implication are
+  cheaply computable — a closed vocabulary, no SMT solver. F* sits
+  at the other end and pays with proof flakiness and solver-version
+  nondeterminism, disqualifying for a dual-implementation language
+  whose product is deterministic answers.
+- **Scala refined / Iron** show a shippable solver-free surface: a
+  finite set of predicate constructors, each with a meet rule, an
+  emptiness rule, and a subsumption rule (a small implication
+  table); scalar-level `Not` composes fine without general
+  complement.
+- **Pkl** (`Int(isBetween(0, 1023))`), **KCL** check blocks with
+  failure messages, and **Nickel** contracts are the evaluate-only
+  band done well: arbitrary predicates, author messages, blame —
+  but no schema-schema reasoning at all. Nickel cannot answer "do
+  these two schemas conflict?".
+- **PVS predicate subtyping** contributes the reporting pattern:
+  obligations the checker cannot discharge are surfaced explicitly
+  (TCCs), never silently accepted — the model for honestly
+  reporting the evaluate-only band.
+- **LIFE residuation** (Aït-Kaci & Podelski, TOPLAS 1994):
+  an insufficiently-instantiated function suspends as a passive
+  constraint and re-fires as unification refines values, with
+  determinacy conditions worked out — the principled version of
+  Aontu's existing defer-and-retry loops.
+- **Semantic subtyping** (Frisch/Castagna) is the warning label:
+  general negation is sound only atop months of emptiness-procedure
+  machinery, twice over for TS and Go. Scalar negation does not
+  need it.
+
+## Design space
+
+**A. CUE-style bound tokens** (`>0`, `>=1 & <10`, `=~"^[a-z]+$"`).
+Maximum familiarity — CUE spellings are in LLM training data and are
+terse. But it spends at least seven new operator tokens in a grammar
+that deliberately reserves its operator characters
+(`test/spec/op-chars.tsv`), contradicts the recorded language
+principle "prefer new functions instead of creating new tokens or
+syntax" (IDEAS.md), grows the surface a constrained-decoding grammar
+([G7](g7-machine-access.md)) must carry, and commits both parsers to
+new precedence interactions with `&`, `|`, `*`, and `?`.
+
+**B. Function-form atoms** (`min(0)`, `max(10)`, `re("^[a-z]+$")`,
+`len(c)`). Zero grammar change: atoms enter through `funcMap`, the
+established extension point; canon already renders functions
+reparseably; the Go port mirrors a registry entry, not a grammar
+change. Cost: more verbose than `>0`, unfamiliar to CUE-trained
+readers and models — an agent will sometimes emit `>0` and must be
+redirected by a good parse hint.
+
+**C. Hybrid: tokens as sugar over function canon.** Parse `>0` but
+canonicalise to `min`/`above` form. Gets familiarity and a single
+canonical form, but pays the full token cost of A *plus* a
+two-spellings documentation burden, and the write/read asymmetry
+(write `>0`, read back `above(0)`) confuses exactly the
+round-tripping agents the language targets.
+
+**D. Evaluate-only predicates only** (the CEL/KCL position). Cheapest
+to build: check concrete data, never reason symbolically. But it
+forfeits emptiness detection and subsumption — the two capabilities
+the review identifies as the lattice's whole advantage — and reduces
+G1 to a feature CEL already does better. This is Band B alone, and
+it fails the brief.
+
+**E. Constraint mini-language in strings**
+(`constraint("0 <= _ <= 10")`). No grammar change, arbitrary syntax
+freedom — and a second parser to keep in TS/Go parity, opaque to
+canon, tooling, and grammar-constrained decoding. Rejected without
+reservation.
+
+**Recommendation: B**, with C's sugar deferred as an open question
+rather than rejected forever. The function form is the only option
+consistent with the codebase's actual extension mechanism and the
+language's recorded design principle; it keeps the grammar — the
+acquisition cost for both humans and models — frozen; and it makes
+TS/Go parity a registry-entry exercise rather than a parser project.
+The familiarity gap is mitigable at low cost: a targeted parse hint
+("`>` is not an Aontu operator; write `min(0)` / `above(0)`") in
+`ts/src/hints.ts` / `go/hints.go`, plus the published grammar and
+examples that G7 owns.
+
+## Proposed design
+
+### Vocabulary
+
+Nine new builtins join `funcMap` (`ts/src/lang.ts`) and the Go
+registry (`go/func.go`). Eight are Band A — full lattice citizens
+with defined meet, emptiness, subsumption, and canonical form. One is
+Band B — evaluate-only, honestly reported as such.
+
+| Atom | Band | Meaning |
+|------|------|---------|
+| `min(x)` | A | value ≥ x (number or string, lexical) |
+| `max(x)` | A | value ≤ x |
+| `above(x)` | A | value > x |
+| `below(x)` | A | value < x |
+| `neq(x, ...)` | A | value equals none of the listed scalars |
+| `re(p)` | A | string matches pattern p (unanchored) |
+| `len(c)` | A | length/count satisfies integer constraint c |
+| `unique()` | A | list elements pairwise distinct |
+| `must(c, msg)` | B | evaluate-only check with author message |
+
+Numeric bound atoms imply the `number` kind; string-argument bounds
+and `re` imply `string`; `unique` implies list; `len` applies to
+strings (length), lists (element count), and maps (entry count),
+with the domain fixed by the peer. Mixing domains in one meet
+(`min(0) & min("a")`) is empty and yields nil.
+
+`len` is compositional: its argument is any integer-domain
+constraint, so `len(3)` means exactly 3 and `len(min(2) & max(5))`
+means between 2 and 5 — "between 2 and 5 replicas" is
+`replicas: len(min(2) & max(5))` on the replica list (there is no
+list kind keyword; the domain resolves against the peer). The meet
+of `len(c1)` and `len(c2)` is `len(c1 & c2)`; its emptiness is the
+emptiness of `c & integer & min(0)`. The count/cardinality atom
+therefore reuses the numeric algebra instead of duplicating it.
+
+### The residual value and the algebra
+
+A new Val kind, `ConstraintVal` (`ts/src/val/ConstraintVal.ts`, Go
+`go/constraint.go`), is the normal form of any meet of Band A atoms
+over one domain: an interval (endpoints plus open/closed flags), an
+exclusion set (from `neq`), a set of regex atoms, a nested integer
+constraint for `len`, and a uniqueness flag. Rules:
+
+- **Meet.** atom & atom (same domain) → interval intersection,
+  exclusion-set union, regex-set union, recursive `len` meet.
+  `min(0) & min(5)` → `min(5)`. Constraint & concrete scalar →
+  membership check → the scalar, or nil. Constraint & kind → domain
+  narrowing (`integer & min(0)` keeps both; `string & min(0)` is
+  nil). Meets are commutative and idempotent by construction, so
+  the lattice guarantee is preserved.
+- **Emptiness**, decided eagerly at unification time: empty interval
+  (`min(5) & max(3)` → nil, with both sites reported); an
+  integer-narrowed interval containing no integer
+  (`integer & above(1) & below(2)` → nil); exclusions deleting a
+  point interval (`min(3) & max(3) & neq(3)` → nil); `len(c)` empty
+  iff its integer constraint is. Regex emptiness is deliberately
+  approximate: distinct `re` atoms accumulate as a residual and are
+  never declared empty — sound (no false conflicts), incomplete
+  (some contradictions surface only against data). This follows the
+  survey's regex-intersection approximation and avoids a product-
+  automaton procedure in two implementations.
+- **Subsumption** (consumed by [G3](g3-subsumption-evolution.md),
+  which owns its exposure): interval containment plus exclusion-set
+  and regex-set superset checks; `re` atoms compare by syntactic
+  equality only; `must` is opaque and reported as evaluate-only
+  residue, PVS-TCC style.
+- **Canonical form.** A residual `ConstraintVal` renders as its
+  normalised atoms joined by `&` in a fixed order — kind, lower
+  bound, upper bound, `neq` (arguments sorted), `re` (patterns
+  sorted), `len`, `unique`, `must` — matching the existing canon
+  style (`docs/reference-language.md`): no spaces, reparseable.
+  Because atoms are functions, `parse(canon(v)) == v` holds through
+  the existing function-canon path: the reparse produces a conjunct
+  of atoms that normalises back to the identical `ConstraintVal`.
+
+```aon
+# canon round-trip
+a: integer & max(10) & min(0) & min(2)
+# canon: {"a":integer&min(2)&max(10)}
+```
+
+### Conjunct ordering and disjunct trials
+
+`ConstraintVal` (and unresolved atom functions) take `cjo = 50000`:
+after `ConjunctVal` (40000) so flattening happens first, before the
+default band (99999) where concrete values live. Constraint atoms
+therefore cluster adjacently in `ConjunctVal.norm` and fold into a
+single normalised residual before meeting the concrete term. Ties
+never depend on sort stability: normalisation, not ordering, defines
+the result — but the Go port must still use a stable sort
+(`sort.SliceStable`) in `go/conjunct.go` to keep canon output
+byte-identical for mixed bands.
+
+In `DisjunctVal` trials, atoms behave as ordinary values:
+`(min(0) | string) & -5` trials `min(0) & -5` (nil, member dropped)
+and `string & -5` (nil), leaving `|:empty`. A *residual* member adds
+no trial errors, so it survives the trial — disjunctions of
+constraints stay symbolic until data arrives. The known
+`DisjunctVal.gen` fold defect (`ts/src/val/DisjunctVal.ts` ~263)
+must not be worsened: spec rows pin generation for
+constraint-bearing disjuncts (`*8080 | min(1024)` generates `8080`)
+before any code lands, and the fold is guarded against conjoining a
+residual constraint into a chosen branch.
+
+### Residuation and cross-field bounds
+
+An atom whose argument contains an unresolved reference, or whose
+peer is not yet concrete, *residuates*: it produces no error,
+remains in place, and is re-evaluated on subsequent fixpoint passes
+— the LIFE semantics, formalising the defer branches that
+`OpBaseVal` and `FuncBaseVal` already contain. Because atoms only
+ever suspend or intersect (never force evaluation), evaluation
+order cannot change results. In the `scaling.aon` example from the
+[Problem](#problem) section, `target` residuates until `floor` and
+`ceiling` are concrete, then normalises to `integer&min(2)&max(10)`.
+The pass bound remains `maxcc = 9` (`ts/src/unify.ts`); whether
+exhaustion with live residuals becomes a distinct semantic error is
+owned by [G5](g5-trust-contract.md). A residual that survives to
+generation is an error, exactly like an unresolved kind today.
+
+### Band B: `must`
+
+`must(c, msg)` wraps any Aontu value `c` as an evaluate-only check:
+it residuates until its peer is concrete, then requires the peer to
+unify with `c`; on failure the author's message is attached to the
+nil. `must` never participates in emptiness or subsumption, and any
+report that includes one states the check was evaluate-only. Its
+initial predicate power is deliberately thin — the language has no
+boolean expression layer, and [G8](g8-generation.md)'s total
+combinators will widen what `c` can say. Its architectural point is
+the honest channel: a place for domain rules beyond the algebra that
+does not pretend to be algebra.
+
+```aon
+tier: string & must("gold" | "silver" | "bronze",
+  "tier must be a support tier name")
+```
+
+### Error behaviour
+
+A constraint violation is a `NilVal` with two sites — the
+constraint's and the value's, later-in-source primary as today
+(`ts/src/val/NilVal.ts`) — and a message in the existing family:
+`Cannot unify value: 99999 with value: max(65535)` (only the
+asserted substring is contractual, per the spec-suite convention).
+The nil's `details` field carries machine-readable data: the failing
+atom, the normalised admissible interval/sets, and any `must`
+message. The rendering of that data into reports, codes, and formats
+is owned by [G2](g2-validation-verb.md); G1 only guarantees the data
+is present.
+
+### Numbers: decide and bound the defect
+
+Decision: Aontu **keeps IEEE-754 double semantics** — and removes
+the *silent* part of the defect. An integer-kind literal whose
+double representation is not exact becomes a located parse-time
+error (`lossy integer literal`) instead of rounding. Float literals
+and exponent forms are untouched: approximation is expected of
+`number`. The language contract becomes explicit: integers are exact
+in [−2^53, 2^53]; the bounds algebra compares exactly within that
+range; outside it, the definition refuses to pretend.
+
+This flips three existing spec rows (`hex-big`, `hex-big-canon`,
+`hex-huge` in `test/spec/scalar.tsv`) to `err` — the only
+deliberate row changes in this design, sequenced as a breaking
+change under [G3](g3-subsumption-evolution.md)'s process. Migrating to
+arbitrary-precision decimals (CUE's choice) is explicitly out of
+scope: it would touch every scalar path in two implementations,
+destabilise the canon formatting that `go/scalar.go` painstakingly
+matches to JS `Number.toString`, and invalidate canon-hash pinning
+([G6](g6-distribution.md)) for every existing document. Loud
+refusal now preserves the option later.
+
+### API/CLI surface
+
+None new. The algebra surfaces through existing evaluation and
+canon; validation verbs are G2's, subsumption queries G3's, query
+and provenance G7's. G1's deliverable is that those surfaces have
+something worth exposing.
+
+## Boundary: what we will not do
+
+- **No SMT solver.** Solver nondeterminism and proof flakiness are
+  disqualifying for a dual-implementation language whose product is
+  deterministic answers (index: traps to refuse).
+- **No general negation or complement.** Sound only atop
+  semantic-subtyping machinery costing months twice over; `neq` and
+  exclusion sets cover the scalar cases that matter (index trap).
+- **No comparison-operator tokens.** The `op-chars.tsv` reservations
+  stand; grammar size is acquisition cost, and the surface-creep
+  trap is CUE's documented scar (index trap; sugar remains an open
+  question, not a plan).
+- **No arbitrary-precision decimal migration.** Bounded instead by
+  loud lossy-literal errors and an explicit exactness contract; full
+  migration would destabilise canon, parity, and semantic hashing.
+- **No time/format/net validator library.** That is the later
+  stdlib stratum in CUE's demand ordering, and its hermeticity
+  questions belong to [G5](g5-trust-contract.md).
+- **No quantified cross-child cardinality atoms.** "Exactly one
+  child with `primary: true`" awaits [G8](g8-generation.md)'s total
+  combinators (`len` over a filter); until then `must` is the honest
+  stopgap.
+- **No user-defined predicates or functions.** Recursion trades away
+  the termination guarantee (index trap); abstraction power is
+  G8's question to resolve on the total side.
+- **No error formats, codes, or CLI verbs** — G2 owns them; **no
+  subsumption exposure** — G3; **no budget/termination semantics** —
+  G5.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| TS/Go regex divergence (JS engine vs RE2) | High | High | Pin an RE2-compatible pattern subset in the spec; reject non-portable patterns (backreferences, lookaround) at construction with a located error; spec rows for rejected patterns |
+| Canon round-trip breaks on bound arguments (float formatting) | Medium | High | Reuse the existing JS-number formatter on both sides (`go/scalar.go`); a round-trip spec row for every atom and every normalisation rule |
+| `DisjunctVal.gen` fold defect compounds with residual members | Medium | Medium | Spec rows pinning disjunct-of-constraint generation land before code; guard the fold against conjoining residuals |
+| Residuals silently unresolved at `maxcc = 9` | Medium | High | Spec rows assert unresolved residual → generation error; escalate the silent-stop question to G5 as designed there |
+| Conjunct sort instability diverges between implementations | Low | Medium | Result defined by normalisation, not order; `sort.SliceStable` in `go/conjunct.go`; parity rows with mixed-band conjuncts |
+| Surface creep: 9 new builtins (12 → 21) | Medium | Medium | One family, one reference section, zero grammar change; demand-ordered phases allow stopping after bounds+regex |
+| Agents emit CUE spellings (`>0`, `=~`) | High | Low | Targeted parse hints in `ts/src/hints.ts` / `go/hints.go`; published grammar and examples via G7 |
+| Breaking spec-row change for lossy hex literals | Certain | Low | Single, deliberate, documented change; assessed with G3's breaking check once it exists |
+| Performance: per-pass regex recompilation, interval churn | Low | Medium | Compile-once cache keyed on pattern; intervals are O(1) merges; add perf-sensitive rows to the parity suite |
+
+## Implementation plan
+
+Every phase is spec-first: TSV rows are authored and reviewed before
+any implementation, TypeScript (canonical) lands first, the Go port
+follows, and `make test` runs both. Nothing may regress: all 44
+existing spec files (~426 rows) except the three rows Phase 6
+deliberately amends, and the canon round-trip property
+`parse(canon(v)) == v` throughout.
+
+1. **Phase 0 — algebra on paper (S).** Write the pairwise meet /
+   emptiness / subsumption tables and the canonical atom order into
+   a new section of `docs/reference-language.md`; author
+   `test/spec/constraint-bound.tsv`, `constraint-re.tsv`,
+   `constraint-len.tsv`, `constraint-cross.tsv` with canon, gen, and
+   err rows, including round-trip and order-independence rows
+   (`min(0)&max(10)` vs `max(10)&min(0)` → identical canon).
+2. **Phase 1 — numeric and lexical bounds, `neq` (M).** New
+   `ts/src/val/ConstraintVal.ts` plus atom entries in `funcMap`
+   (`ts/src/lang.ts`); `cjo` slot and fold interplay in
+   `ts/src/val/ConjunctVal.ts`; messages in `ts/src/err.ts` /
+   `ts/src/hints.ts`; rebuild committed dist (`make build-ts`).
+   Then `go/constraint.go`, `go/func.go`, `go/conjunct.go`,
+   `go/hints.go`.
+3. **Phase 2 — `re` (M).** Pinned RE2-compatible subset; portability
+   validation at construction in TS (`ts/src/val/ConstraintVal.ts`);
+   Go side is native `regexp`. Spec rows for matching, residual
+   accumulation, and rejected patterns.
+4. **Phase 3 — `len` and `unique` (M).** `len` reuses the integer
+   algebra recursively; domain resolution against string/list/map
+   peers touches `ts/src/val/ListVal.ts` and `MapVal.ts` membership
+   checks (`go/listval.go`, `go/mapval.go`).
+5. **Phase 4 — cross-field arguments and residuation (M).**
+   `RefVal`-valued atom arguments; residuation rows including
+   forward references and spread interplay (`&:` templates carrying
+   bounds onto children — the existing `spread-*.tsv` files must
+   pass unchanged); fixpoint behaviour rows at the `maxcc` boundary.
+6. **Phase 5 — `must` (S).** Wrapper Val, message plumbed into
+   `NilVal.details`; rows asserting evaluate-only reporting; the
+   report rendering itself waits for G2.
+7. **Phase 6 — number exactness (S).** Lossy-integer-literal error
+   in `ts/src/lang.ts` number handling and `go/lang.go`; amend
+   `scalar.tsv` rows `hex-big`, `hex-big-canon`, and `hex-huge` to
+   `err` mode — the one sanctioned regression, in its own commit.
+
+Ongoing, per the review's method: property-based differential
+testing of the algebra laws (commutativity, idempotence,
+normalisation convergence) across TS and Go, seeded from the atom
+vocabulary — the ShardStore lightweight-formal-methods pattern
+applied to the language itself.
+
+## Open questions
+
+- **Token sugar later?** Should `>0` ever parse as sugar for
+  `above(0)` once adoption data exists? For: CUE familiarity and
+  agent emissions observed in the wild. Against: grammar budget,
+  two spellings, the op-chars reservation policy. Decide after G7
+  publishes the grammar and real usage shows how often the hint
+  fires.
+- **String length semantics.** TS strings are UTF-16 code units, Go
+  strings are bytes with rune iteration — `len` on strings must pin
+  one definition (Unicode code points is least surprising and costs
+  Go nothing) and spec-test the astral-plane cases. A parity
+  landmine either way; a Phase 0 row, not an implementation
+  accident.
+- **Eager kind-tightening.** Should `integer & above(0.5)`
+  canonicalise to `integer&min(1)`, and `integer & above(1) &
+  below(2)` be eagerly empty (as proposed), or should integer
+  tightening be lazy (emptiness only, no endpoint rewriting)? Eager
+  gives stronger composition-time errors and sharper subsumption
+  for G3; lazy keeps canon closer to source. The Phase 0 meet
+  tables must pick one and pin it.
+- **Bare-`min` kinds.** `min(0)` alone implies `number`; should a
+  lint (G2's territory) nudge authors to write the kind explicitly
+  (`integer & min(0)`) for agent legibility, or is the implication
+  enough?
+- **`unique` with a projector.** `unique()` compares whole
+  elements; uniqueness by key ("no two services share a port")
+  needs a projection, which drags in G8's combinator questions.
+  Defer, but reserve the arity.
+- **How much admissible-set detail travels in `NilVal.details`.**
+  Repair-loop evidence says admissible alternatives drive agent
+  self-correction; the exact shape (interval endpoints? nearest
+  admissible value?) should be settled jointly with G2's report
+  schema so the data is produced once, correctly.

--- a/docs/capability-review/g2-validation-verb.md
+++ b/docs/capability-review/g2-validation-verb.md
@@ -1,0 +1,511 @@
+# G2: The validation verb
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G2 — turning Aontu from an evaluator of its own files into a guardrail
+that validates external data — with alternatives, an explicit boundary,
+risks, and an implementation plan.*
+
+## Problem
+
+The canonical agent loop is *emit, validate, repair*. Aontu's CLI
+(ts/src/cli.ts) supports none of it: it evaluates one file (or stdin)
+to JSON or canonical form, full stop. There is no way to hand the
+engine a definition and a separate piece of concrete data and ask "is
+this data admissible?". Because Aontu is a JSON superset, the
+unification machinery needed is already present — what is missing is
+the verb, and the machine-readable contract around it.
+
+Consider a schema an agent is meant to satisfy:
+
+```aon
+# service.aon
+service: close({
+  name:     string
+  port:     integer
+  replicas: integer
+  owner:    string
+})
+```
+
+An agent emits `deploy.json`:
+
+```json
+{ "service": { "name": "auth", "prot": 8080,
+               "replicas": "3", "owner": "team-identity" } }
+```
+
+The user wants to write `aontu vet service.aon deploy.json` — and
+cannot. The workaround is textual concatenation
+(`cat service.aon deploy.json | aontu`), which unifies — but every
+site now points into an anonymous synthetic document, the typo `prot`
+is reported without the closed struct's allowed keys or a nearest-key
+suggestion, the `"3"`-versus-`integer` conflict may never surface
+because the fixpoint stops after the first erroring pass
+(ts/src/unify.ts), and the report is ANSI-coloured prose on stderr
+(`color: { active: true }` is hard-coded in ts/src/err.ts) that an
+agent must regex-parse. Exit code 1 means only "something failed".
+
+Second example: drift detection. The same verb pointed at a live
+system dump is spec-versus-reality checking:
+
+```aon
+# system.aon
+services: &: {
+  image:    string
+  replicas: integer
+}
+services: auth: { image: "auth:v2.3", replicas: 3 }
+```
+
+The platform reports reality as `live.json`:
+
+```json
+{ "auth": { "image": "auth:v2.4", "replicas": 3 } }
+```
+
+The user wants `aontu vet system.aon live.json --at $.services` and
+to learn that `$.services.auth.image` conflicts — `"auth:v2.4"`
+observed at live.json:1, `"auth:v2.3"` declared at system.aon:6 — a
+located drift report. Today the dump must be hand-edited into an
+Aontu file that happens to nest under `services`, and the result is
+still prose.
+
+The deeper defect is the output contract. The survey's repair-loop
+evidence is that error *content* — failing path, observed value, and
+above all the admissible alternatives ("what would have unified
+here") — drives an agent's ability to self-correct; one benchmark
+reports gains of tens of percentage points from alternatives alone
+(a single-benchmark figure, per the critique pass, but the direction
+is corroborated). Aontu's errors carry two sites and a why-code but
+enumerate nothing: not the expected kind, not the closed struct's key
+set, not the surviving disjunct branches. And the spec suite
+conflates the two fundamentally different negative verdicts: in
+test/spec/error.tsv, `a:1 a:2` (a contradiction) and `a:number` (mere
+incompleteness) are both just `err` rows — yet for a gate, "your data
+contradicts the truth" and "your data has not yet supplied everything
+the truth requires" are different answers.
+
+## Current state
+
+What exists and is reusable:
+
+- **Unification of external JSON is free.** Any JSON document is
+  valid Aontu source, so "validate data against schema" is "unify two
+  parsed values and inspect the result". Parsing the data file with
+  the Aontu parser gives every node a site (`{row, col, url}`), so
+  external data slots into the two-site error model as-is.
+- **Collect mode.** `AontuOptions.collect` (ts/src/aontu.ts,
+  ts/src/ctx.ts) accumulates errors on `result.err` instead of
+  throwing; `AontuError.errs()` (ts/src/err.ts) exposes the raw
+  `NilVal` list. The LSP already builds a structured surface on
+  exactly this: `computeDiagnostics` (ts/src/lsp.ts) unifies with
+  `{collect: true}`, walks the tree collecting every `NilVal`
+  (`walkNils`), and maps `nil.why` to a diagnostic `code` with LSP
+  severity constants. This walk is the embryo of the vet report.
+- **A why-code vocabulary.** ts/src/hints.ts holds some forty
+  why-code strings (`scalar_kind`, `closed`, `no_path`,
+  `mapval_required`, …) plus five dynamic prefix patterns (`func:`,
+  `op:`, `var[`, `ref[`, `op[`), each with hint text; go/hints.go
+  mirrors it. These seed a stable code scheme, but nothing pins them:
+  test/spec/error.tsv asserts message substrings, not codes, so codes
+  can silently drift between implementations.
+- **The two-site error model.** `NilVal` (ts/src/val/NilVal.ts)
+  carries `why`, `primary`, `secondary`, `path`, `site`, `details`;
+  `NilVal.make` picks the primary by "later in the same file wins";
+  `descErr` (ts/src/err.ts) renders both sites with source context.
+- **Exit codes.** docs/reference-api.md documents 1 for an evaluation
+  error, 2 for a bad option — a two-way split, no verdict classes.
+
+What structurally blocks the capability:
+
+- **Single-document CLI.** ts/src/cli.ts accepts one file and two
+  output modes (`json`/`canon`); no (schema, data) pairing, no
+  anchor concept.
+- **First-error fixpoint break.** The pass loop in ts/src/unify.ts
+  (bounded at `maxcc = 9`) breaks as soon as `uctx.err` is non-empty;
+  go/unify.go does the same. Errors raised within one pass all
+  collect, but no later pass ever runs — multi-error reporting is
+  inherently truncated today.
+- **Prose-only rendering.** `descErr` produces ANSI-coloured terminal
+  text; no JSON serialisation of a `NilVal` exists outside the LSP's
+  partial mapping.
+- **No incomplete/contradiction distinction.** Residual `top`/kind
+  values become `nil_gen`/`no_gen`-family errors only at generate
+  time; test/spec/error.tsv and incomplete.tsv pin both as generic
+  `err` rows.
+- **Go has no public collect surface.** The Go API returns
+  `(Val, error)` with one wrapped message; `Ctx.collect` (go/ctx.go)
+  is internal optional-subtree machinery. A structured multi-finding
+  report is a genuinely new surface on the Go side.
+
+## Prior art
+
+**cue vet** is the direct model: `cue vet schema.cue data.yaml`
+validates YAML/JSON against constraints without exporting;
+concreteness is a separate dial (`vet -c`). It proves the verb's
+value — "validate data" is CUE's homepage headline — and its failure
+mode: output is prose, and CUE's community documents 3,000-line
+configs erroring with 30+ stacked sites and no root cause, debugged
+by bisection. Verb without contract does not serve agents.
+
+**SHACL validation reports** show the contract half: a standard
+machine-readable report vocabulary, three severities
+(`sh:Info`/`sh:Warning`/`sh:Violation`), author-attached `sh:message`
+on constraints. Cost: RDF-shaped verbosity, and no two-site conflict
+concept — SHACL checks data against shapes, it does not merge peers.
+
+**Rust and Elm** set the error-craft bar: stable codes (`E0123`) with
+mandatory long-form explanations, JSON diagnostics, suggestions
+graded by `Applicability` that rustfix applies automatically; Elm
+shows the code as written, both conflicting fragments, one plain
+sentence, one hint. Cost: a code registry is a forever-contract —
+every code frozen, documented, parity-tested.
+
+**SARIF** is the interchange standard CI systems and coding agents
+already consume (GitHub code scanning, MSVC, rustc); the critique
+pass flags "inventing a JSON report format" while ignoring SARIF as a
+survey blind spot. Cost: rule-centric and verbose; two-site conflicts
+squeeze into `relatedLocations`; much of the spec (code flows, fixes,
+baselines) is dead weight for a unifier.
+
+**Policy-as-code CI practice** (OPA/conftest, Kubernetes admission,
+buf breaking) settles the ergonomics: exit-code classes, a published
+GitHub Action, machine-readable output as table stakes, the engine as
+a deterministic decision service at the boundary — "the agent does
+not decide what is allowed; the policy engine does".
+**datacontract-cli** demonstrates the drift half: a definition is
+only ground truth if continuously verified against the running
+system.
+
+## Design space
+
+**A. Bless the concatenation idiom.** Document
+`cat schema.aon data.json | aontu` as the validation story. Zero
+cost; but sites collapse into one synthetic document, there is no
+report contract, no verdict classes, no anchor, and the identity
+claim ("Aontu is a gate") stays false. Rejected.
+
+**B. A thin `vet` verb, text output only (cue parity).** Add the CLI
+pairing, reuse `descErr`. Small (mostly ts/src/cli.ts); but it
+reproduces CUE's documented weakness — the output contract matters as
+much as the verb, and agents cannot branch on coloured prose.
+Rejected as an end state; it is a waypoint of the phased plan.
+
+**C. Vet with a full machine contract on today's engine.** The verb,
+JSON and SARIF reports, stable codes with classes, verdict-classed
+exit codes, admissible-alternative enumeration — the first-error
+fixpoint break kept and reported honestly (`truncated: true` when the
+pass loop stopped early). Moderate cost, no engine risk; the price is
+that repair loops may need several round trips to see all errors.
+
+**D. C plus an error-tolerant fixpoint.** Change ts/src/unify.ts and
+go/unify.go to localise a `nil` to its subtree and continue passes,
+collecting all independent errors in one run. Highest loop
+efficiency; but real engine surgery: `nil` is currently absorbing,
+and naive continuation risks exactly the cascading spurious-error
+pathology CUE users report (one root cause, thirty stacked findings),
+plus cost on the hot path.
+
+**E. Validation as a resident service instead of a CLI verb.** Ship
+validation as an LSP extension or MCP tool only. But the
+delivery-channel evidence (llms.txt versus AGENTS.md) says CI gates
+and exit codes are what pull a format into loops,
+[G7](g7-machine-access.md) owns the MCP surface and will wrap
+whatever engine call vet exposes, and a daemon without a CLI is
+untestable in the spec suite. Rejected as a substitute; correct as a
+later consumer.
+
+**Recommendation: C, with D as a follow-on engine phase.** The verb
+plus the contract changes the language's identity and is
+implementable now on collect mode and the existing `NilVal` walk.
+The repair literature supports the ordering: alternatives content,
+not error count, drives repair success — one well-furnished finding
+beats ten bare ones. Multi-error collection is then an efficiency
+upgrade whose absence the contract already marks (`truncated`), so
+the report shape does not change when D lands.
+
+## Proposed design
+
+### The verb
+
+```
+aontu vet [options] <schema.aon> <data.json|data.aon> [more-data...]
+
+  --at <path>        validate data against this path of the
+                     evaluated schema (e.g. --at $.services)
+  --format <f>       text | json | sarif        (default: text)
+  --closed           close() the anchor value for this run
+  --partial          incomplete residue is not a failure
+  --surplus          report unconstrained data keys (info severity)
+  --max-errors <n>   cap findings in the report (default 20)
+  --watch            re-run on file change, streaming reports
+```
+
+Semantics, in order:
+
+1. Evaluate `schema.aon` alone. If it errors, the *schema* is broken:
+   verdict `error`, exit 4 — never blamed on the data.
+2. Select the anchor: the evaluated root, or the value at `--at`;
+   `--closed` wraps it in `close()`.
+3. Parse each data file with the Aontu parser, so every data node
+   carries `{row, col, url}` sites pointing into the data file.
+4. Unify anchor & data under `{collect: true}`, then generate-check.
+   Parsed trees are single-use, so each data file gets a fresh
+   evaluation of the schema — the documented mutation caveat.
+5. Walk the result (the ts/src/lsp.ts `walkNils` pattern,
+   generalised): every `NilVal` is a finding; every residual
+   non-generable value (`top`, scalar kinds, unresolved required
+   keys) is an *incomplete* finding, a distinct class.
+6. Render the report in the chosen format; exit by verdict class.
+
+### Verdicts and exit codes
+
+| Verdict      | Meaning                                        | Exit |
+|--------------|------------------------------------------------|------|
+| `valid`      | unifies, fully concrete (or `--partial`)       | 0    |
+| `invalid`    | at least one contradiction-class finding       | 1    |
+| `incomplete` | no contradiction, but residue remains          | 3    |
+| `error`      | schema unusable (parse/unify failure)          | 4    |
+| —            | usage error (bad flags, unreadable file)       | 2    |
+
+Exit 2 stays reserved for usage, matching the existing CLI convention
+(docs/reference-api.md). The `invalid`/`incomplete` split is the
+mechanical answer to the error.tsv conflation: contradiction means
+the data can never satisfy the truth; incomplete means it does not
+yet. Agent-emitted whole documents want incomplete to fail (the
+default); layered drift checks over partial dumps want `--partial`.
+
+### The finding object
+
+`--format json` emits one object (stable field order, canonical value
+rendering, no ANSI):
+
+```json
+{ "aontu": { "version": "0.49.0", "verb": "vet" },
+  "verdict": "invalid", "truncated": false,
+  "findings": [
+    { "code": "no_scalar_unify", "class": "conflict",
+      "severity": "error", "path": "$.service.replicas",
+      "message": "Cannot unify value: \"3\" with value: integer",
+      "sites": [
+        { "file": "deploy.json", "row": 2, "col": 28,
+          "role": "data",   "value": "\"3\"" },
+        { "file": "service.aon", "row": 5, "col": 13,
+          "role": "schema", "value": "integer" } ],
+      "expected": "integer", "actual": "\"3\"",
+      "alternatives": ["integer"], "note": null },
+    { "code": "closed", "path": "$.service.prot",
+      "allowed": ["name", "owner", "port", "replicas"],
+      "nearest": "port", "...": "..." } ] }
+```
+
+Field semantics:
+
+- **`code`** — a frozen snake_case string: today's why-codes
+  (ts/src/hints.ts, go/hints.go) promoted to contract — append-only,
+  renames forbidden, each carrying a `class` and hint text. The
+  registry becomes a shared spec asset (`test/spec/errcodes.tsv`:
+  code, class, since-version) both implementations load in tests, so
+  code parity is assertable the way error substrings are today.
+- **`class`** — one of `conflict`, `incomplete`, `reference`,
+  `parse`, `budget` (cycle/pass-limit, per
+  [G5](g5-trust-contract.md)), `internal`. Verdicts derive from
+  classes, so new codes never change exit behaviour.
+- **`severity`** — `error`, `warning`, `info`. Conflict and
+  incomplete findings are errors; `warning` is reserved for the
+  [G3](g3-subsumption-evolution.md) deprecation mark and
+  [G1](g1-constraint-algebra.md)'s evaluate-only advisories; `info`
+  for `--surplus`. Maps one-to-one onto the LSP severity constants in
+  ts/src/lsp.ts and onto SARIF levels.
+- **`expected` / `actual` / `alternatives`** — the
+  admissible-alternatives contract, all rendered in canonical form
+  (deterministic and byte-identical across TS and Go, so reports are
+  diffable and cacheable). For a kind conflict, `expected` is the
+  kind's canon; for a failed disjunction, `alternatives` lists the
+  member canons a corrected value could still satisfy — rendered from
+  member canons, *not* via `DisjunctVal.gen`, which has a known fold
+  defect (ts/src/val/DisjunctVal.ts:263); for a closed struct,
+  `allowed` lists the key set and `nearest` gives an edit-distance-≤2
+  suggestion. When G1's bounds land, `expected` renders via G1's
+  canonical bound syntax — consumed here, defined there.
+- **`note`** — the author-attached message carried by G1's
+  message-bearing constraint wrappers. Reserved here; designed there.
+
+### The two-site model with external data
+
+`NilVal.make`'s primary/secondary heuristic ("later in the same file
+wins") is source-order reasoning within one document and says nothing
+useful when one side is external. Vet assigns site *roles* by URL
+provenance instead: a site whose `url` is a data file gets
+`role: "data"` and is listed first (the thing to fix); schema sites
+get `role: "schema"`. The underlying `NilVal` fields are unchanged —
+a report-layer projection — so the existing error.tsv message
+assertions do not move.
+
+### SARIF output
+
+`--format sarif` emits a minimal SARIF 2.1.0 profile: one run, one
+`result` per finding with `ruleId: "aontu/<code>"`, `level` from
+severity, the data site as primary `location`, the schema site under
+`relatedLocations`, the JSON finding embedded in `properties`.
+Nothing beyond this profile (no fixes, no code flows); enough for
+GitHub code-scanning upload and PR annotation.
+
+### Collect-mode API surface
+
+TypeScript (ts/src/vet.ts, exported from ts/src/aontu.ts):
+
+```ts
+const report = aontu.vet(schemaSrc, dataSrc, { at: '$.services' })
+// report: { verdict, truncated, findings: Finding[] } — never throws
+// for findings; throws AontuError only for unusable schema/args.
+```
+
+Go (go/vet.go):
+
+```go
+report, err := a.Vet(schemaSrc, dataSrc, aontu.VetOpts{At: "$.services"})
+// err != nil only for engine/schema failure; findings are data.
+```
+
+`Vet` is Go's first structured multi-finding surface, built on the
+internal error list the unifier already accumulates (go/ctx.go)
+rather than the single wrapped `AontuError` message. The report
+struct is the parity contract: both implementations must emit
+byte-identical JSON for the same inputs, pinned by spec rows.
+
+### CI ergonomics
+
+- **GitHub Action** (`aontu-vet-action`, separate repo): runs vet
+  over declared (schema, data) pairs, uploads SARIF, fails the job by
+  exit class. A pre-commit hook recipe ships in docs/how-to.md.
+- **Watch mode**: `--watch` re-runs on file mtime change, one report
+  per run. Honestly non-incremental: parsed trees are single-use, so
+  every run is a full re-parse and re-unify — acceptable at current
+  model sizes and bounded by the `maxcc = 9` fixpoint. Incremental
+  re-validation is future engine work; evaluation budgets belong to
+  [G5](g5-trust-contract.md).
+- **Resolver posture**: vet inherits the include resolver chain
+  (memory → filesystem → package, ts/src/lang.ts) and its documented
+  stance that opening an untrusted source is running it. Untrusted
+  schemas are a [G5](g5-trust-contract.md)/[G6](g6-distribution.md)
+  problem (sandboxing, pinning) — vet adds no fetching of its own.
+
+## Boundary: what we will not do
+
+- **No auto-applied fixes.** Suggestions are data; applying a patch
+  is [G7](g7-machine-access.md)'s format-preserving patch surface.
+- **No JSON Schema import/export inside vet.** Interop is a separate
+  capability and is lossy until G1's algebra exists.
+- **No constraint-bound design.** What `number > 0` means, its meet
+  and emptiness rules, and its canonical rendering belong to
+  [G1](g1-constraint-algebra.md); vet only reports them.
+- **No subsumption or breaking checks.** "Does v2 still admit v1?"
+  is [G3](g3-subsumption-evolution.md)'s verb.
+- **No lint-rule plugin framework.** Governance rules are ordinary
+  Aontu files unified over the target; a Spectral-style engine is
+  surface-area creep toward CUE, a trap in [index.md](index.md).
+- **No executable hooks in validation.** No callbacks or shell-outs
+  on findings — deterministic and total, per the
+  Turing-completeness trap.
+- **No LLM-graded validation.** Vet's answer to the
+  JSON-Schema-plus-prose null hypothesis is mechanical — two-site
+  conflicts, merge-as-unification, admissible alternatives — not
+  another eval harness.
+- **No incremental evaluation engine here.** Watch mode is
+  re-run-everything; incrementality is a later engine project shared
+  with the LSP.
+- **No full SARIF fidelity.** Minimal profile only; the JSON report
+  is the native contract.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| TS/Go report divergence (Go has no collect surface today) | Medium | High | Report JSON pinned byte-for-byte by shared vet spec rows; Go builds on the existing internal error list, not new semantics |
+| First-error truncation makes "multi-error report" oversell | High | Medium | `truncated: true` in the contract from day one; phased engine work (Phase 6) removes it; docs state the limit plainly |
+| Error-tolerant fixpoint causes cascading spurious findings (CUE's stacked-error pathology) | Medium | High | Gate Phase 6 behind spec rows for nil-localisation; `--max-errors` cap; findings deduplicated by (code, path) |
+| Freezing today's why-codes bakes in bad names | Medium | Low | Append-only registry with an alias/deprecation column; codes are contracts, hint text is not |
+| Alternatives enumeration touches the known DisjunctVal.gen fold defect | Medium | Medium | Render alternatives from member canons only; never call `gen` on a disjunct to enumerate; add regression spec rows |
+| Per-data-file schema re-evaluation is slow in watch/CI loops (single-use trees) | Medium | Medium | Acceptable now (`maxcc = 9` bounds passes); measure; incrementality is explicitly deferred, budgets are G5's |
+| Canon round-trip or existing error text regresses while adding classes | Low | High | `class` is additive on `NilVal`; error.tsv substrings and `parse(canon(v)) == v` stay green throughout |
+| Exit-class numbering collides with scripts assuming 0/1 | Low | Low | Non-zero on any failure is preserved; classes are refinements; documented in reference-api.md |
+| Adoption risk: agents default to JSON Schema validators | Medium | High | Ship the Action + SARIF so vet drops into existing CI; lead with what JSON Schema cannot do (two-site conflicts, merge-as-unification) |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows before code; TypeScript (canonical) first, Go port follows.
+Nothing may regress: the 45 existing spec files (~426 rows), the
+error.tsv substring assertions, and canon round-trip
+`parse(canon(v)) == v` stay green in every phase.
+
+**Phase 1 — error taxonomy groundwork (M).**
+Spec: new `test/spec/errcodes.tsv` (code, class, since-version); new
+error.tsv rows distinguishing incomplete from conflict (existing rows
+untouched). Code: ts/src/hints.ts (registry export),
+ts/src/val/NilVal.ts (`class` field), ts/src/err.ts; go/hints.go,
+go/val.go. Runners ts/test/spec.test.ts and go/spec_test.go learn to
+assert codes.
+
+**Phase 2 — vet engine API, TypeScript (M).**
+Spec: new `test/spec/vet.tsv` — columns name, schema, data, verdict,
+findings (`code@path` lists) — plus JSON-report goldens for a
+representative subset. Code: new ts/src/vet.ts (anchor selection,
+data parse, unify-with-collect, residue walk generalising
+ts/src/lsp.ts `walkNils`, finding construction); ts/src/aontu.ts
+export.
+
+**Phase 3 — CLI verb and JSON format (M).**
+Code: ts/src/cli.ts (`vet` subcommand, `--at`, `--format`, verdict
+exit classes); docs/reference-api.md, docs/how-to.md. Text renderer
+reuses `descErr`, with roles replacing the same-file primary
+heuristic for cross-file sites.
+
+**Phase 4 — Go port (L).**
+Code: go/vet.go, go/report.go, go/cmd/aontu, go/hints.go.
+go/spec_test.go runs vet.tsv and errcodes.tsv with no skip list,
+including byte-identical report JSON.
+
+**Phase 5 — SARIF, Action, watch (S).**
+Code: ts/src/report-sarif.ts and Go twin; `--watch` in both CLIs;
+`aontu-vet-action` repository; SARIF goldens in test/spec/files/.
+
+**Phase 6 — multi-error collection (L, engine).**
+Localise `nil` to its subtree and let the pass loop continue. Spec
+rows first: two independent conflicts must yield two findings;
+single-cause models exactly one. Code: ts/src/unify.ts (the
+`if (0 < uctx.err.length) break` site), affected Val classes;
+go/unify.go. Ships only if the cascade risk is demonstrably
+controlled by the spec rows; `truncated` then becomes rare.
+
+Rough sizing: S ≈ days, M ≈ a week or two, L ≈ several weeks per
+implementation.
+
+## Open questions
+
+- **Default completeness.** Should bare `vet` require full
+  concreteness (incomplete ⇒ exit 3) or admit partial data? Agent
+  emission favours strict; drift checks over partial dumps favour
+  `--partial`. Must be settled before the exit classes are documented
+  as stable.
+- **YAML ingestion.** Live dumps are often YAML. Accepting it means a
+  site-accurate YAML parser in *both* implementations, or a
+  documented `yq`-style conversion step; parser cost decides.
+- **Relaxed versus strict data parsing.** Full-grammar parsing lets
+  "data" carry operators and constraints — arguably a feature (a
+  candidate can refine the truth) but it blurs the data/schema role
+  labels. A `--strict-data` JSON mode is the conservative
+  alternative; the default depends on whether vet's contract is
+  "validate a document" or "validate a contribution".
+- **Registry source of truth.** Whether hints.ts generates
+  errcodes.tsv or errcodes.tsv generates both hint tables; the
+  generation direction decides which artifact is the contract.
+- **Anchor convention beyond `--at`.** A schema could name its own
+  validation entrypoints (an in-file mark), which travels better than
+  a flag once schemas are distributed ([G6](g6-distribution.md)) but
+  adds language surface; the flag ships first.
+- **Finding cap and ordering once Phase 6 lands.** CUE's thirty-site
+  pile-ups argue for a low default cap; agent loops argue for
+  data-site document order so repairs apply top-down.

--- a/docs/capability-review/g3-subsumption-evolution.md
+++ b/docs/capability-review/g3-subsumption-evolution.md
@@ -1,0 +1,575 @@
+# G3: Subsumption as a first-class query; schema evolution
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G3 — exposing the lattice's instance-of relation as a query, and
+building the schema-evolution story (breaking checks, compatibility
+policy, deprecation) on top of it. Sibling documents own adjacent
+surfaces — see [Boundary](#boundary-what-we-will-not-do).*
+
+## Problem
+
+Ground truth is a claim about *time*. Agents cache and act on stale
+snapshots of a definition; the definition evolves underneath them; and
+today Aontu cannot answer the one question that makes evolution safe:
+*does the new truth still honour the old one?* The lattice makes the
+principled answer nearly free — a value's instances are exactly the
+values below it in the ordering — yet no API, verb, or builtin exposes
+the relation.
+
+Consider a schema that a platform team ships and other teams' agents
+validate against:
+
+```aon
+# service-v1.aon
+service: close({
+  name: string
+  port: *8080 | integer
+})
+```
+
+```aon
+# service-v2.aon
+service: close({
+  name:  string
+  port:  *9090 | integer
+  owner: string
+})
+```
+
+The team wants a CI gate — the review index names the verb:
+`aontu breaking --against git#main service.aon` — that reports two
+findings: a required key `owner` was added to a closed struct (a
+v1-valid document without it is now rejected: backward-breaking), and
+the default port changed (every consumer that relied on the default
+now materialises a different config). No such verb exists. The only
+workaround is textual concatenation of the two files — which answers
+the wrong question. Verified live, it fails with `Cannot add to
+closed structure` at `$.service.owner`: a symmetric conflict that
+cannot distinguish "these schemas disagree" from "v2 no longer
+admits v1's instances". And it never reports the default change at
+all: the meet quietly holds `9090|8080|integer` for the port, and
+the equal-rank refusal (`Cannot unify value: 9090 with value: 8080`)
+would surface only at generation, which the closed error preempts.
+
+Nor can the check be derived naively from the engine. The obvious
+approximation — "a subsumes b if `a & b` comes out as `b`" — fails
+on exactly the values that matter, verified live against this
+repository's Go implementation:
+
+- `(*1|number) & (*1|number)` canonicalises to `*1|1|number` — even
+  `a & a` is not syntactically `a`, so the comparison misfires on
+  *identical* inputs.
+- `(*1|number) & number` canonicalises to `1|number` — the meet
+  silently erases the preference mark, so a derived check cannot see
+  default changes at all.
+- `close({x:1})` canonicalises to `{"x":1}`, and `hide(1)` to `1` —
+  canon does not render closedness or marks, so canon comparison is
+  blind to the two features that decide whether an extra key or an
+  omitted field is breaking.
+
+And parsed/unified trees are single-use (the documented mutation
+caveat), so the original `b` no longer exists to compare against
+once the meet is computed.
+
+Second failing example: default validity. A default is supposed to be
+one of its disjunct's alternatives, but nothing checks it:
+
+```aon
+# level.aon — the default is a typo; nothing objects
+level: *wran | info | warn | debug
+```
+
+This unifies cleanly and *generates* `{"level":"wran"}` (verified:
+`a:*5|string` generates `{"a":5}` today). The schema author shipped a
+default its own disjunct does not admit, and every consumer that
+leaned on the default received an invalid value from the ground truth
+itself. "The default must be an instance of the rest of its disjunct"
+is precisely a subsumption query.
+
+Third, there is no way to retire anything. An author renaming
+`service.port` can only delete the old field — instantly breaking —
+or keep both forever, silently. What they want to write, and cannot:
+
+```aon
+# not expressible today
+service: {
+  port: deprecate(*8080 | integer, {
+    msg: "renamed", use: "$.service.listen", since: "2.0.0" })
+  listen: *8080 | integer
+}
+```
+
+with the mark surfaced as a warning at every point of use. Finally,
+the same missing relation is the entailment query agents need
+directly: "does spec A still guarantee invariant B?" is
+`subsume(B, A)` — if A is an instance of B, everything A admits, B
+admits. The fact-check pass ranked this family Aontu's most
+defensible differentiator; none of it exists until the relation is an
+operation.
+
+## Current state
+
+The ordering exists operationally; the relation does not.
+
+- **The unite ladder** (`ts/src/unify.ts`, mirrored in `go/unify.go`)
+  computes meets by dispatching on Val kinds. It is the semantics the
+  subsumption rules must agree with, but it is not reusable as-is:
+  the MapVal/ListVal TOP fast path refines in place (the single-use
+  caveat), `DisjunctVal.unify` swap-and-restores the context error
+  array for member trials (`ts/src/val/DisjunctVal.ts`), and the
+  fixpoint is bounded at `maxcc = 9`. A non-mutating "check mode"
+  would be a second behavioural contract on every Val.
+- **`superior()` is the embryonic generalisation primitive.**
+  `ScalarVal.superior()` lifts a scalar to its kind
+  (`ts/src/val/ScalarVal.ts`); `UpperFuncVal`/`LowerFuncVal` lift to
+  their argument's kind; the `FeatureVal` default is `top`. `PrefVal`
+  already reasons with it: `superpeg = this.peg.superior()`
+  (`ts/src/val/PrefVal.ts`), so a preference admits any peer that is
+  an instance of the preferred value's generalisation — one place
+  where the engine natively asks an instance-of question.
+- **The `super()` builtin is degenerate and unpinned.**
+  `docs/reference-language.md` documents `super(1)` → `number`, but
+  `SuperFuncVal.resolve` (`ts/src/val/SuperFuncVal.ts`) returns
+  `this.superior()`, which falls through to `FeatureVal`'s `top`;
+  verified live, `a:super(1)` canonicalises to `{"a":top}` in Go, and
+  the TS code path is the same. No spec row mentions `super` at all.
+  The builtin is reserved surface this design can re-found.
+- **Defaults are rich and fragile.** `PrefVal` carries an integer
+  `rank` (`**` outranks `*`); `DisjunctVal.rankPrefs` merges
+  equal-rank preferences and drops outranked ones; `test/spec/pref.tsv`
+  pins ranked behaviour, and equal-rank conflicting defaults refuse at
+  generation (verified: `a:*1|number a:*2|number` errors). But meets
+  can silently strip preference marks (the probes above), so default
+  information cannot be reconstructed from unify output.
+- **Closedness is directional machinery.** `BagVal` holds the
+  `closed` flag and `optionalKeys` (`ts/src/val/BagVal.ts`);
+  `MapVal.unify` redirects so the closed side drives, with a
+  deterministic tie-break when both sides are closed
+  (`ts/src/val/MapVal.ts`, ~lines 141–161). `test/spec/close.tsv`
+  pins gen/err behaviour but contains no canon row — closedness never
+  reaches canonical form.
+- **Marks are boolean-only.** `ValMark` (`ts/src/val/Val.ts`) allows
+  `type`, `hide`, and custom `_`-prefixed boolean flags. A deprecation
+  needs a message, a replacement path, and a version — a record, not
+  a bit.
+- **Spread templates** live in `spread.cj` on `BagVal`; the
+  `isPathDependent` flag (`ts/src/val/Val.ts`) already identifies
+  templates whose meaning depends on their location (`key()`,
+  `.$KEY`) — exactly the templates a subsumption comparison cannot
+  decide structurally.
+- **No verdict vocabulary, no pairing.** The CLI evaluates one file
+  ([G2](g2-validation-verb.md) adds the (schema, data) pairing); the
+  spec suite's modes are canon/gen/err over a single source — no mode
+  compares two documents.
+
+## Prior art
+
+- **CUE `Value.Subsume`** is the direct model: instance ordering
+  *is* compatibility checking ("for a newer version of an API to be
+  backwards compatible with the previous version it must subsume
+  it"), exposed in the Go API. Two costs observed: the answer is a
+  bare boolean with documented false negatives, and CUE's production
+  history shows defaults and closedness — the two non-lattice-pure
+  features — are where the semantics rot; their interactions with
+  disjunction forced the multi-year evaluator rewrite. Aontu carries
+  the same trio plus ranked preferences and spreads.
+- **Confluent Schema Registry** contributes the policy vocabulary:
+  BACKWARD (default), FORWARD, FULL, and `*_TRANSITIVE` variants,
+  enforced at publish time — compatibility as *declared, checked
+  policy* rather than reviewer judgement.
+- **buf breaking** contributes the CI shape: compare against a past
+  git ref, fail the build, ship as an Action; and protobuf's deeper
+  lesson — `reserved` field numbers and deprecate-before-remove make
+  retirement a staged, mechanical process. Both are curated rule
+  catalogues, not computed relations; the null-hypothesis trap in
+  [index.md](index.md) says Aontu's answer must be the principled
+  version.
+- **Kubernetes and Terraform deprecation workflows** set the
+  point-of-use bar: warnings surfaced by every client, naming the
+  removal version and the replacement; the LSP protocol renders
+  deprecated symbols natively (strikethrough). Deprecation that is
+  only release-notes prose does not reach agents.
+- **Typed-feature-structure lineage** (LKB): subsumption is
+  quasi-linear alongside unification — the algorithmic cost is low;
+  the design cost is writing the rules down per value former. The
+  formal survey's algebra checklist is meet, join, emptiness, *and
+  subsumption exposed as a query*; completing the disjunct/negation
+  cases needs semantic-subtyping machinery whose cost the index's
+  traps rule out.
+
+## Design space
+
+**A. Derive from unification.** `subsume(a,b)` := evaluate both,
+unify fresh copies, compare the result's canon with `b`'s canon.
+Cheapest; no new recursion. Structurally wrong, as verified in the
+[Problem](#problem) section: canon idempotence fails on preferences,
+defaults are erased by meets, closedness and marks never reach
+canon, and single-use trees force the comparison through text.
+Retained only as a *differential-testing oracle* where it is sound
+(mark-free, pref-free, open, concrete values).
+
+**B. A dedicated three-valued subsumption recursion over the Val
+zoo.** A parallel structural walk with explicit rules per value
+former — CUE's `Subsume` shape, but returning
+subsumes / does-not (with witness) / undecided (with reason) instead
+of a boolean with silent false negatives. Cost: a second recursion
+whose rules can drift from `unify`'s semantics, twice (TS and Go).
+Mitigable: rules land as spec rows first, and property-based
+differential tests bind the two recursions together (laws below).
+
+**C. A check-mode flag threaded through the unite ladder.** Reuse
+the existing machinery in a non-mutating, non-erroring mode.
+Rejected: the mutation exceptions (MapVal TOP fast path), the
+trial-mode error plumbing, and preference erasure are load-bearing
+behaviours of the hot path; a suppression mode is a second contract
+on every Val anyway, and it still cannot make the meet *preserve*
+the default/closedness information the meet is defined to consume.
+
+**D. Normalise-then-compare.** Define a semantic normal form and
+compare forms. Circular for this purpose — minimising `number|integer`
+to `number` *is* a subsumption computation — and equality of normal
+forms yields equivalence, not the ordering. This is
+[G6](g6-distribution.md)'s hashing problem, which will consume G3's
+relation, not the other way round.
+
+**E. Witness-based bounded checking.** Generate concrete instances of
+the specific side and vet them against the general side
+(Alloy's small-scope UX). Can refute subsumption with a concrete
+counterexample; can never affirm it. Adopted as the *fallback* that
+sharpens the undecided band, not as the primitive.
+
+**Recommendation: B, with A as the test oracle and E as the
+counterexample refiner.** Only B gives a total, deterministic,
+three-valued answer — the Ivy lesson in the survey: an agent-facing
+query must return a definite verdict or an honest "undecided
+because", never a silent false negative. The three-valued contract is
+also the honest treatment of what [G1](g1-constraint-algebra.md)'s
+algebra leaves open (regex relations, `must`) and what this
+language's path-dependent features genuinely cannot decide
+structurally.
+
+## Proposed design
+
+### The relation
+
+`subsume(general, specific)` operates on two *evaluated* values (each
+freshly parsed and unified — single-use trees make this mandatory)
+and returns one of:
+
+- `subsumes` — every instance admitted by `specific` is admitted by
+  `general`, under the selected profile;
+- `does_not_subsume` — with a witness: the failing path, the two
+  sub-values in canonical form, and, where the fallback finds one, a
+  concrete counterexample instance;
+- `undecided` — with a reason code and the path, never silently.
+
+Three profiles widen what "instance" measures:
+
+| Profile | Compares | Use |
+|---------|----------|-----|
+| `values` | admitted value sets only | entailment queries |
+| `defaults` | values + default materialisation | `breaking` (default) |
+| `gen` | defaults + mark-driven output shape | strict pipelines |
+
+Rules, by value former (the full pairwise table is a Phase 0
+deliverable in `docs/reference-language.md`):
+
+- **Scalars and kinds.** A scalar subsumes only itself; a kind
+  subsumes its scalars and narrower kinds (`number` ⊒ `integer` ⊒
+  integer scalars); `top` subsumes everything; nothing but nil
+  relates to nil.
+- **Maps.** `G` subsumes `S` iff every required key of `G` is
+  required in `S` with `G.k ⊒ S.k`; every optional key of `G`
+  present in `S` satisfies `G.k ⊒ S.k`; if `G` is closed, `S` is
+  closed and `keys(S) ⊆ keys(G)`; if `G` carries a spread template,
+  `S`'s surplus keys and template must be subsumed by it.
+  Path-dependent templates (`isPathDependent`) are `undecided`
+  (`sub_path_dependent_spread`).
+- **Lists.** Element-wise by position; a closed general list bounds
+  the specific list's length; spreads as for maps.
+- **Disjunctions.** Member-wise sufficiency: `G` subsumes `S` if
+  every member of `S` is subsumed by some member of `G`. Member-wise
+  failure is *not* proof of non-subsumption (`{x:1}|{x:2}` does
+  subsume `{x:1|2}` even though no single member does), so on failure
+  the checker attempts to concretise the failing member into a real
+  counterexample — built from member canons, never via
+  `DisjunctVal.gen` and its known fold defect
+  (`ts/src/val/DisjunctVal.ts`) — and returns `does_not_subsume` with
+  the witness, else `undecided` (`sub_disjunct_distribution`).
+- **Preferences.** Under `values`, a preference is its superior for
+  admission (the existing `PrefVal.superpeg` semantics). Under
+  `defaults`, the *effective default* of each side — computed by the
+  existing `rankPrefs` merge, not reimplemented — must additionally
+  agree: adding a default where none existed is compatible; changing
+  or removing one is not (removal turns previously generable
+  documents incomplete).
+- **Marks.** Ignored under `values` and `defaults`. Under `gen`,
+  changing `type`/`hide` on a field the old version emitted is a
+  finding, because generated output changes.
+- **G1 constraint atoms.** Deferred entirely to
+  [G1](g1-constraint-algebra.md)'s subsumption rules (interval
+  containment, exclusion/regex superset checks, `re` by syntactic
+  equality only); G1's evaluate-only residue (`must`) surfaces here
+  as `undecided` (`sub_evaluate_only`).
+- **Unresolved residue.** References, functions, conjuncts, or
+  operators surviving evaluation are `undecided` with the specific
+  reason (`sub_unresolved_ref`, `sub_unresolved_func`); budget
+  exhaustion is `undecided` (`sub_budget`), with budget semantics
+  owned by [G5](g5-trust-contract.md).
+
+The recursion is bounded by the structure of the two values, carries
+no fixpoint, and never mutates its inputs — it runs after evaluation,
+on finished trees.
+
+### API surface
+
+```ts
+// ts/src/subsume.ts, exported from ts/src/aontu.ts
+const r = aontu.subsume(generalSrc, specificSrc, {
+  profile: 'defaults', at: '$.service',
+})
+// r: { verdict: 'subsumes'|'does_not_subsume'|'undecided',
+//      findings: Finding[] }   — G2's finding object, verbatim
+```
+
+Go mirrors it as `a.Subsume(generalSrc, specificSrc, SubsumeOpts)`
+in `go/subsume.go`. Findings reuse [G2](g2-validation-verb.md)'s
+object, codes, and formats — reported via the G2 error contract,
+with new codes appended to the shared registry (`compat_narrowed`,
+`compat_required_added`, `compat_default_changed`,
+`compat_marks_changed`, `deprecated`, and the `sub_*` undecided
+reasons).
+
+### CLI verbs
+
+```
+aontu subsume [--profile values|defaults|gen] [--at <path>]
+              <general.aon> <specific.aon>
+
+aontu breaking --against <file|git#rev> [--mode backward|forward|full]
+               [--allow-undecided] [--allow-deprecated-removal]
+               <file.aon>
+```
+
+`breaking` evaluates both versions and runs the mode's checks:
+backward = new subsumes old (v1-valid documents stay valid); forward
+= old subsumes new; full = both — the index's framing, and CUE's.
+`--against` takes a file path or `git#<rev>` (resolved by shelling
+out to `git show <rev>:<relpath>` — no embedded git), and is
+repeatable, which is the manual transitive form until
+[G6](g6-distribution.md)'s registry can enumerate published versions;
+"version" attaches to files and git refs now, module versions when
+G6 lands.
+
+Exit classes mirror G2's convention: 0 compatible, 1 breaking,
+3 undecided, 4 schema/engine error, 2 usage. Undecided fails the
+gate by default — a gate that shrugs is not a gate — downgradable
+with `--allow-undecided`.
+
+Per-document policy makes the mode declared rather than flagged:
+
+```aon
+# provisional key until G6 fixes module metadata; hidden, so it
+# participates in unification but never generates
+aontu_policy: hide({
+  compat: *backward | forward | full | none
+})
+```
+
+`breaking` reads `$.aontu_policy.compat` from the new document, and
+`--mode` overrides it; the disjunction-with-default is itself the
+declaration's schema. Where the key finally lives, and transitive
+variants as registry-enforced policy, are G6 decisions.
+
+### The deprecation mark
+
+A thirteenth builtin, function-form per the G1 precedent:
+
+```aon
+port: deprecate(*8080 | integer, {
+  msg: "renamed", use: "$.service.listen", since: "2.0.0" })
+```
+
+- **Unification-transparent:** `deprecate(x, m)` unifies exactly as
+  `x`; the record (all keys optional; `use` is a path spelled as a
+  string — a live reference would resolve and unify, which is not
+  wanted) rides on the result through meets, alongside the existing
+  mark propagation. Boolean `ValMark`s cannot hold it, so the Val
+  gains one optional record field.
+- **Canonical form:** renders reparseably as the call,
+  `deprecate(*8080|integer,{"msg":"renamed",...})`, in the existing
+  function-canon style; `parse(canon(v)) == v` holds.
+- **Point of use, three surfaces:** a [G2](g2-validation-verb.md)
+  finding with code `deprecated` and severity `warning` — the slot
+  G2 explicitly reserved for this mark — whenever vet unifies data
+  against a deprecated value or generation emits one; an LSP
+  diagnostic with the native Deprecated tag at reference sites
+  resolving through the value (`ts/src/lsp.ts`); and a `breaking`
+  downgrade — removing a field is breaking, but removing one already
+  deprecated in the `--against` version warns instead, under
+  `--allow-deprecated-removal` or document policy. Plain evaluation
+  output is unchanged.
+- `since` is free text until G6 defines module versions to check it
+  against.
+
+A key rename remains two findings (removal plus addition) — protobuf
+makes renames safe through name-independent field numbers, and the
+analogous move for Aontu is [G4](g4-identity-relations.md)'s stable
+identity mark, not anything G3 adds. Deprecate-then-remove is the
+supported rename path meanwhile.
+
+### Default validity and entailment
+
+With the relation in place, the `*wran` defect becomes a mechanical
+check: for every preference inside a disjunction, the effective
+default must be subsumed by the disjunction of the remaining
+members. Surfaced first as a vet `warning` (code
+`pref_not_instance`): `a:*5|string` generating `{"a":5}` is today's
+observed behaviour (no spec row pins it either way), and existing
+documents may lean on it — promoting the warning to an error is
+itself a breaking change, sequenced through this document's own
+gate, exactly as G1 sequenced its lossy-literal rows.
+
+Entailment for agents is the same call with the roles named: "does
+spec A still guarantee B" is `subsume(B, A)` under `values`.
+[G7](g7-machine-access.md) owns exposing it as an MCP tool and query
+verb; G3 guarantees the engine call exists and is three-valued.
+
+### Trim, as a follow-on
+
+`aontu trim --check <file.aon>` reports redundant entries — implied
+by a spread template, or leaving the evaluated result unchanged when
+removed — as paths, report-only. The test is subsumption against the
+governing template plus evaluate-and-compare. *Rewriting* the file
+is excluded: canon discards comments and layout, so deletion needs
+[G7](g7-machine-access.md)'s format-preserving patch surface. Trim
+ships as a reporter here and becomes an editor there.
+
+## Boundary: what we will not do
+
+- **No in-language `subsume()` builtin.** Documents reasoning about
+  documents is reflection the surface does not need; the verdict is
+  three-valued and does not fit a lattice scalar; revisit only if
+  [G8](g8-generation.md)'s combinators demonstrate a need
+  (surface-creep trap, [index.md](index.md)).
+- **No semantic-subtyping completion of the disjunct rule.** Full
+  union/complement decision procedures cost months twice over; the
+  three-valued answer with witness search is the honest substitute
+  (general-negation trap).
+- **No version numbering, auto-bump, or registry enforcement.**
+  [G6](g6-distribution.md) owns module identity and versions; G3 only
+  computes the relation between two values it is handed.
+- **No report formats, codes registry mechanics, or severities of our
+  own.** [G2](g2-validation-verb.md) owns the error contract; G3
+  appends codes to it.
+- **No file rewriting** — not for trim, not for
+  migrate-off-deprecated codemods; both need G7's patch surface.
+- **No buf-style configurable rule packs.** The lattice is the rule;
+  a curated rule catalogue is exactly the ad-hoc-ness the principled
+  version replaces (null-hypothesis trap: this is what JSON Schema
+  diffing and buf structurally cannot do).
+- **No LLM-graded judgement, no behavioural/temporal compatibility.**
+  The product is a deterministic verdict about values; "v2 eventually
+  serves v1 traffic" is not a lattice fact (eval-harness and
+  temporal-logic traps).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Rule drift between `subsume` and `unify` recursions (TS and Go, four artefacts) | Medium | High | Spec rows first; property laws bound both: `subsume(a, a&b)` holds whenever the meet is not nil; `canon(a&b)==canon(b)` ⇒ verdict is never `does_not_subsume`; run as PBT differential tests across TS/Go |
+| Defaults × closedness × spreads interactions rot (CUE's documented scar) | Medium | High | Pin the pairwise interaction rows (`*` with `close()`, `&:`, `?`, ranked prefs) in Phase 0 before any code, per the index trap |
+| False verdicts from member-wise disjunct rule | Medium | Medium | Three-valued contract; witness search from member canons only (never `DisjunctVal.gen`); `undecided` when no counterexample found |
+| Undecided verdicts erode trust in the gate | Medium | Medium | Fail-closed default; every `undecided` carries a reason code and path; the reason taxonomy is spec-pinned so it cannot grow silently |
+| Single-use trees force re-evaluation per comparison; CI loops re-evaluate both versions every run | High | Low | Accept now (`maxcc = 9` bounds evaluation); incrementality is an engine project outside G3; budgets are G5's |
+| Canon blindness to closedness/marks leaks into golden reports | Medium | Medium | The recursion walks Vals, never canon; report goldens render closedness/marks via finding fields, not canon strings; flag the canon-fidelity gap to G6 |
+| `deprecate()` record breaks canon round-trip or mark propagation | Low | High | Round-trip and propagation spec rows land before the builtin; record piggybacks on the existing propagation path |
+| Surface creep: 13th builtin plus two CLI verbs | Low | Medium | One builtin, function-form, zero grammar change; verbs mirror G2's established shape |
+| `git#rev` resolution varies across environments | Medium | Low | Shell out to `git show`, document it, and always accept a plain file path; the Action pins its own git |
+| Adoption: teams already wire buf/JSON-Schema diff tools | Medium | Medium | Ship exit classes + G2 SARIF so `breaking` drops into existing CI; lead with what rule lists cannot do (computed relation, located witnesses, default-awareness) |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows before code; TypeScript (canonical) first, the Go port follows;
+`make test` runs both. Nothing may regress: the shared suite (44
+files, ~426 rows at review time), the canon round-trip
+`parse(canon(v)) == v`, and today's generation behaviour of
+invalid-default disjuncts (until the sanctioned flip, which goes
+through `breaking` itself).
+
+1. **Phase 0 — rules on paper (M).** Write the per-former subsumption
+   table (all three profiles, including the `*` × `close()` × `&:` ×
+   `?` interaction cells) into a new section of
+   `docs/reference-language.md`. Author `test/spec/subsume.tsv` with
+   its own columns — name, profile, general, specific, verdict,
+   detail — following the precedent that G2's `vet.tsv` sets for
+   non-canon/gen/err shapes; extend `ts/test/spec.test.ts` and
+   `go/spec_test.go` to run it. Include rows for every probe in the
+   [Problem](#problem) section and for each `undecided` reason.
+2. **Phase 1 — the recursion, TypeScript (L).** New
+   `ts/src/subsume.ts` (a single visitor with a per-former dispatch
+   table, so the Val zoo stays untouched); effective-default
+   extraction reusing `rankPrefs`; witness construction from member
+   canons; export via `ts/src/aontu.ts`; rebuild the committed dist
+   (`make build-ts`).
+3. **Phase 2 — Go port (L).** `go/subsume.go`, mirroring the
+   dispatch table; `go/spec_test.go` runs every subsume row with no
+   skip list.
+4. **Phase 3 — CLI verbs (M).** `subsume` and `breaking` in
+   `ts/src/cli.ts` and `go/cmd/aontu`; `git#rev` resolution; policy
+   key read; exit classes; findings through G2's renderer (depends on
+   G2 Phases 1–3, which the index sequences earlier);
+   `docs/reference-api.md` and `docs/how-to.md`. A CI recipe and the
+   Action variant follow G2's.
+5. **Phase 4 — `deprecate()` (M).** `test/spec/deprecate.tsv` rows
+   first (canon round-trip, unification transparency, propagation
+   through refs and spreads, vet warning, breaking downgrade). Code:
+   `funcMap` entry in `ts/src/lang.ts`, new
+   `ts/src/val/DeprecateFuncVal.ts`, record propagation, `deprecated`
+   code in `ts/src/hints.ts`; LSP tag in `ts/src/lsp.ts`; then
+   `go/func.go`, `go/marks.go`, `go/hints.go`.
+6. **Phase 5 — default-validity lint (S).** `pref_not_instance`
+   warning wired through vet, built on Phase 1; rows in
+   `subsume.tsv`; the future warning-to-error flip documented but not
+   taken.
+7. **Phase 6 — trim reporter (M).** `aontu trim --check` in both
+   CLIs; redundancy rows in a new `test/spec/trim.tsv`; rewriting
+   explicitly deferred to G7.
+
+Ongoing: the PBT differential laws from the risk table run in both
+implementations as the Val zoo grows — the ShardStore
+lightweight-formal-methods pattern the review adopts throughout.
+
+## Open questions
+
+- **Is a default change backward-breaking by default?** Confluent's
+  BACKWARD ignores defaults (value sets only); this design's
+  `defaults` profile flags them, because materialised configs change
+  under agents' feet. Whether `breaking --mode backward` uses
+  `defaults` (proposed) or `values` should be settled by dogfooding
+  on this repository's own spec evolution before the exit classes are
+  documented as stable.
+- **The policy key.** `aontu_policy` is a plain reserved-by-convention
+  name and could collide with user data; alternatives (a mark, a G6
+  module-metadata field once modules exist) each move the
+  declaration further from the document. G6's module design should
+  get a veto before the name ships.
+- **Witness search budget.** How hard the disjunct fallback tries
+  (branch enumeration depth, instance count) trades undecided-rate
+  against runtime; the budget must be deterministic and spec-stated,
+  and its exhaustion class belongs to G5. Needs measurement on real
+  schemas.
+- **Does `subsume` get an `--explain` trace?** A proof-style trace
+  ("subsumes because every member …") would serve agents, but
+  provenance rendering is [G7](g7-machine-access.md)'s surface; the
+  open question is whether the engine records the derivation from day
+  one (cheap now, hard to retrofit — the site-tracking lesson) or
+  waits for G7's format.
+- **Re-founding `super()`.** The builtin is documented as kind-lift,
+  implemented as top-lift, and spec-tested as neither. Once
+  `superior()` matters to subsumption, should `super(x)` be pinned to
+  the documented kind-lift (useful, breaking for nobody observable),
+  or deprecated with the new mark as reserved surface? A Phase 0 row
+  must pick one — leaving it unpinned is the one indefensible option.

--- a/docs/capability-review/g4-identity-relations.md
+++ b/docs/capability-review/g4-identity-relations.md
@@ -1,0 +1,570 @@
+# G4: Identity and typed relations
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands
+the G4 entry in the review index: a stable identity mark on any
+node, reference constraints with checked referential integrity,
+typed relations with inverse and acyclicity properties,
+identity-merge semantics, and a standard-library vocabulary for
+ports, interfaces, and connections. Sibling documents own adjacent
+surfaces — see [Boundary](#boundary-what-we-will-not-do).*
+
+## Problem
+
+Systems are graphs; Aontu documents are trees whose only names are
+tree paths. Every relation except containment must be smuggled in as
+data, and the language can check nothing about it. Consider what an
+author writes today:
+
+```aon
+# system.aon — nothing checks the dependsOn entries
+services: {
+  auth: { kind: service, port: 8080 }
+  billing: {
+    kind: service
+    dependsOn: [auth, paymets]   # typo: no such service
+  }
+}
+```
+
+This evaluates and generates cleanly. `paymets` is a bare string;
+no constraint can say "each `dependsOn` entry must name an existing
+node that is a service". The obvious repair — writing
+`dependsOn: [$.services.auth]` — makes a different mistake. A
+reference does check existence (`a:$.nope` is pinned as `Cannot
+resolve value: $.nope` in `test/spec/ref.tsv`), but resolution is
+copy-based: `RefVal.find` clones the target into place
+(`ts/src/val/RefVal.ts`, the `out = out.clone(ctx)` branch), so the
+generated JSON embeds a full copy of the `auth` node inside
+`billing.dependsOn`. That is an embedding, not a link — the output
+shape is wrong, and the copy carries no identity of its own.
+Today's choice is strings that check nothing or references that
+embed everything.
+
+Second, two files that describe the same real-world entity at
+different paths never meet:
+
+```aon
+# catalog.aon
+catalog: payments: { owner: "team-pay", tier: 1 }
+
+# deploy.aon
+deploy: eu1: payments: { replicas: 3, tier: 2 }
+```
+
+Both files evaluate together without complaint: unification is
+path-aligned, so `tier:1` and `tier:2` are never brought into
+contact. The contradiction survives silently — a quieter cousin of
+the `owl:sameAs` failure mode. An agent reading
+`catalog.payments.tier` learns a "fact" the deploy layout
+contradicts, and no evaluation ever says so: there is no way to
+declare that two nodes denote one entity and have the lattice
+enforce the consequences.
+
+Third, relation-level properties are inexpressible. A dependency
+cycle in data passes silently:
+
+```aon
+a: { dependsOn: [b] }
+b: { dependsOn: [c] }
+c: { dependsOn: [a] }
+```
+
+(Reference cycles *are* caught — `RefVal.find` returns a
+`path_cycle` nil when a path resolves through itself — but those
+are evaluation cycles, not data-level relation cycles.) Nor can a
+definition declare `dependedOnBy` as the inverse of `dependsOn` and
+have the two checked for consistency. Impact analysis,
+reachability, and the GraphRAG-style multi-hop retrieval the survey
+identifies as the reason structured graphs beat markdown all
+require an edge set the language can see. Today there is none.
+
+## Current state
+
+What exists is a tree evaluator with strong path machinery and
+several reusable precedents:
+
+- **References.** `RefVal` (`ts/src/val/RefVal.ts`, `go/ref.go`)
+  resolves absolute (`$.a.b`) and relative (`.a.b`) paths from
+  `ctx.root`, defers across fixpoint passes until the target
+  appears (row `forward-ref` in `test/spec/ref.tsv`), detects
+  self-prefix cycles, and *clones* the found target, clearing
+  `type`/`hide` marks on the clone. Cross and chained references
+  converge within the fixpoint (`cross`, `chain` rows).
+- **Path lookup.** `ctx.find(path)` (`ts/src/ctx.ts`) walks the
+  root; the `_pathTrie` assigns path indices for cycle detection
+  and caching — an evaluation index, not an entity index.
+- **A registry precedent.** `MapVal.unify`
+  (`ts/src/val/MapVal.ts`) stores ref-spread snapshots on the unify
+  root context, keyed by canon plus source site, surviving all
+  fixpoint passes — exactly the shape an identity registry needs.
+- **A second namespace, but host-owned.** `$name` variables
+  (`ts/src/val/VarVal.ts`, `test/spec/var.tsv`) resolve outside the
+  tree, but are injected by the calling program, not declarable
+  in-language.
+- **Marks.** `type()`/`hide()` set boolean marks; `copy()` clears
+  them. Row `type-canon` in `test/spec/marks.tsv` pins that canon
+  of `type(1)` is `1` — marks do not survive canonical form, so an
+  identity cannot be a pure mark if canon round-trip and
+  [G6](g6-distribution.md) semantic hashing are to preserve it.
+- **Spread machinery.** `&:` templates (`MapVal.spread`,
+  `spreadClone`, the `isPathDependent` flag) let a schema constrain
+  every child of a map or list — the delivery mechanism for a
+  vocabulary.
+- **Resolver chain.** Includes resolve memory → filesystem →
+  package (`ts/src/lang.ts`, `makeModelResolver`, ~line 757;
+  security comment ~750). The memory resolver can serve
+  `@"std/system"` before the [G6](g6-distribution.md) module layer
+  exists.
+- **Fixpoint.** `maxcc = 9` passes (`ts/src/unify.ts`); anything
+  that converges like references must converge within that bound.
+
+Structurally blocking: (1) the only in-language names are tree
+paths, so nothing can denote an entity independent of its location;
+(2) reference resolution is copy-based — there is no machinery for
+two tree positions to denote one value, only for copies to converge
+during a single evaluation; (3) evaluation ends at generation or
+canon — there is no post-unification analysis pass where a global
+graph property (acyclicity, inverse consistency) could live; (4)
+generation targets JSON trees, so shared or cyclic structure can
+never be emitted directly.
+
+## Prior art
+
+- **JSON-LD `@id`** gives entities globally unique IRIs so the
+  same entity can be referenced and merged across documents. The
+  cost is the RDF stack and its open-world semantics — the stance
+  Aontu deliberately rejects for validation.
+- **`owl:sameAs`** is the cautionary tale: full-substitutability
+  identity links with no conflict detection produced silent
+  corruption at web scale. Unification inverts this — declaring
+  two nodes the same entity means unifying them, so a
+  contradiction is a hard, located error. This document designs
+  toward that inversion deliberately.
+- **DTDL** (Azure Digital Twins) is the closest JSON-shaped
+  relative: named, typed, target-constrained `Relationship`s
+  distinct from containment; a `Component` distinction for
+  subtrees without independent identity; and DTMI ids that fuse
+  identity and version (`dtmi:…:Thermostat;1`). The fusion makes
+  evolution addressable but forces reference rewrites on every
+  version bump — and makes "v1 and v2 describe the same entity"
+  inexpressible. Take the relationship/component checklist; refuse
+  the fusion.
+- **SHACL** shows target-typed reference constraints
+  (`sh:class`/`sh:node`) and declared inverse paths
+  (`sh:inversePath`) checked closed-world — the right checks, paid
+  for with a second language separate from the data.
+- **SysML v2 / AADL / Structurizr** converge on ports, interfaces,
+  and connections as the recurring modelling primitives, and AADL
+  shows the payoff: once connection topology is first-class data,
+  latency, error-propagation, and impact analyses are graph
+  traversals. SysML's cost is enormous language weight; Structurizr
+  gets identity by element name with no constraint checking. The
+  lesson: primitives as vocabulary, not syntax.
+- **Protobuf field numbers** (via buf): stable identity independent
+  of names makes renames non-breaking. In Aontu, a key rename today
+  silently breaks every `$.path` reference to it.
+- **CUE structural cycles** (survey caution): graph-shaped values
+  were a major source of evaluator complexity in the evalv3
+  rewrite. Do not put aliasing into the value model.
+
+## Design space
+
+**A. Graph-native lattice.** Make references alias instead of
+clone; identified nodes become one shared value. The semantically
+purest reading of identity, and the most expensive thing this
+language could do: it rewrites the clone-based, single-use-tree
+evaluator in both implementations, leaves generation-to-JSON of
+shared/cyclic structure undefined, and walks into the
+structural-cycle complexity CUE paid a multi-year rewrite to
+manage. Rejected.
+
+**B. Convention plus external checks.** Reserve an `id` key by
+convention; check uniqueness, integrity, and cycles in a lint pass;
+change the language not at all. Cheapest — and the JSON Schema
+null-hypothesis position: the lattice learns nothing, nodes sharing
+an id are never merged, contradictions stay silent, and the checks
+are exactly as principled as any external script. Fails the brief.
+
+**C. Adopt JSON-LD.** Import `@id`/`@context`, gaining semantic-web
+interop — but also IRI machinery and open-world assumptions
+wholesale, plus a second document model to explain, for interop an
+*export* can provide later at a fraction of the cost. Rejected as
+the core mechanism.
+
+**D. Identity as syntax.** A sigil for identified nodes (CUE-style
+`#name`, or an anchor token). Terse, grep-able — and a grammar
+change in a language whose recorded principle is "prefer new
+functions instead of creating new tokens or syntax" (IDEAS.md),
+whose operator characters are deliberately reserved
+(`test/spec/op-chars.tsv`), and whose small surface the review
+calls a moat. Everything a sigil can say, a builtin can say.
+Rejected.
+
+**E. Hybrid, split by monotonicity.** Identity and referential
+integrity are *monotone* — more information only refines them, and
+a conflict is a real conflict — so they enter the lattice as two
+new builtins (`id()`, `refer()`) with defined unification
+semantics. Global graph properties (acyclicity, inverse
+consistency, reachability) are *not* monotone — an edge added
+later can falsify them — so they must not be lattice citizens:
+they are declared as ordinary data under a blessed vocabulary and
+checked by a post-unification pass reported via the
+[G2](g2-validation-verb.md) error contract.
+Ports/interfaces/connections ship as vocabulary, not syntax.
+
+**Recommendation: E.** It is the only option that keeps the
+lattice guarantee intact, reuses the codebase's actual extension
+points (`funcMap`, marks, spreads, the root-context registry
+precedent), keeps the grammar frozen, and still delivers the
+differentiator the survey identified: identity whose consequences
+are checked by unification, with contradictions as located errors.
+
+## Proposed design
+
+Two new builtins join `funcMap` (`ts/src/lang.ts`) and `go/func.go`
+— 12 today, 14 with G4, alongside the nine
+[G1](g1-constraint-algebra.md) adds. The rest is vocabulary and a
+vet-time pass.
+
+### `id(name)`: the identity mark
+
+`id(name)` declares that the enclosing value is an independent
+entity named `name`. It composes by conjunction like any value:
+
+```aon
+services: auth: id(svc/auth) & {
+  kind: service
+  port: 8080
+}
+```
+
+Semantics:
+
+- `name` matches a pinned pattern (letters, digits, `_`, `-`, `/`;
+  **no dots** — dots are reserved for sub-paths, see below); a
+  non-conforming name is a located parse-time error. Under
+  unification an identity behaves like a scalar: equal names unify;
+  two *different* names on one node are a located conflict (one
+  entity, one id — aliasing is an open question).
+- **Identity-merge.** All nodes in one evaluation carrying the
+  same id are unified with each other. Declaring two nodes the same
+  entity *means* unifying them; any contradiction is a hard error
+  naming both declaration sites — the anti-`owl:sameAs`. The
+  `catalog.aon`/`deploy.aon` example becomes, once both add
+  `id(svc/payments) &`, a located `Cannot unify value: 2 with
+  value: 1` at the two `tier` sites instead of a silent fork.
+- **Positions.** The tree stays a tree. After merging, *every*
+  declared position holds the merged value, and generation emits it
+  at each path — duplication, exactly as references generate today.
+  Identity adds a location-independent addressing scheme without
+  changing the shape of the output.
+- **Canon.** Canon renders `id("svc/auth")&{…}` reparseably, and
+  reparsing re-merges idempotently, so `parse(canon(v)) == v`
+  holds. This deliberately differs from `type`/`hide` marks, which
+  canon drops (`test/spec/marks.tsv`, row `type-canon`): identity
+  is semantic content that [G6](g6-distribution.md) canon-hashing
+  must see.
+- **Generation.** The `id()` declaration itself is not data and is
+  not emitted; id strings used in value position are ordinary
+  strings.
+
+Mechanics: an identity registry lives on the unify root context —
+the same lifetime and placement as the ref-spread snapshot map in
+`ts/src/val/MapVal.ts` — mapping id → representative value and
+site. Each fixpoint pass, a position carrying an id unifies with
+the representative and updates it; positions converge across passes
+as chained references do today, within the `maxcc = 9` bound
+(`ts/src/unify.ts`). Whether bound exhaustion with an unconverged
+merge is a distinct semantic error is owned by
+[G5](g5-trust-contract.md).
+
+Three rules protect existing behaviour, and all existing spec rows
+must pass unchanged under them:
+
+1. **References do not carry identity.** The clone `RefVal.find`
+   produces clears the id, extending the existing mark-clearing
+   walk. Otherwise `w:b:$.q.a & {y:2,z:3}` (row `ref-and-merge`,
+   `test/spec/ref.tsv`) would push `y:2` back into `q.a` through
+   the merge — a silent change to pinned behaviour.
+2. **`copy()` clears identity**, consistent with `copy()` clearing
+   marks today (`marks.tsv`, `copy-clears-type`).
+3. **Spread templates may not stamp one id onto every child.** An
+   `id()` with a concrete argument inside an `&:` template is a
+   located error (all children would merge into one entity). A
+   path-dependent argument is allowed — `&: id(svc/ + key()) & {…}`
+   gives each child a distinct id, resolved per destination by the
+   existing `spreadClone` machinery.
+
+The entity/component distinction falls out free: a node with
+`id()` is an independent entity; a node without one is a component
+of its nearest identified ancestor, addressable only relative to
+it — DTDL's `Component` with no further design.
+
+### `refer(t?)`: checked, typed, link-shaped references
+
+`refer(t)` is a constraint on a string-valued field: the string must
+be an *entity address*, the addressed node must exist in the
+evaluation, and — if the optional `t` is given — `t` is unified
+**into** the target entity. The field's own value remains the
+address string: a link, not an embedding.
+
+```aon
+@"std/system"
+
+services: {
+  auth: id(svc/auth) & $.std.Service & { port: 8080 }
+  billing: id(svc/billing) & $.std.Service & {
+    dependsOn: [&: refer($.std.Service), svc/auth, svc/payments]
+  }
+}
+```
+
+The list spread applies `refer` to every element; `svc/auth`
+resolves; `svc/payments` names no entity, so evaluation fails with
+a located error at the string's site. The generated `dependsOn` is
+`["svc/auth", …]` — the link shape the Problem section could not
+produce.
+
+Semantics:
+
+- **Address grammar.** An address is an entity id, optionally
+  followed by a dot-separated path *inside* that entity:
+  `svc/auth.ports.http`. This reconciles the two addressing
+  schemes: `$.a.b` answers *where* (a tree location), an entity
+  address answers *what* (an id anchor), and beneath entity
+  granularity the tree is authoritative again. The no-dots rule on
+  ids makes the split point unambiguous.
+- **Constraints flow through links.** `refer(t)` does not merely
+  check the target against `t`; it unifies `t` into it. Referring
+  to something as a `Service` makes it one, and if it cannot be,
+  the conflict is a located error naming the `refer` site and the
+  target site. Check-only semantics would be non-monotone
+  (true-then-false as the target grows); constraint flow is
+  ordinary unification and keeps the lattice guarantee.
+- **Timing.** `refer` residuates, using the defer branch
+  `FuncBaseVal` already has (`ts/src/val/FuncBaseVal.ts`): a target
+  may be introduced by a later conjunct, include, or spread, so the
+  constraint retries each fixpoint pass, as forward references do
+  today. Within one evaluation the document-set is fixed, so
+  existence *is* decidable: a `refer` still unresolved when the
+  fixpoint ends is an error at generation, mirroring an unresolved
+  reference. Integrity is a unification-time property, per the
+  review index — there is no vet-time deferral.
+- **Canon** renders the residual reparseably:
+  `"dependsOn":[refer($.std.Service)&"svc/auth", …]`.
+- **Error data.** Failures carry both sites and the machine-facing
+  details field established by [G1](g1-constraint-algebra.md);
+  rendering into reports and codes is owned by
+  [G2](g2-validation-verb.md).
+
+### Relations, inverses, and acyclicity: vocabulary plus vet pass
+
+Relation-level properties are declared as data under a blessed
+vocabulary and checked after unification, because they are global
+and non-monotone — an acyclic graph can become cyclic when one
+more edge unifies in, and no lattice citizen may be falsified by
+more information.
+
+```aon
+@"std/system"
+
+relations: dependsOn: $.std.Relation & {
+  target: $.std.Service
+  inverse: dependedOnBy
+  acyclic: true
+}
+```
+
+The vet pass (delivered with G2's verb, reported via the G2 error
+contract) walks the unified tree before generation: it collects
+the edge set — (source entity, relation key, target address)
+triples for every field whose key matches a declared relation —
+then checks acyclicity (reporting the offending cycle as a path of
+addresses) and inverse consistency (for each `a --dependsOn--> b`,
+`b` must list `a` under `dependedOnBy`; the report names the exact
+missing entry). *Derivation* of inverse fields — writing
+`dependedOnBy` for the author — is field generation and belongs to
+[G8](g8-generation.md)'s total combinators; v1 validates only.
+Traversal order is sorted and deterministic in both
+implementations, per [G5](g5-trust-contract.md).
+
+### The `std/system` vocabulary
+
+Ports, interfaces, and connections need no syntax — they are schemas
+(abbreviated sketch):
+
+```aon
+# std/system.aon (sketch)
+std: hide({
+  Component: type({
+    ports?: {&: $.std.Port}
+  })
+  Port: type({
+    direction: *in | out | inout
+    protocol?: string
+  })
+  Connection: type({
+    from: refer($.std.Port)
+    to: refer($.std.Port)
+  })
+  Service: type($.std.Component & { kind: service })
+  Relation: type({
+    target: top
+    inverse?: string
+    acyclic?: *false | boolean
+  })
+})
+```
+
+A connection's `from`/`to` are entity addresses reaching ports
+inside identified components. Everything is ordinary unification:
+`&` composition, spreads, marks, defaults. Until
+[G6](g6-distribution.md) exists, `@"std/…"` is served by the
+resolver's memory entry (`makeModelResolver`, `ts/src/lang.ts`) —
+bundled with the implementation, touching neither filesystem nor
+package resolution, so the [G5](g5-trust-contract.md) hermeticity
+posture is not widened. The vocabulary is marked experimental until
+G6's canon-hash pinning can version it; and — per the DTDL lesson —
+entity ids do *not* embed versions.
+
+### Downstream: what this buys the graph consumers
+
+The evaluation result gains two derived structures: an entity index
+(id → list of tree paths) and the relation edge set. Impact
+analysis ("what reaches `svc/auth`?"), reachability, and
+context-window-sized entity slices become traversals over them;
+their exposure — CLI verbs, projections, the MCP tool set — is
+owned by [G7](g7-machine-access.md). G4's deliverable is that the
+structures exist and are deterministic. Renames also soften: moving
+an entity to a new tree path breaks `$.path` references but no
+entity address — the protobuf field-number lesson applied.
+
+## Boundary: what we will not do
+
+- **No graph-shaped values or aliasing references.** Positions
+  converge to equal values; they never become one shared mutable
+  node. The alternative rewrites both evaluators and re-opens CUE's
+  structural-cycle scar (index trap: surface creep forcing an
+  evaluator rewrite).
+- **No acyclicity or reachability constraints inside the lattice.**
+  They are non-monotone and would break "any observed field value
+  holds for the final result"; they live in the vet pass.
+- **No URI/IRI or JSON-LD machinery.** A JSON-LD export can come
+  later as interop; the core mechanism stays closed-world.
+- **No identity+version fusion in ids** (contra DTDL). Versioning
+  belongs to [G6](g6-distribution.md); fused ids make cross-version
+  identity inexpressible.
+- **No automatic inverse derivation.** Writing fields is
+  generation; it waits for [G8](g8-generation.md)'s totality story.
+- **No new syntax for ports/interfaces/connections.** Vocabulary,
+  not grammar — grammar size is acquisition cost (index trap:
+  surface-area creep toward CUE; SysML's weight is the cautionary
+  example).
+- **No cross-evaluation entity registry.** Identity is scoped to
+  one evaluated document-set; sharing truth across repos is G6's
+  distribution problem.
+- **No temporal or behavioural relation properties** ("eventually
+  consistent") — inexpressible in a value lattice by construction
+  (index trap).
+- **No error formats or CLI verbs** — [G2](g2-validation-verb.md)
+  owns them; **no query surface** — [G7](g7-machine-access.md); **no
+  subsumption exposure** for id/refer — [G3](g3-subsumption-evolution.md).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Identity-merge fails to converge within `maxcc = 9` on deep id/ref chains, silently under-merging | Medium | High | Spec rows at the pass boundary; registry unifies eagerly per pass; escalate silent-stop semantics to G5 as designed there |
+| Id leaks through `RefVal` clones, `copy()`, or spread snapshots, changing pinned behaviour | Medium | High | The three clearing rules land with dedicated spec rows; all existing `ref.tsv`, `spread-*.tsv`, `marks.tsv` rows must pass unchanged |
+| Canon round-trip breaks for `id()`/`refer()` residuals | Medium | High | Round-trip rows (`parse(canon(v)) == v`) for every new form before code lands |
+| TS/Go divergence in registry and vet-pass iteration order (Go map order is random) | High | Medium | Sort ids and keys at every iteration point; byte-identical canon and report rows in the parity suite |
+| Constraint-flow through `refer(t)` surprises authors (a link mutates its target) | Medium | Medium | Document loudly; error messages name both sites; a lint-level notice via G2 when a refer adds fields rather than matching them |
+| `DisjunctVal.gen` fold defect (`ts/src/val/DisjunctVal.ts` ~263) compounds when identified nodes appear in disjuncts | Low | Medium | Spec rows pin disjunct-of-entity generation before code; do not extend the defect's reach |
+| Performance: per-pass registry unification on models with many entities | Medium | Medium | Merges are idempotent after convergence (apply-once discipline as in spread application); perf-annotated parity rows |
+| Vocabulary churn before G6 versioning exists | High | Low | `std/system` marked experimental; breaking changes assessed with G3's check once it ships |
+| Two addressing schemes confuse authors and agents | Medium | Medium | One documented rule — `$.path` for schema reuse and templating, entity addresses for system links — plus targeted hints in `ts/src/hints.ts` / `go/hints.go` |
+
+## Implementation plan
+
+Every phase is spec-first: TSV rows are authored and reviewed before
+implementation, TypeScript (canonical) lands first, the Go port
+follows, `make test` runs both, and committed `ts/dist` is rebuilt
+(`make build-ts`). Nothing may regress: all 44 existing spec files
+(~426 rows) pass unchanged, and the canon round-trip property
+`parse(canon(v)) == v` holds throughout, including for the new
+forms.
+
+1. **Phase 0 — semantics on paper (S).** New "Identity" and
+   "Entity references" sections in `docs/reference-language.md`:
+   id pattern, address grammar, merge semantics, the three
+   clearing rules. Author `test/spec/id.tsv` (merge, contradiction
+   with two sites, ref-clone/copy/spread clearing, canon
+   round-trip, pass-boundary rows) and `test/spec/refer.tsv`
+   (existence, typed flow, residual canon, unresolved errors).
+2. **Phase 1 — `id()` (M).** New `ts/src/val/IdFuncVal.ts`; entity
+   slot and canon rendering on the carriers (`ts/src/val/Val.ts`,
+   `MapVal.ts`, `ListVal.ts`); registry on the unify root context
+   (`ts/src/unify.ts`, `ts/src/ctx.ts`); clearing walks in
+   `RefVal.ts`, `CopyFuncVal.ts`, and the spread snapshot path in
+   `MapVal.ts`; messages in `ts/src/err.ts`, `ts/src/hints.ts`.
+   Then the Go port: `go/func.go`, `go/val.go`, `go/mapval.go`,
+   `go/ref.go`, `go/unify.go`, `go/hints.go`.
+3. **Phase 2 — `refer()` (M).** New `ts/src/val/ReferFuncVal.ts`
+   using the `FuncBaseVal` defer branch; address parsing;
+   constraint flow into registry targets; generation-time
+   unresolved errors. Go: `go/func.go`, `go/unify.go`.
+4. **Phase 3 — derived structures (S).** Entity index and edge-set
+   extraction exposed through the evaluation result
+   (`ts/src/aontu.ts`, `go/aontu.go`; `docs/reference-api.md`) for
+   G2 and G7 to consume; deterministic ordering pinned by parity
+   rows.
+5. **Phase 4 — `std/system` vocabulary (M).** The vocabulary file
+   served via the memory resolver entry (`ts/src/lang.ts`,
+   `go/source.go`); `test/spec/std-system.tsv` rows exercising
+   Component/Port/Connection/Relation purely through unification;
+   experimental status noted in `docs/reference-language.md`.
+6. **Phase 5 — relation graph checks (L).** The vet-time pass:
+   edge extraction, acyclicity, inverse validation, deterministic
+   cycle reports — delivered alongside G2's verb and reported via
+   the G2 contract; err-mode spec rows where the TSV format can
+   express them, G2 report fixtures otherwise.
+
+Phases 1–3 are self-contained language work; Phases 4–5 can trail
+into the review's Phase C sequencing without blocking G1/G2.
+
+## Open questions
+
+- **Naming.** `id()` collides with a common data key name only as a
+  function, but `entity()`/`refer()` versus `id()`/`refers()` should
+  be settled once against the final builtin roster (G1 adds nine,
+  [G3](g3-subsumption-evolution.md)'s `deprecate()` one; the
+  combined surface is 24) — one naming pass, not two. Note also
+  that id arguments containing `-` must be quoted
+  (`id("team-pay")`): `-` is an invalid bare-text character today
+  (test/spec/op-chars.tsv pins `a:6-2` as a parse error), while `/`
+  parses as plain text and may stay bare.
+- **Aliasing.** Should one node be allowed several ids (merging the
+  namespaces), for staged renames of entities? For: the protobuf
+  `reserved` lesson suggests rename windows need overlap. Against:
+  multiple ids reintroduce a sliver of `sameAs` ambiguity and
+  complicate the registry. Decide with
+  [G3](g3-subsumption-evolution.md)'s deprecation mark, which is
+  the natural carrier for "old id, still honoured, warn on use".
+- **Should generated output optionally include ids?** Marks are not
+  data, but downstream consumers of plain JSON lose identity unless
+  a projection includes it. Likely a [G7](g7-machine-access.md)
+  projection flag rather than a generation change; decide when G7
+  fixes its projection surface.
+- **Subsumption of identified values.** For G3's compatibility
+  check, does adding an `id()` to a previously anonymous node
+  narrow it (breaking) or annotate it (compatible)? The
+  scalar-like semantics suggest narrowing; the annotation reading
+  matches author intent. G3 owns the answer; the semantics here
+  must not foreclose it.
+- **Edge extraction from plain strings.** Should the vet pass
+  treat an unadorned string under a declared relation key as an
+  edge, or only `refer`-constrained values? Permissive extraction
+  catches more real systems; strict extraction never guesses.
+  Decide jointly with G2's severity vocabulary — unconstrained
+  edges can carry a distinct severity.

--- a/docs/capability-review/g5-trust-contract.md
+++ b/docs/capability-review/g5-trust-contract.md
@@ -1,0 +1,627 @@
+# G5: A specified trust contract
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G5 — hermeticity, termination, determinism, and sandboxing as
+specified, spec-pinned guarantees — with alternatives, an explicit
+boundary, risks, and an implementation plan.*
+
+## Problem
+
+For a document that agents evaluate unattended, safety guarantees are
+not hardening applied afterwards — they are constitutive. An agent
+harness that evaluates a definition it did not write needs four
+promises: evaluation touches nothing outside its declared inputs
+(hermeticity), it always finishes (termination), it always gives the
+same answer (determinism), and a hostile input cannot make the
+evaluator do harm (sandboxing). Aontu today has good bones for all
+four and a written guarantee for none — and one of them, hermeticity,
+is currently false.
+
+First failing example, verified live. A model an agent has been asked
+to evaluate:
+
+```aon
+# inner/model.aon
+a: @"../secret.aon"
+```
+
+```
+$ aontu inner/model.aon
+{
+  "a": {
+    "secret": "hunter2"
+  }
+}
+$ echo $?
+0
+```
+
+The include resolver follows relative paths and symlinks with no
+containment check, so evaluating an untrusted file reads any file the
+process can read — `@"../../etc/passwd"` included. The code says so
+itself (ts/src/lang.ts, the SECURITY comment: "treat opening an
+untrusted source as running it"), and the package leg of the resolver
+chain resolves `@"pkg"` through Node's require machinery, walking
+`node_modules` directories upward from the process working directory.
+The consequences compound: the same file set evaluated on two
+machines, or from two directories, can resolve `@"pkg"` differently —
+so "same files + same `$` bindings ⇒ same output" does not hold under
+the default resolver. And the LSP builds a fresh default-configured
+evaluator per change and per hover (`new Aontu()` in
+`computeDiagnostics`, ts/src/lsp.ts), so merely *opening* a hostile
+`.aon` file in an editor performs the reads. There is no CLI flag, no
+API default, and no documented profile that confines any of this; the
+confinement hooks (`options.resolver`, `options.fs`) exist but are
+opt-in and unspecified.
+
+Second failing example, also verified live. Three different answers —
+"your model is cyclic", "your model is incomplete", and "my budget
+ran out" — collapse into one message today:
+
+```aon
+# cycle.aon — a genuine reference cycle
+a: $.b
+b: $.a
+```
+
+```
+$ aontu cycle.aon
+[aontu/ref]: Cannot resolve value at path $.a
+```
+
+```aon
+# missing.aon — merely incomplete
+a: $.b
+```
+
+```
+$ aontu missing.aon
+[aontu/no_path]: Cannot resolve value at path $.a
+```
+
+The two-element cycle reports the generic `ref` code with the same
+"Cannot resolve value" headline as a missing target; only a
+reference to itself or an enclosing ancestor (`a: $.a`) earns the
+distinct `path_cycle`. Worse, the
+third case has no code at all: the fixpoint loop in ts/src/unify.ts
+runs at most `maxcc = 9` passes and simply exits when the budget is
+spent — a model still refining on pass nine stops silently, and the
+residue surfaces later as ordinary non-generable errors
+indistinguishable from incompleteness. The bound is real and
+semantic: deferral works by conjunct-wrapping unresolved values for
+the next pass (ts/src/val/RefVal.ts, ts/src/val/FuncBaseVal.ts), and
+ts/src/val/KeyFuncVal.ts contains an explicit pass-count hack
+(deferring real work until `ctx.cc >= 3`, commented "this delay ...
+is a hack"). Meanwhile the revisit bound `MAXCYCLE = 999` carries an
+acknowledged defect in the other direction — "TODO: FIX: false
+positive when too many top unifications" (ts/src/unify.ts:29) — so a
+large-but-legal model can be misreported as `unify_cycle`.
+
+An agent repairing a model needs these verdicts separated: a genuine
+cycle means *fix the model*, incompleteness means *supply more*, and
+budget exhaustion means *the evaluator gave up* — retrying with a
+larger budget is valid for the third and useless for the first two.
+A gate whose failure modes are indistinguishable cannot anchor an
+emit → validate → repair loop, and an evaluator that reads the
+filesystem at the direction of its input cannot be pointed at
+untrusted input at all.
+
+## Current state
+
+What exists and is reusable:
+
+- **A pure evaluation core.** The language has no clock, no
+  randomness, no environment access: the 12 builtins (`upper`,
+  `lower`, `copy`, `key`, `type`, `hide`, `move`, `path`, `pref`,
+  `close`, `open`, `super` — ts/src/lang.ts funcMap) are pure value
+  transformers, the single `+` operator works over concrete scalars
+  (ts/src/val/PlusOpVal.ts), and external input enters only through
+  `@"…"` includes and host-injected `$name` variables (`ctx.vars`,
+  ts/src/ctx.ts). Hermeticity fails only at the resolver boundary.
+- **Injectable capability points.** `AontuOptions` (ts/src/type.ts)
+  accepts `resolver`, `fs`, and `base`; docs/reference-api.md
+  documents an in-memory resolver and `memfs` volumes for tests. The
+  resolver chain itself (`makeModelResolver`, ts/src/lang.ts, ~line
+  757) tries memory → filesystem → package in order, so a confined
+  memory-only evaluation is constructible today — it is a posture, not
+  a default, and nothing tests it.
+- **Bounded evaluation, mechanically.** The fixpoint is already
+  budgeted (`maxcc = 9` passes, `MAXCYCLE = 999` revisits per
+  `(a.id, b.id, pathidx)` key, a 9999 depth cap in `walk`,
+  ts/src/utility.ts) and the catch-all in `unite` converts even
+  stack-overflow `RangeError` into an `internal` nil. Termination is
+  a fact of the implementation, not a stated guarantee, and its
+  edges (silent pass exhaustion, cycle false positives) leak.
+- **Determinism, engineered and partially pinned.** Conjunct-term
+  sorting and the canonical closed-map unify direction make `&`
+  order-independent by construction (ts/src/val/ConjunctVal.ts,
+  ts/src/val/MapVal.ts); `gen` and canon sort map keys; Go reproduces
+  JS `Number.toString` for the shared IEEE-754 double semantics
+  (go/scalar_format_test.go). Crucially, the spec suite already pins
+  canon **byte-for-byte**: `canon` rows are strict string equality in
+  both runners (ts/test/spec.test.ts, go/spec_test.go), and the Go
+  runner has no skip list. `gen` rows, however, compare deep-equal
+  JSON *values*, not serialised bytes — byte-identical generated
+  output is true in practice and guaranteed nowhere.
+- **A parity method to extend.** 45 shared spec files (~426 rows,
+  modes `canon`/`gen`/`err`); test/spec/engine-parity.tsv is
+  precedent for pinning whole regression *classes*, and
+  test/spec/var.tsv for a spec file with fixed runner-side
+  configuration (a shared variable set) — the pattern a
+  trust-profile spec file needs. Per AGENTS.md, only the asserted
+  substring of an error message is contractual.
+- **Dependency plumbing.** A `deps` record is threaded through parse
+  (ts/src/aontu.ts, ts/src/lang.ts) — the skeleton of an evaluation
+  manifest — but it arrives empty in the paths exercised while
+  writing this document; the manifest is wiring work, not invention.
+
+What structurally blocks the capability:
+
+- **Unsafe-by-default resolution at every surface.** CLI
+  (ts/src/cli.ts: no flags beyond `--canon`/`--help`/`--version`),
+  library (default `makeModelResolver`), and LSP (fresh `new Aontu()`
+  per request) all get the full memory → filesystem → package chain.
+  The Go port is narrower by accident, not by design: go/source.go
+  implements only the file resolver (no memory or package leg), with
+  the same SECURITY comment — an undocumented parity asymmetry.
+- **No budget error taxonomy.** Pass exhaustion emits nothing;
+  `unify_cycle` conflates suspicion with proof; the pass loop also
+  breaks on the first erroring pass, so budget behaviour and error
+  collection interact invisibly.
+- **Single-use trees as folklore.** The in-place mutation contract
+  ("the returned Val is SINGLE-USE") lives in a comment on
+  `Aontu.parse` (ts/src/aontu.ts) and in Val.ts; TOP is deliberately
+  not a singleton for the same reason (ts/src/val/top.ts). Nothing
+  enforces it and reference documentation understates it — a
+  determinism hazard for embedders who reuse a tree.
+- **No spec vocabulary for trust.** The TSV format cannot currently
+  express "this include must be denied" or "this evaluation must be
+  byte-identical", so none of the four guarantees is testable in the
+  shared suite as it stands.
+
+## Prior art
+
+**Jsonnet** states hermeticity as a design axiom — "the same JSON
+should be generated regardless of the environment" — with external
+input confined to explicit `--ext-str` variables and top-level
+arguments. The cost: the guarantee lives in prose and code review,
+not in an enforced capability surface. Aontu's `$` variables already
+match the input model; the lesson is to *test* the claim.
+
+**Starlark** shows determinism as an engineering discipline:
+deterministic iteration order, values frozen after module
+evaluation, no recursion, all errors fatal. Frozen values enable
+safe parallel reuse — the opposite of Aontu's single-use mutable
+trees — but freezing an existing mutating unifier is a rewrite; the
+adoptable part is pinning observable ordering in the spec suite.
+
+**Dhall** contributes two things. Totality — "if an expression
+type-checks then evaluating it always succeeds in finite time" — is
+the headline Aontu should be able to print, with explicit fuel where
+structural totality is not enough. And its import-sandbox rules are
+the reference design for the day includes go remote: remote imports
+may only transitively import other remote resources (never local
+files or environment), computed import paths are prohibited, custom
+headers forward only same-domain, CORS-style opt-in blocks SSRF.
+Adopting the rules early costs nothing; adopting them late means
+retrofitting a deployed ecosystem.
+
+**Pkl** demonstrates evaluator-level capability policy:
+`--allowed-modules` / `--allowed-resources` regex allowlists
+enforced by the evaluator and exposed through its bindings API,
+trust levels that stop remote modules importing local ones, external
+readers confined to child processes. The lesson: the *host* declares
+what an evaluation may touch, in the API, not in documentation. The
+cost is real surface — allowlist syntax, precedence, and error
+reporting all become contract.
+
+**Kubernetes CEL** shows the sophisticated end of budgeting: a
+statically estimated worst-case cost in abstract "cost units",
+rejecting over-budget rules at registration time unless authors bound
+sizes. Deterministic by construction — no wall-clock anywhere. This
+is the model [G8](g8-generation.md)'s combinators will need; the cost
+of building it before combinators exist is waste, so G5 lays only the
+budget units it would consume.
+
+**Cedar** documents the selection criteria buyers apply to
+agent-boundary languages: AWS chose it citing determinism ("same
+decision for identical requests"), analysability, and
+non-Turing-completeness. The agent-industry survey adds an economic
+angle: prompt caches require byte-identical prefixes, so a canonical
+form byte-stable across runs and implementations is directly
+monetisable as cache hits (one team went from 7% to 84% hit rate by
+stabilising serialisation alone).
+
+**Ivy** supplies the meta-lesson: fix the fragment first, and treat
+staying inside it as a language-design activity. Every query must
+return a total, deterministic answer; "maybe/timeout" destroys
+trust. The trust contract is that fragment discipline written down —
+near-zero code, outsized payoff — with features that would exit it
+(wall-clock budgets, ambient I/O, unbounded recursion) refused at
+the design table, not patched after.
+
+## Design space
+
+**A. Document-only.** Write docs/trust.md stating the four
+guarantees; change no code. Cheapest possible; but hermeticity is
+*false* today under the default resolver, so the document would be
+marketing, not contract — and an untested guarantee in a
+dual-implementation project is a parity bug waiting to happen.
+Rejected as an end state; the written contract is Phase 1 of the
+plan.
+
+**B. Flip every default to safe.** Memory-only resolution unless
+explicitly widened, in CLI, library, and LSP alike, in one release.
+Maximal safety, minimal design; but it breaks the CLI's primary
+current use (evaluating your own files, with `@"file"` includes and
+package-distributed models) with no migration path, for users who
+face no untrusted input at all. The Pkl/Dhall precedent is
+graduated capability, not prohibition. Rejected.
+
+**C. A capability-scoped trust profile with per-surface defaults.**
+One `trust` option on the evaluator — include capability (`none` /
+`mem` / root-confined / `system`) plus deterministic budgets — with
+defaults chosen per surface (LSP: workspace-confined; library:
+explicit; CLI: entry-file root, `system` behind a flag) and a staged
+default flip. Budget exhaustion and cycle suspicion become distinct
+error codes reported via the [G2](g2-validation-verb.md) contract;
+determinism and hermeticity land as spec rows. Moderate cost spread
+over existing seams (`options.resolver`, `options.fs`, the pass
+loop).
+
+**D. Process-level sandboxing.** Run evaluation in an isolated child
+process or WASM sandbox (Pkl external readers, browser-style). Strong
+containment even against evaluator bugs; but it is heavy machinery in
+two implementations for a language whose only effect *is* the
+resolver — confining the resolver confines the language. Justified
+only when [G6](g6-distribution.md) ships remote includes and the
+threat model includes evaluator compromise. Deferred.
+
+**E. Termination and determinism only.** Fix the budget taxonomy and
+pin byte-stability, leave resolver posture as a documented caveat.
+Cheaper than C; but sandboxing is the acute agent-facing risk (the
+verified exfiltration example), and the review's sequencing places
+the trust contract in Phase A precisely because agent evaluation of
+third-party definitions is the positioning claim. Rejected.
+
+**Recommendation: C**, with D noted as the G6-era escalation path.
+C is the only option that makes all four guarantees simultaneously
+*true* and *tested* without breaking the existing user base: the
+capability surface reuses injection points the code already has, the
+budget taxonomy is a small unifier change, and the spec suite is the
+natural home for the guarantees — which is what distinguishes a
+contract from a claim.
+
+## Proposed design
+
+The design adds **zero language syntax**. Trust is a property of the
+evaluation, not the document: a `.aon` file cannot request more
+capability, and canonical form is untouched — `parse(canon(v)) == v`
+is not at risk from anything below.
+
+### The contract
+
+A new docs/trust.md states four normative clauses, each backed by
+spec rows:
+
+1. **Hermeticity.** The output of evaluation is a pure function of:
+   the entry source text, the resolved include closure, the
+   host-injected `$` bindings, and the evaluator (implementation,
+   version, options). Nothing else — no clock, no randomness, no
+   environment variables, no network. The language has no construct
+   that observes time or entropy, and never will (see Boundary).
+   Under the `system` include capability the closure is unbounded and
+   machine-dependent; hermeticity is therefore *conditional on the
+   include capability*, and the contract says so plainly: confined
+   capabilities (`none`, `mem`, root) make the input set explicit and
+   the guarantee total.
+2. **Termination.** Every evaluation halts within deterministic,
+   configurable budgets counted in engine steps (never wall-clock).
+   Exhausting a budget is a semantic error with a distinct code —
+   never silent truncation.
+3. **Determinism.** Identical inputs (clause 1) produce byte-identical
+   canonical output and byte-identical generated JSON, across runs
+   and across the TypeScript and Go implementations. Error *codes*
+   and asserted substrings are stable per the G2 registry; full error
+   text remains non-contractual (AGENTS.md rule, unchanged).
+4. **Sandboxing.** What an evaluation may read is declared by the
+   host through the trust profile; the default at each surface is the
+   least capability that serves that surface's primary use. Denied
+   resolution is a located, deterministic error.
+
+### Trust profile and budgets (API)
+
+```ts
+const aontu = new Aontu({
+  trust: {
+    // include capability, one of:
+    //   'none'                — @"…" always denied
+    //   { mem: {...} }        — virtual file set only
+    //   { root: '/models' }   — real files, realpath-confined
+    //                           below root; no package resolution
+    //   'system'              — today's mem → file → pkg chain
+    include: { root: '/models' },
+    budget: {
+      passes: 9,        // fixpoint passes (today's maxcc, reified)
+      revisits: 999,    // per-pair revisit bound (today's MAXCYCLE)
+      depth: 512,       // structural recursion depth
+    },
+  },
+})
+```
+
+Go mirrors this on `aontu.Options` (go/aontu.go), with the honest
+parity note made explicit: Go's `system` capability is file-only
+today (go/source.go has no package leg), so `system` in Go equals
+`root: '/'` semantics. The profile makes the asymmetry visible
+instead of accidental.
+
+Budgets are configurable-but-deterministic: integer counts of engine
+events (pass index, per-pair revisit count, descent depth). The
+contract pins *verdicts* at default budgets — every spec row must
+produce the same verdict in TS and Go — not internal step counts,
+which are implementation detail. Wall-clock and memory limits are
+refused (Boundary): a budget that varies with machine load makes the
+same input fail differently across runs, precisely the property this
+document exists to forbid.
+
+### Budget and cycle errors
+
+Three distinct outcomes replace today's conflation, all reported
+through the [G2](g2-validation-verb.md) error contract:
+
+- **`path_cycle`** (exists) — a *proven* structural cycle, detected
+  deterministically by path-prefix analysis (ts/src/val/RefVal.ts).
+  Extend detection to mutual reference chains (`a: $.b, b: $.a`,
+  today a generic `ref` error) by tracking the resolution chain, so
+  proven cycles stop masquerading as unresolved references.
+- **`budget_passes`** (new) — the pass loop (ts/src/unify.ts)
+  finished `budget.passes` passes with the root not `DONE` and no
+  other error. The nil's details name the budget, its limit, and the
+  paths still refining; the message asserts the substring
+  "evaluation budget". This is the error that makes the `maxcc = 9`
+  bound honest.
+- **`unify_cycle`** (exists, retained) — the per-pair revisit bound
+  tripped: *suspected* non-convergence. The unify.ts:29 false
+  positive ("too many top unifications") is addressed under this
+  code: revisit counting must not increment when a visit made
+  progress (the pair's done state advanced), which the existing
+  `PrefVal` peg-identity note in ts/src/unify.ts already gestures at.
+  A corpus of large-but-legal models (generated-SDK scale, which the
+  performance comments show the engine has met) lands as spec rows
+  guarding the fix.
+
+Per G2's class table, count-triggered `budget_passes` and
+`unify_cycle` carry class `budget`; the proven `path_cycle` is a
+semantic reference error. An agent can therefore branch: class
+`budget` → retry with a raised budget or restructure; `path_cycle` →
+the model is wrong; `no_path` → the model is incomplete.
+
+`budget.passes` keeps its default of 9 initially: the value is
+load-bearing (ts/src/val/KeyFuncVal.ts defers until `ctx.cc >= 3`),
+so reifying the bound and erroring distinctly is Phase 2; raising
+the default is a separate, spec-guarded decision (Open questions).
+
+### Determinism, pinned
+
+- **Canon**: already byte-pinned per row by strict string equality in
+  both runners — the contract documents this as a guarantee rather
+  than an implementation habit.
+- **Generated JSON**: a new spec mode `gens` (docs/shared-spec.md;
+  runners ts/test/spec.test.ts, go/spec_test.go) asserts the
+  *serialised* generated output byte-for-byte: stable key order
+  (already alphabetical from `gen`), no whitespace variance, JS
+  number formatting (which go/scalar_format_test.go already
+  reproduces). Existing `gen` rows are untouched; `gens` rows start
+  with a number-heavy corpus, the known risk surface.
+- **Repeatability**: a property row class — evaluate the same source
+  twice (fresh parse each time, honouring the single-use contract)
+  and require byte-equal canon and `gens` output.
+- **Single-use trees as API contract**: the mutation caveat moves
+  from code comment to docs/reference-api.md as a named rule
+  ("evaluation consumes the tree"), with a debug-mode guard (a
+  consumed flag checked at `unify` entry, raising `reused_tree`) so
+  violations fail loudly instead of nondeterministically. Debug-only
+  keeps it off the measured hot path.
+
+### Hermeticity, tested
+
+A new test/spec/include-trust.tsv follows the var.tsv precedent (a
+spec file with fixed runner-side configuration): the runner evaluates
+its rows under a declared trust profile rooted at the fixtures
+directory. Representative rows:
+
+```
+deny-parent	err	a:@"__FIXTURES__/../secret.aon"	include denied
+deny-abs	err	a:@"/etc/hostname"	include denied
+deny-pkg	err	a:@"some-package"	include denied
+allow-in-root	gen	a:@"__FIXTURES__/foo.aon"	{"a":{"f":11}}
+```
+
+Denial is a parse-stage nil, `include_denied`, carrying the denied
+path and the active capability — deterministic, located, and pinned
+by substring like every other error row. The existing file.tsv rows
+continue to run under a root profile scoped to the fixtures
+directory, making the shared suite itself hermetic: no spec row may
+depend on files outside the repository or on installed packages.
+
+The `deps` record is wired and specified as the evaluation manifest:
+after evaluation, `result.deps` lists the resolved include closure
+(absolute resolved path, resolving capability). This is the "file
+set" of clause 1 made observable — the seed for caching and replay —
+while content hashing and pinning stay with
+[G6](g6-distribution.md).
+
+### Surfaces and migration
+
+- **LSP** (first to flip, least breakage, highest exposure):
+  ts/src/lsp.ts constructs its evaluator with
+  `trust.include = { root: workspaceRoot }` from the `initialize`
+  params; no package resolution. A client setting
+  (`aontu.trust.include`) widens explicitly. go/lsp mirrors it —
+  diagnostics parity (AGENTS.md) demands identical denial behaviour.
+- **Library**: the `trust` option ships immediately; the default
+  stays `system` for one minor-version window with a documented
+  deprecation, then flips to requiring an explicit capability when
+  any include is present (a model with no `@"…"` needs no profile
+  and never errors).
+- **CLI**: gains `--trust <system|root[:dir]|none>` and
+  `--include-root <dir>`. During the warning window the default
+  stays `system`, but any resolution that escapes the entry file's
+  directory tree or hits the package leg prints a one-line stderr
+  warning naming the flag that will be required. At the next major
+  version the default becomes root-confinement at the entry file's
+  directory — keeping fixture-style relative includes working
+  (test/spec/file.tsv, `load-rel-chain`) — with `--trust system`
+  restoring today's behaviour.
+
+### Rules pre-registered for remote includes
+
+Adopted now, enforced the day [G6](g6-distribution.md) ships any
+remote resolver — so the ecosystem never has a permissive interlude:
+
+1. Remote sources may include only remote sources: never local
+   files, never `$` bindings, never anything environment-derived.
+2. Include paths are literal strings — true today (`@` takes a
+   literal, not an expression) and pinned by a spec row so it stays
+   true.
+3. No credential or header forwarding across origins; explicit
+   opt-in for anything beyond a bare fetch.
+4. Remote resolution is only available under an explicit capability;
+   it never joins `system`.
+
+## Boundary: what we will not do
+
+- **No wall-clock or memory budgets.** A limit that varies with
+  machine load makes identical inputs fail differently — the exact
+  nondeterminism this contract forbids; budgets are counted engine
+  events only.
+- **No time, randomness, or environment access in the language,
+  ever.** `now()`/`random()`/`env()` would each falsify clause 1 by
+  construction; parameterise through `$` bindings instead.
+- **No remote includes here.** Fetching, versioning, and pinning are
+  [G6](g6-distribution.md)'s; G5 only pre-registers the sandbox
+  rules they must obey.
+- **No process/WASM isolation runtime.** Confining the resolver
+  confines the language's only effect; heavier isolation is a
+  G6-era decision for a changed threat model.
+- **No CEL-style static cost estimation yet.** There are no
+  user-facing combinators to estimate; [G8](g8-generation.md)'s
+  generation constructs will bring the cost model and must express
+  it in G5's budget units.
+- **No error-format invention.** Budget and denial findings ride the
+  [G2](g2-validation-verb.md) contract (class `budget`, stable
+  codes); this document adds codes, not formats.
+- **No canon-hash or module identity.** Semantic hashing over
+  canonical form is [G6](g6-distribution.md)'s differentiator; the
+  `deps` manifest here deliberately stops at paths.
+- **No Turing-completeness and no SMT solvers** (index.md traps):
+  termination stays structural plus fuel, and every trust query is
+  answered by counting, never by solving.
+- **No freezing/parallel-reuse rewrite.** Starlark-style frozen
+  values would mean rewriting the mutating unifier; the single-use
+  contract is documented and guarded instead.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Default flip breaks CLI/library users relying on `@"pkg"` or parent-relative includes | High | Medium | Warning window that prints the exact future-required flag on every escaping resolution; entry-root default keeps relative-include projects working; `--trust system` remains |
+| Reifying the pass budget perturbs existing models (pass index is semantic: KeyFuncVal `cc >= 3` hack) | Medium | High | `budget.passes` default stays 9; all 45 spec files must pass unchanged before and after; KeyFuncVal behaviour pinned by spec rows prior to any change |
+| `unify_cycle` false-positive fix changes which large models error | Medium | Medium | Fix lands behind the distinct code with a generated-SDK-scale row corpus; both implementations run the corpus with no skip list |
+| Byte-pinning `gens` exposes latent TS/Go serialisation divergence (numbers, escaping) | Medium | Medium | Go already mirrors `Number.toString` (go/scalar_format_test.go); introduce `gens` rows incrementally, numbers first; divergences become fixes, not suite carve-outs |
+| Root-confinement path handling diverges across OS/implementations (symlinks, case, realpath) | Medium | High | Confinement = realpath then prefix check, specified in docs/trust.md; include-trust.tsv exercises traversal and symlink escapes; Windows caveats documented |
+| Mutual-cycle detection (upgrading `ref` to `path_cycle`) misclassifies legal forward references | Low | High | Detection only on the resolution chain revisiting a node, never on syntactic shape; existing ref.tsv rows must stay green |
+| Debug-mode consumed-tree guard leaks onto the hot path | Low | Medium | Guard compiled behind `opts.debug`; perf comments in ts/src/unify.ts give the baseline to re-measure |
+| Adoption: safe defaults read as friction next to permissive competitors | Medium | Low | The flip is staged and the message is positive (Cedar-style determinism/analysability selection criteria); models without includes never see the profile |
+| LSP confinement breaks editing files that include outside the workspace | Low | Low | Client setting widens per-workspace; denial diagnostics say exactly what to set |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows before code; TypeScript (canonical) first, Go port follows.
+Nothing may regress at any phase: the 44 existing spec files
+(~426 rows), the error.tsv substring assertions, canon round-trip
+`parse(canon(v)) == v`, and byte-equal canon rows across TS and Go.
+
+**Phase 1 — write the contract (S).**
+New docs/trust.md (four clauses, profiles, budget names, remote-
+include pre-registered rules); docs/reference-api.md gains the
+single-use-tree rule and the trust option stub; AGENTS.md points to
+the contract. No behaviour change. This plus Phase 2 is the review's
+Phase A slice ("trust contract written and spec-pinned").
+
+**Phase 2 — budget and cycle taxonomy (M).**
+Spec: new test/spec/budget.tsv pinning `path_cycle` (self and
+mutual), `no_path`, `budget_passes`, `unify_cycle` as distinct
+substrings; large-but-legal corpus rows for the false-positive fix.
+Code: ts/src/unify.ts (pass-loop exit emits `budget_passes` on
+residue; progress-aware revisit counting for the line-29 TODO),
+ts/src/val/RefVal.ts (mutual-cycle chain detection),
+ts/src/hints.ts; then go/unify.go, go/ref.go, go/hints.go.
+
+**Phase 3 — trust profile and confinement, TypeScript (L).**
+Spec: test/spec/include-trust.tsv (fixed-profile runner convention à
+la var.tsv; denial and allow rows; literal-include-path row); file.tsv
+re-scoped under a fixtures-root profile. Code: ts/src/type.ts
+(`trust` option), ts/src/lang.ts (`makeModelResolver` honours the
+capability; `include_denied` nil), ts/src/ctx.ts plumbing,
+ts/src/cli.ts (`--trust`, `--include-root`, escape warnings),
+ts/src/lsp.ts + ts/src/lsp-server.ts (workspace-root default,
+`initializationOptions`); runner change in ts/test/spec.test.ts.
+
+**Phase 4 — Go port of profile and budgets (L).**
+Code: go/aontu.go (options), go/source.go (root confinement,
+`include_denied`, documented `system`≡file-only note), go/ctx.go,
+go/unify.go defaults, go/cmd/aontu flags, go/lsp. go/spec_test.go
+runs budget.tsv and include-trust.tsv with no skip list; LSP denial
+diagnostics byte-identical to TS.
+
+**Phase 5 — determinism byte-pinning (M).**
+Spec: `gens` mode documented in docs/shared-spec.md; rows in a new
+test/spec/gens.tsv (numbers first, then strings/escaping, then
+structures); repeatability property rows. Code: ts/test/spec.test.ts
+and go/spec_test.go mode handling; any serialisation divergence fixed
+in the implementation, never carved out of the suite. `deps` manifest
+wired (ts/src/lang.ts → ts/src/aontu.ts; go/lang.go) and documented.
+
+**Phase 6 — default flip (S code, staged socially).**
+Warning window ships with Phase 3; the flip itself (CLI entry-root
+default, library explicit-capability requirement, LSP already
+confined) lands at the next major version with a migration note in
+docs/how-to.md.
+
+Rough sizing: S ≈ days, M ≈ a week or two, L ≈ several weeks per
+implementation.
+
+## Open questions
+
+- **Where the CLI default root lands.** Entry-file directory (keeps
+  relative-include projects working, breaks shared-parent layouts)
+  versus process cwd (broader, but surprising when invoked from
+  elsewhere). The warning-window feedback decides; the flag names
+  must not change afterwards.
+- **Whether `budget_passes` advice names the remedy.** An error that
+  says "raise `--budget-passes`" repairs agent loops faster (G2's
+  admissible-alternatives finding) but invites cargo-cult budget
+  inflation that hides genuine non-convergence. Possibly: name the
+  flag only when the residue shrank on the final pass (still
+  converging), not when it was stable (likely a true cycle).
+- **Raising the default pass budget.** 9 is historical
+  (`maxcc = 9 // 99` in ts/src/unify.ts suggests it was once
+  higher); a larger default plus the distinct error may serve big
+  models better. Requires the Phase 2 corpus first, and a decision
+  on whether KeyFuncVal's `cc >= 3` hack is replaced (residuation,
+  per the survey) or preserved bit-for-bit.
+- **Does the hermeticity tuple include evaluator version?** Clause 1
+  currently says yes (canon can legitimately change between
+  versions), which makes cross-version caching unsound by contract.
+  [G6](g6-distribution.md)'s canon-hash work may want a stronger
+  within-major-version stability promise; that promise should be
+  made there, once, not twice.
+- **Whether `mem`-profile rows should become the only sanctioned
+  include mechanism inside the shared suite.** Fixtures-on-disk under
+  a root profile are simpler today; a fully virtual file set would
+  make the suite runnable with no filesystem at all (useful for
+  future WASM/browser runners) at the cost of a bigger runner change.

--- a/docs/capability-review/g6-distribution.md
+++ b/docs/capability-review/g6-distribution.md
@@ -1,0 +1,556 @@
+# G6: A distribution layer — versioned, integrity-hashed, pinnable modules
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G6 — growing `@"…"` file inclusion into module identity, versioning,
+registry distribution, and semantic integrity hashing over Aontu's
+canonical form. Sibling documents own adjacent surfaces — see
+[Boundary](#boundary-what-we-will-not-do).*
+
+## Problem
+
+Textual file inclusion is a single-project mechanism. A ground truth
+earns the name only if it can travel — across repositories, teams,
+and agent sessions — and remains tamper-evident while it travels.
+Today Aontu has neither an identity for a shareable unit of truth,
+nor a version to name a moment in its evolution, nor an integrity
+check to prove the truth received is the truth reviewed.
+
+First failing example: importing across a repository boundary. A
+platform team publishes a service schema; a consuming team's agent
+wants to validate against it by name and version:
+
+```aon
+# consumer.aon — what a user wants to write today, and cannot
+service: @"corp.example/schemas/service@1"
+service: {
+  name: "checkout"
+  port: 9091
+}
+```
+
+Today this fails with `source not found:
+corp.example/schemas/service@1` after the resolver chain exhausts
+memory, filesystem, and package resolution (the error shape pinned
+by `test/spec/file.tsv:load-not-found`). The only cross-repository
+channel that *does* work is the package resolver — `@"pkg"` via
+`require()` — so distributing a schema today means publishing an
+npm package and having every consumer execute its code on load. The
+security comment above `makeModelResolver` (`ts/src/lang.ts`, near
+line 750) is blunt: treat opening an untrusted source as running
+it. That is a supply chain without any of a supply chain's
+protections.
+
+Second failing example: vendored copies drift silently. Two
+repositories each copied `service.aon` in January; one was edited in
+March:
+
+```aon
+# repo-a/vendor/service.aon  (as reviewed)
+service: close({ name: string, port: *8080 | integer })
+```
+
+```aon
+# repo-b/vendor/service.aon  (edited later; nothing objects)
+service: close({ name: string, port: *9090 | integer })
+```
+
+Both evaluate cleanly. Agents in the two repositories now hold
+different ground truths under the same name, materialise different
+defaults, and no tool in the language can detect the divergence, let
+alone locate it. "Ground truth" that forks silently is prose with
+extra steps.
+
+Third failing example: "has the truth changed?" cannot be answered
+cheaply or correctly. An agent caching a definition must decide
+whether to re-read and re-review it. Byte comparison — the only
+check available today — fails in both directions:
+
+```aon
+# service.aon, before a tidy-up commit
+service: { port: *8080 | integer, name: string }
+```
+
+```aon
+# service.aon, after a tidy-up — new bytes, identical meaning
+# The service schema.
+service: { name: string, port: *8080 | integer }
+```
+
+Both unify to canon
+`{"service":{"name":string,"port":*8080|integer}}`, yet a byte-level
+pin breaks, forcing a pointless re-review; conversely, a semantic
+change hidden two includes deep never touches the bytes the agent
+pinned. The economics compound: prompt caches require byte-identical
+prefixes, so a meaning-stable name for "the truth as of hash H" is
+directly monetisable as cache hits — the query surface is
+[G7](g7-machine-access.md)'s; the hash that names its entries is
+this document's.
+
+What is missing is one coherent layer: module identity, a version
+scheme, a lockfile, a distribution channel that does not execute
+code, and — the differentiator Aontu's canonical form makes nearly
+free — a semantic integrity hash that survives refactors and
+comments but breaks on any semantic change in the transitive
+include closure.
+
+## Current state
+
+What exists is a resolver chain and a canonical form; both are good
+bones, and both fall short in specific, enumerable ways.
+
+- **Source loading.** `@"path"` loads, parses, and unifies another
+  source in place (`docs/reference-language.md`, "Source loading").
+  Extensions `.aon`/`.aontu` are tried for bare paths; relative
+  paths resolve against the including file's own directory
+  (`test/spec/file.tsv:load-rel-chain`); the entry base is
+  configurable (TS `path` option, Go `NewWithBase`).
+- **The resolver chain.** `makeModelResolver` (`ts/src/lang.ts`,
+  ~757–816) tries memory → filesystem → package, composing
+  `makeMemResolver`, `makeFileResolver`, and `makePkgResolver` from
+  `@tabnas/multisource`. The memory resolver
+  (`options.resolver.mem`) is the sandbox-friendly entry point the
+  review counts as an asset; the package resolver calls
+  `require()`, with the consequences the security comment above
+  the function documents. The Go port wires only the file leg
+  (`go/source.go`, over `github.com/tabnas/multisource/go`) — no
+  memory or package resolver, an asymmetry
+  [G5](g5-trust-contract.md) records.
+- **Spec coverage.** `test/spec/file.tsv` (11 rows) pins loading,
+  merging, nested and colon-chain imports, relative chains,
+  conflict errors, and the not-found error text, against fixtures
+  in `test/spec/files/` (`__FIXTURES__` keeps rows hermetic).
+- **Canonical form.** `unify(src).canon` renders a deterministic,
+  reparseable text: map keys sorted alphabetically
+  (`ts/src/val/MapVal.ts`, ~421, matching Go's sorted JSON
+  marshalling), strings via `JSON.stringify`
+  (`ts/src/val/StringVal.ts`), numbers pinned to JavaScript
+  `Number.toString` in both implementations (`go/scalar.go`,
+  `formatNumber`). Includes are load-transparent: the imported value
+  unifies in place, so canon shows the merged result with no module
+  boundary.
+
+Four things structurally block the capability:
+
+1. **No identity or version anywhere.** The resolver interface is
+   find-by-path; nothing models "module", "version", or "the same
+   truth in two places". There is no lockfile and no verb to fetch,
+   pin, or publish (`ts/src/cli.ts` accepts one file and
+   `-c/--canon`, plus help/version flags; nothing else).
+2. **Canon is not semantically complete.** Closedness is not
+   rendered — `MapVal.canon` and `ListVal.canon` emit `{…}`/`[…]`
+   with no `close(…)` wrapper, so `close({x:1})` and `{x:1}`
+   canonicalise identically despite behaving differently under
+   further unification; `hide`/`type` marks are likewise invisible.
+   A hash over today's canon could report "unchanged" for a real
+   semantic change — the dangerous direction.
+3. **Parse-level canon is not in parity.** AGENTS.md records that
+   `parse(src).canon` parenthesises nested `&`/`|` in TS but not
+   in Go; only `unify(src).canon` is contractual. A hash must be
+   scoped to post-unification canon or it diverges by
+   implementation.
+4. **Evaluation and fetching are fused.** The resolver reads at
+   parse time, inside evaluation; a network-fetching resolver
+   there would break the hermeticity contract
+   [G5](g5-trust-contract.md) establishes. Parsed trees are also
+   single-use (the documented mutation caveat), so hashing needs a
+   deliberate evaluation, not a peek at a live tree.
+
+## Prior art
+
+- **Dhall — semantic integrity checks.** `dhall freeze` pins each
+  import with a SHA-256 of the CBOR-encoded *normal form* of the
+  imported expression. Refactors, comments, and whitespace do not
+  break the pin; any semantic change, including in transitive
+  dependencies, does. The cost: Dhall has no versioning or
+  discovery at all — every upgrade edits every import site, and
+  content addresses carry no "what changed" narrative. Dhall pays a
+  normalisation pass per hash; Aontu's existing canon makes the
+  same idea nearly free. No unification-family language has it.
+- **CUE — modules v3 and the Central Registry.** Domain-based
+  module paths with the major version in the path (`@v0`),
+  `cue.mod/module.cue`, Minimum Version Selection, distribution
+  over any OCI registry with a hosted default (registry.cue.works),
+  `cue mod init/tidy/publish`. The cost: a large tooling surface
+  and registry operations; CUE's own history warns that each added
+  stratum raised its floor. Integrity is byte-level (OCI digests),
+  not semantic.
+- **KCL — kpm.** `kcl.mod` plus `kcl.mod.lock`, push/pull to any
+  OCI registry (ghcr.io, Harbor). Confirms OCI as the settled
+  ecosystem default: every platform team already runs one.
+- **Go modules and Nix flakes.** MVS resolution, `go.sum` byte
+  hashes, a public checksum transparency log (sumdb); `flake.lock`
+  pins byte-level narHashes. Byte hashing suits Go because gofmt
+  makes formatting churn rare; config languages churn more, and
+  meaning-preserving refactors break these pins.
+- **buf / BSR.** Breaking-change checks enforced server-side at
+  publish time — the precedent for registry hooks that refuse a
+  push whose semantics regress, which
+  [G3](g3-subsumption-evolution.md) makes computable for Aontu
+  rather than heuristic.
+- **Agent practice.** Context7's resolve-then-query pattern shows
+  agents preferring a named, versioned authority over parametric
+  memory; prompt-cache studies (a 7%→84% hit-rate gain purely from
+  serialisation stability) make byte-stable canonical output an
+  economic asset.
+
+## Design space
+
+**A. Git/URL imports with optional byte-hash pins.** Terraform- and
+Bazel-style: `@"github.com/org/repo//schemas/service?ref=v2"`. No
+new infrastructure, transparent provenance. Costs: tags are mutable
+(a moved tag silently changes the truth), no version resolution
+across a dependency graph, byte pins break on refactors, and fetch
+logic creeps into the evaluator — against
+[G5](g5-trust-contract.md).
+
+**B. Piggyback on host package managers.** Ship `.aon` files inside
+npm and Go modules; the package resolver already half-does this.
+Disqualifying: `require()` executes code on load, the TS and Go
+ecosystems would resolve versions differently (breaking the "same
+truth in both implementations" contract), and non-Node/Go
+consumers are locked out.
+
+**C. Pure content addressing, Dhall-style.** Every remote import is
+a URL plus a semantic hash; no versions, no registry, no lockfile.
+Maximally tamper-evident and beautifully simple. Costs: no
+discovery, no upgrade story short of editing every import site, and
+no place to hang publish-time policy (G3 breaking gates). Right
+mechanism, insufficient layer.
+
+**D. Versioned modules over OCI, with a lockfile and canon-hash
+pins.** CUE/KCL's settled shape — domain-based module identity,
+SemVer with MVS, any OCI registry — plus the Dhall idea grafted on
+top: the lockfile pins each dependency by a hash of its canonical
+form, not its bytes. Costs: the largest tooling surface of the
+four; a module file and lockfile to specify; OCI plumbing in two
+implementations.
+
+**E. A bespoke hosted registry service.** A custom protocol and a
+service the project operates. Rejected without much ceremony:
+infrastructure the project must run forever, and OCI already
+provides storage, auth, replication, and org familiarity.
+
+**Recommendation: D, with C's inline pin as a degenerate mode.**
+The registry layer is commodity — adopt the ecosystem default and
+spend no novelty budget on it. The differentiation is entirely in
+the integrity layer: semantic hashes over canon give pins that
+survive refactors and break on meaning — which none of CUE, KCL,
+Go, or Nix offer, and which Dhall offers only without versioning.
+An inline hash fragment keeps the no-lockfile case — a gist, a
+prompt, a one-file agent sandbox — honest and pinnable. A is
+subsumed (a git remote can become a fetch source later); B is
+retired to a legacy role and fenced off by G5's resolver
+confinement.
+
+## Proposed design
+
+### Module identity and import syntax
+
+A module path is domain-based, CUE/Go-style, with the major version
+in the path. An import is still just `@"…"` — the string's *shape*
+routes it, so the grammar is untouched and every existing include
+keeps its exact behaviour:
+
+```aon
+# Module import: domain-shaped first segment + @<major>.
+service: @"corp.example/schemas/service@1"
+
+# Optionally frozen inline (SRI-style fragment) — the degenerate
+# no-lockfile mode for single-file and agent-sandbox use:
+service: @"corp.example/schemas/service@1#aon1-4vJemVYtWFR2mQeN…"
+
+# Everything else resolves exactly as today:
+extra: @"./local-fragment.aon"
+```
+
+A string routes to the module resolver only when it matches
+`host.tld/path…/name@N` (first segment contains a dot; trailing
+`@<integer>` major). Anything else falls through to the existing
+chain unchanged, so no current spec row can be affected.
+
+### Module file and lockfile — written in Aontu
+
+The module file is ordinary Aontu, validated against a schema the
+toolchain ships (the language dogfooding its own validation verb,
+[G2](g2-validation-verb.md)):
+
+```aon
+# mod.aon — module identity and requirements
+mod: {
+  path: "corp.example/schemas"
+  main: "schemas.aon"
+}
+dep: {
+  "corp.example/schemas/service@1": { v: "1.4.2" }
+}
+```
+
+The lockfile is machine-written Aontu **in canonical form** — one
+line, sorted keys, diffable, and parseable by the language itself:
+
+```aon
+# mod-lock.aon (generated by `aontu mod tidy`; do not edit)
+{"lock":{"corp.example/schemas/service@1":{"canon":"aon1-4vJemVYtWFR2mQeN…","oci":"sha256:6b86b273ff34fce1…","v":"1.4.2"}}}
+```
+
+Each entry carries **two** pins with distinct roles: the OCI digest
+certifies *these are the bytes the registry served* (transport
+tamper-evidence, free from OCI); the canon-hash certifies *this is
+the meaning that was reviewed* (semantic tamper-evidence, Aontu's
+contribution). Version selection is Minimum Version Selection —
+deterministic without a solver; the lockfile *confirms* the
+resolution rather than determining it.
+
+### The canon-hash
+
+`canonHash(v)` is defined as:
+
+```
+"aon1-" + base64url( SHA-256( UTF-8( hcanon( unify(module) ) ) ) )
+```
+
+where `hcanon` — the **hash form** — is exactly today's
+unify-level canon with two additions that close its semantic gaps:
+
+- a closed map or list renders wrapped: `close({…})`, `close([…])`
+  (today `MapVal.canon`/`ListVal.canon` drop closedness);
+- `hide`/`type` marks render as their builtin wrappers:
+  `hide(x)`, `type(x)`.
+
+Both additions reuse existing parseable syntax, so the hash form
+remains valid Aontu source and round-trips:
+`hcanon(unify(parse(hcanon(v)))) == hcanon(v)` is a spec-suite
+property. The hash is scoped to *post-unification* canon only —
+parse-level canon parenthesisation differs between TS and Go
+(AGENTS.md) and is excluded by construction. User-facing `canon`
+is unchanged; `hcanon` is a separate rendering, so no existing
+canon row moves.
+
+The hash covers the module evaluated **standalone**: its own
+include closure resolved and unified at its own root, before any
+consumer context — Dhall's choice (hash the normal form of the
+imported expression), and what makes the pin transitive: an edit
+two includes deep changes the unified root, hence the hash.
+Unresolved references to consumer context (`$.x`) must stay part
+of the hashed meaning in textual form; today standalone
+unification reports them as `no_path` errors and canon renders
+`nil`, so preserving them is part of the `hcanon` definition, not
+free behaviour.
+
+**The pin survives** comments, whitespace, formatting, key
+reordering, splitting one file into several includes — any refactor
+that leaves the unified value identical. **It breaks on** any
+semantic change in the transitive closure: a default flipped, a
+field added, a map closed, a constraint tightened.
+
+**The honest label.** This is a *canonical-text* hash, not a hash
+of semantic equivalence classes: canon is deterministic syntax,
+not a unique normal form — `number|integer` denotes the same value
+set as `number` yet canonicalises differently (`DisjunctVal` drops
+only `same()` alternatives). The failure direction is the safe one:
+a false "changed" forces a needless re-review, while a false
+"unchanged" is impossible *provided the hash form is semantically
+complete* — exactly why the `close`/mark additions are part of the
+definition, not an optimisation. Once
+[G3](g3-subsumption-evolution.md)'s subsumption lands, a
+minimisation pass (drop disjuncts subsumed by siblings) can
+upgrade the hash toward a true semantic normal form under a new
+scheme id; the `aon1-` prefix exists so that day is an upgrade,
+not a breakage.
+
+### Resolution, offline, and vendoring
+
+Evaluation never touches the network. The module resolver slots
+into the existing chain — memory → **module** → filesystem →
+package — and reads only local stores: `aon_vendor/` in the
+project, then a content-addressed user cache
+(`~/.cache/aontu/mod`, keyed by canon-hash). The memory resolver
+stays first so sandboxes and the spec suite can stub module paths
+without touching disk. [G5](g5-trust-contract.md) pre-registers
+sandbox rules for any future remote resolver; this design
+satisfies them trivially by never resolving remotely during
+evaluation. Fetching is a separate, explicit tool step:
+
+```
+aontu mod get           # fetch deps into the cache, verify both pins
+aontu mod tidy          # resolve MVS, rewrite mod-lock.aon
+aontu mod vendor        # materialise the closure into aon_vendor/
+aontu mod publish       # package + push the current module
+aontu hash [file]       # print the canon-hash of a file/module
+```
+
+A module import absent from vendor and cache is an evaluation
+error instructing the fetch step; a present module whose
+*recomputed* canon-hash disagrees with the lock (or inline
+fragment) is an integrity error — verification is always local,
+the registry's annotation merely advisory. Both errors are
+reported via the [G2](g2-validation-verb.md) contract; in the
+spirit of the existing `source not found:` row, the asserted
+substrings are:
+
+```
+module not fetched: corp.example/schemas/service@1 (run: aontu mod get)
+module integrity: corp.example/schemas/service@1 expected aon1-4vJe… got aon1-9kQz…
+```
+
+The determinism this rests on — same file set plus same `$`
+bindings gives identical output — is
+[G5](g5-trust-contract.md)'s guarantee; this design consumes it
+and adds none of its own.
+
+### Distribution and registry hooks
+
+A module is an OCI artifact: config media type
+`application/vnd.aontu.module.v1+json`, one layer holding the
+module source tree, manifest annotations carrying module path,
+version, and canon-hash. Any OCI registry works; no hosted default
+is required for v1. Two hooks make the registry more than storage:
+
+- **Publish-time breaking gate.** `aontu mod publish` runs the
+  breaking check against prior published versions, and a
+  registry-side hook can enforce the same check server-side,
+  buf-style. The semantics of "breaking" belong wholly to
+  [G3](g3-subsumption-evolution.md); this layer only invokes them
+  where versions are minted.
+- **"Has the truth changed?"** becomes one annotation read and a
+  string compare — no download, no parse. The same hash names
+  cache entries for [G7](g7-machine-access.md)'s query surface: an
+  agent's context keyed "truth as of `aon1-4vJe…`" stays
+  prompt-cache-stable until the meaning actually moves.
+
+## Boundary: what we will not do
+
+- **No network access during evaluation, ever** — fetching is a
+  tool verb; hermeticity is [G5](g5-trust-contract.md)'s contract
+  and this design must not be the thing that breaks it.
+- **No private-registry auth design in v1** — ambient OCI
+  credentials (docker login) suffice to start; a credential surface
+  designed in haste becomes an exfiltration channel.
+- **No signing or provenance attestation in v1** — dual pins give
+  tamper-evidence; signatures answer "who", a separable problem
+  with mature OCI ecosystem answers (sigstore) to adopt later.
+- **No version ranges or dependency solver** — MVS only; a
+  constraint solver in resolution reintroduces the
+  nondeterminism the review's "no SMT solvers" trap exists to keep
+  out.
+- **No project-operated central registry service** — any OCI
+  registry works; running infrastructure forever is not a language
+  feature.
+- **No import namespaces or symbol system** — an import stays a
+  value unified in place, not a scope; module-scoped identifiers
+  are exactly the surface-area creep toward CUE the review warns
+  against.
+- **No semantic minimisation inside the v1 hash** — it needs
+  [G3](g3-subsumption-evolution.md)'s subsumption to be principled;
+  v1 ships the clearly-labelled canonical-text hash.
+- **No error-format invention** — integrity and not-fetched errors
+  are shaped by the [G2](g2-validation-verb.md) contract.
+- **No comment or formatting preservation in distributed modules**
+  — modules travel as source but pin as meaning; a
+  format-preserving rewrite story belongs to
+  [G7](g7-machine-access.md)'s patch surface.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| TS/Go hash divergence (string escaping, number formatting, future canon drift) | Medium | High — pins flap by implementation | Scope to unify-level canon (already in parity); add escape-heavy and extreme-magnitude `hcanon` rows; add cross-implementation byte-equality of hash form to the shared suite |
+| Hash form misses a semantic feature (as canon misses closedness today) | Medium | High — false "unchanged", the unsafe direction | Per-Val completeness audit as a spec-writing step; scheme id (`aon1-`) so a discovered gap ships as `aon2-` rather than silently re-pinning |
+| G1's new constraint syntax changes canon, invalidating all pins | High | Medium — one-time ecosystem re-pin | Coordinate: hash GA after [G1](g1-constraint-algebra.md)'s canon settles, or bump the scheme id with G1's landing |
+| Single-use trees force an extra evaluation per hash; large closures are slow | Medium | Medium | Content-address the cache by source-byte digest so unchanged inputs never re-evaluate; hash at fetch/publish time, not per eval |
+| Canon round-trip regression from `hcanon` work leaking into `canon` | Low | High — breaks ~426-row contract | `hcanon` is a separate rendering; existing canon/gen/err rows are the regression gate |
+| Registry/tooling surface overwhelms a small project (CUE's floor-raising lesson) | Medium | Medium | Phase strictly: hash first (useful alone, zero infrastructure), registry later; vendoring works with no registry at all |
+| Dependency confusion / name squatting on domain paths | Low | Medium | Domain-based identity ties names to DNS control; first-segment host mapping; lockfile pins make substitution detectable |
+| Adoption: nobody publishes modules for a small ecosystem | Medium | Medium | The hash is valuable with zero publishers (vendored-copy drift detection, cache keys); inline pins work on gists and single files |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows, TypeScript (canonical) makes them pass, then the Go port.
+Nothing may regress the existing 45 spec files (~426 rows) or the
+canon round-trip `parse(canon(v)) == v`; `@tabnas` pins stay exact.
+
+**Phase 0 — the hash form (S/M).** Add the `hcanon` rendering
+(closedness wrappers, mark wrappers) and a new shared-spec mode
+`hcanon` asserting its text. Rows: closed maps/lists at depth,
+marks, spreads, optional keys, prefs, refs, escape-heavy strings,
+extreme-magnitude numbers, and `hcanon` idempotence/round-trip.
+Touches: `ts/src/val/MapVal.ts`, `ts/src/val/ListVal.ts`,
+`ts/src/val/Val.ts` (default `hcanon` delegating to `canon`),
+`ts/test/spec.test.ts`, `go/mapval.go`, `go/listval.go`,
+`go/val.go`, `go/spec_test.go`, `docs/shared-spec.md`, new
+`test/spec/hcanon.tsv`. User-facing `canon` must not change.
+
+**Phase 1 — the hash itself (S).** `canonHash()` in the API and
+`aontu hash` in the CLI; a `hash`-mode row family pinning full
+`aon1-…` strings cross-implementation. Touches: `ts/src/aontu.ts`,
+`ts/src/cli.ts`, `go/aontu.go`, `go/cmd/aontu/`, the two spec
+runners, new rows in `test/spec/hcanon.tsv` (or a sibling
+`hash.tsv`). This completes the review's Phase B item ("canon-hash
+pinning") and is independently useful with no registry.
+
+**Phase 2 — module identity and local resolution (M).** Module-path
+routing in the resolver chain, `mod.aon`/`mod-lock.aon` reading,
+vendor-dir and cache lookup, integrity verification, the two new
+error shapes. Spec rows stay hermetic by stubbing module paths
+through the memory resolver (as `file.tsv` uses `__FIXTURES__`).
+Touches: `ts/src/lang.ts` (resolver chain), new `ts/src/mod.ts`,
+`go/lang.go`, new `go/mod.go`, new `test/spec/mod.tsv`,
+`docs/reference-language.md`. Existing `file.tsv` rows are the
+guard that non-module paths behave byte-identically.
+
+**Phase 3 — fetch and publish tooling (L).** `aontu mod
+get/tidy/vendor/publish` over OCI; MVS resolution; lockfile
+writing in canonical form. Network code lives outside evaluation
+and outside the shared spec — per-implementation integration tests
+against a local OCI registry. Touches: `ts/src/cli.ts`, a new
+`ts/src/mod-tool.ts`, `go/cmd/aontu/`, `docs/reference-api.md`.
+
+**Phase 4 — registry hooks and agent integration (M).**
+Publish-time canon-hash annotations; the breaking gate invoking
+[G3](g3-subsumption-evolution.md); hash-keyed cache/query
+integration with [G7](g7-machine-access.md)'s surface. Sized M
+here because the semantics are owned elsewhere; this phase is
+wiring at the publish boundary.
+
+## Open questions
+
+- **Standalone-evaluation hashing of fragment modules.** A module
+  written as a reusable fragment may lean on consumer context
+  (`$`-rooted refs, `$name` variables); the hash form keeps them
+  in unresolved textual form — correct, but is it
+  *useful* for heavily parameterised modules, or should `mod.aon`
+  declare required bindings so the hash covers a closed interface?
+  Decided by: how common context-dependent modules prove to be,
+  and G5's ruling on `$` bindings as evaluation inputs.
+- **Text versus binary hash encoding.** Hashing UTF-8 canon text is
+  simple and debuggable; Dhall hashes a CBOR encoding to dodge
+  text-escaping ambiguity. The parity suite already forces
+  byte-identical canon text, which argues text is safe — but
+  `JSON.stringify` escaping edge cases (lone surrogates,
+  non-characters) need pinning before the scheme freezes. Decided
+  by: fuzzing the escape space across both implementations in
+  Phase 0.
+- **New spec modes versus native-only tests.** Adding
+  `hcanon`/`hash` modes touches both runners and
+  `docs/shared-spec.md`; testing the rendering only natively would
+  leave the hash outside the cross-language contract — wrong for a
+  feature whose whole point is cross-implementation identity.
+  Decided by: whether the suite format is frozen or versioned.
+- **Scheme-bump policy when canon evolves.** G1 will extend canon
+  with constraint-atom syntax; later features will too. Options: a
+  scheme id bump per canon-affecting release, or freezing hash
+  scope to a language-version tag recorded in the lockfile.
+  Decided by: how often canon actually changes once G1 lands, and
+  registry migration cost per bump.
+- **Lockfile granularity in monorepos.** One `mod.aon` per
+  repository versus per directory-module (CUE allows nesting);
+  affects vendoring layout and the resolver's search rules.
+  Decided by: the first real multi-module consumer's shape.
+- **Memory-resolver shadowing of module paths.** Letting the memory
+  resolver pre-empt module resolution is what makes spec rows and
+  sandboxes hermetic — but it also lets an embedding host silently
+  substitute a pinned module. Whether shadowing requires an
+  explicit opt-in is a [G5](g5-trust-contract.md) capability-surface
+  question this design defers.

--- a/docs/capability-review/g7-machine-access.md
+++ b/docs/capability-review/g7-machine-access.md
@@ -1,0 +1,607 @@
+# G7: A machine-facing access surface
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G7 — query, provenance, patch, and delivery: the surfaces through
+which agents consume an Aontu definition as ground truth — with
+alternatives, an explicit boundary, risks, and an implementation
+plan.*
+
+## Problem
+
+Agents do not consume ground truth by evaluating whole files into one
+JSON blob. They hold lightweight identifiers, retrieve task-sized
+slices on demand, ask why a value holds, and patch by path. Aontu
+today supports none of these: the CLI (ts/src/cli.ts) evaluates one
+file to JSON or canonical form, full stop, and the evaluated output
+is a terminal artifact rather than a knowledge substrate.
+
+First failure: query. A modest system definition —
+
+```aon
+# system.aon
+services: &: {
+  image:    string
+  replicas: integer
+  owner:    string
+}
+services: auth:    { image: "auth:v2.3", replicas: 3, owner: "identity" }
+services: billing: { image: "billing:v1.9", replicas: 2, owner: "payments" }
+services: gateway: { image: "gw:v4.0", replicas: 4, owner: "platform" }
+```
+
+An agent repairing the auth deployment needs `$.services.auth` and
+nothing else. It wants to write `aontu get $.services.auth --canon`
+— and cannot. The only option is `aontu system.aon`, whose output
+grows linearly with the whole system: every billing and gateway
+token is context-window noise for the auth task. The survey's
+context-engineering doctrine is unambiguous — the smallest set of
+high-signal tokens, retrieved just-in-time by identifier — and there
+is no way to follow it. Nor is there a cheaper first look: no
+keys-only listing ("what services exist?"), no types-only view
+("what shape must a service have?"), no depth limit.
+
+Second failure: provenance. Layered definitions are Aontu's home
+ground:
+
+```aon
+# org.aon
+services: &: { replicas: *1 | integer }
+
+# service.aon
+@"org.aon"
+services: auth: { replicas: 3 }
+```
+
+The evaluated result has `replicas: 3`. A reviewer — human or
+agent — asks: why 3? Which file set the default, which overrode
+it? The question has no answer today. Sites (`{row, col, url}`)
+are tracked only for *errors*: a conflict gets a two-site
+`NilVal`, but on every successful unification the winning value
+keeps its own site and the peer's is dropped — `update()` in
+ts/src/unify.ts is literally a one-line function with a
+`TODO: update x with y.site` comment. So
+`aontu why $.services.auth.replicas` cannot be built without
+touching the engine, and LSP hover (ts/src/lsp.ts `computeHover`)
+can show the resolved value but never its origin story. CUE's
+community documents exactly this as the incumbent's worst pain;
+building positive provenance into a young engine is far cheaper
+than retrofitting it later.
+
+Third failure: patch. The agent decides auth needs five replicas.
+The lattice-honest move — append a new conjunct — fails correctly
+but unhelpfully:
+
+```aon
+@"service.aon"
+services: auth: { replicas: 5 }   # conflict: 5 vs 3 — correct, but
+                                  # now what?
+```
+
+`3` is a pinned literal, so the overlay conflicts; the right repair
+is to edit the pinning site. But there is no evaluated-path →
+file/line map to find that site, canon destroys comments and source
+order by construction (docs/reference-language.md), and no
+format-preserving rewriter exists — the parser stack discards
+comments at parse time. The agent's remaining option is regex
+surgery on text it does not understand.
+
+Finally, delivery. There is no MCP server, so none of the above is
+reachable from an agent harness; the REPL is human-only (no
+structured per-command protocol); and no machine-consumable grammar is
+published, so constrained decoding — now production infrastructure
+— cannot guarantee syntactically valid Aontu emission. Aontu is a
+low-resource language for every model, and the llms.txt post-mortem
+shows a file sitting in a repo is advisory unless tools actively
+pull it into agent loops.
+
+## Current state
+
+What exists and is reusable:
+
+- **Path lookup.** `ctx.find(path: string[])` (ts/src/ctx.ts) walks
+  the unified root through `MapVal`/`ListVal` pegs — the seed of
+  `get`. TS only: go/ctx.go has no equivalent; it is also not
+  exposed on any CLI.
+- **Per-node canonical form.** `Val.canon` renders any node, not
+  just the root, as deterministic reparseable text
+  (docs/reference-language.md). A path-scoped slice is therefore
+  "find, then canon" — the rendering half of query is free.
+- **The explain trace.** `AontuOptions.explain`
+  (docs/reference-api.md) threads an opt-in trace through
+  `ctx.explain`; `explainOpen`/`ec`/`explainClose` and
+  `formatExplain` (ts/src/utility.ts) record every `unite` call in
+  ts/src/unify.ts as nested positional arrays (pass count, path,
+  operand ids and canon, result). Honest assessment: this is a
+  *derivation trace*, not provenance. It proves the hook points
+  exist and costs nothing when off (`ctx.explain &&` guards), but
+  it records no file/line sites, has no per-path index, grows with
+  every unite call across up to `maxcc = 9` passes, its positional
+  format is not a contract, and it is TS-only — the Go port has no
+  explain machinery at all.
+- **Sites, lazily.** `Site` (ts/src/site.ts) carries
+  `{row, col, url}`; `Val` allocates its site on first access via a
+  getter (ts/src/val/Val.ts) — an explicit optimisation because
+  most sites are never read. Provenance must not silently defeat it.
+- **The LSP split.** The library/handler/server layering
+  (ts/src/lsp.ts, ts/src/lsp-server.ts, go/lsp, docs/lsp.md) is the
+  template for any resident surface: pure analysis functions, a
+  transport-free protocol handler, a thin stdio loop. Hover already
+  reads the unified tree — and re-parses and re-unifies the whole
+  document per request, which bounds what per-request provenance
+  may cost.
+- **A REPL.** ts/src/cli.ts ships one (CUE has none): line-oriented,
+  one `Aontu` instance per session, each line evaluated
+  independently, `:canon`/`:json` mode switches. A head start for
+  an inspection tool.
+- **Marks as projection machinery.** `hide`/`type` marks already
+  exclude nodes from generation (ts/src/val/BagVal.ts) — evidence
+  the engine can carry view-relevant metadata through unification.
+
+What structurally blocks the capability:
+
+- **Positive provenance is not recorded.** Success drops the peer's
+  site (`update()` in ts/src/unify.ts); only `NilVal` keeps
+  `primary`/`secondary`. Nothing remembers which ordered conjuncts
+  produced a resolved value.
+- **Single-use trees.** The documented contract in ts/src/val/Val.ts
+  (the MapVal/ListVal TOP fast-path refines in place) makes parsed
+  and unified trees single-use. A resident server cannot cache live
+  `Val`s and serve queries from them; it must cache *rendered*
+  artifacts.
+- **Unification is global.** A `$.path` reference or spread anywhere
+  can contribute to any node, so there is no sound partial
+  evaluation of a fragment. `get` must evaluate the whole document;
+  the honest win is output slicing plus caching, not partial
+  evaluation.
+- **No source map, no CST.** Comments and layout are discarded at
+  parse; no evaluated-path → contributing-spans map exists; nothing
+  can rewrite a file in place while preserving what the author
+  wrote.
+- **No grammar artifact.** The surface is defined operationally by
+  the jsonic plugin stack (ts/src/lang.ts and the `@tabnas/*`
+  ports); there is no declarative grammar file to publish.
+- **Resolver posture.** Any resident server inherits the
+  memory → filesystem → package resolver chain (`makeModelResolver`,
+  ts/src/lang.ts, ~line 750) and its documented stance that opening
+  an untrusted source is running it — confinement is
+  [G5](g5-trust-contract.md)'s contract and a precondition here.
+
+## Prior art
+
+**Context engineering and progressive disclosure.** Anthropic's
+doctrine (smallest high-signal token set, identifiers over
+documents), the Skills three-tier loading model (~100-token stub,
+body on demand), and Context7's resolve-then-query pattern all
+converge: agents prefer querying an authority for a scoped fragment
+over holding a corpus. Cost: someone must run the authority.
+
+**GraphQL introspection.** The proven model of "schema queryable
+by the consumer" — the critique pass notes the survey's query
+recommendations partially reinvent it. Its lesson is the habit it
+created, not its machinery; the machinery costs a full query
+language with resolvers, far beyond path selection.
+
+**SysML v2 API & Services and Structurizr's MCP server.** MBSE
+learned that a language without a standard machine API cannot
+anchor a toolchain; Structurizr — the nearest commercial neighbour
+— already ships an MCP server so agents can inspect architecture
+models. Neither has constraint checking worth the name; Aontu's
+differentiator is that its slices are *unified, validated* values.
+Cost of the SysML route: an enormous REST/CRUD spec surface.
+
+**nix why-depends and OPA's explain ladder.** The exemplars for
+"why": a shortest path through the graph with the exact fragment at
+each hop; filtered trace levels (full for machines, notes for
+humans, fails as default). CUE's discussion #3723 (30+ stacked
+sites, 3,000-line config, debugging by deletion) is the
+counter-example that motivates doing this early; CUE is on its
+second evaluator partly to retrofit error tracking.
+
+**Terraform plan.** Diff-as-explanation works — until noise
+destroys trust. Deterministic canon already gives Aontu
+noise-free diffs; the design must protect that, not add it.
+
+**Grammar-constrained decoding.** Lark CFGs are accepted by
+provider custom-tool APIs; llguidance/XGrammar make enforcement
+cheap; GBNF covers local inference. A published grammar makes
+syntactic validity guaranteed and leaves semantics to the unifier —
+a clean two-layer story competitors lack. Few-shot studies say
+low-resource DSLs are learnable given a grammar card plus curated
+examples. Cost: the artifact must be parity-tested against both
+parsers forever, or it rots into a liar.
+
+**AGENTS.md versus llms.txt.** The delivery-channel verdict:
+harnesses actively read AGENTS.md (adopted across agent tooling);
+llms.txt failed because nothing pulled it. Ship the stanza and the
+tools that make it true, not a passive file.
+
+## Design space
+
+**A. Library-only.** Document `ctx.find` and `explain`, let the
+ecosystem build servers. Near-zero cost; but Go has neither
+surface, the explain format is not a contract, and the llms.txt
+lesson says capabilities nothing pulls into loops go unused.
+Rejected.
+
+**B. CLI slicing only.** Ship `get` with projections and a REPL
+JSON mode; defer provenance, patch, and MCP. Cheap and real; but
+"why" is the incumbent's most documented pain and gets strictly
+more expensive to add as the engine matures, and without MCP the
+surface never reaches the harnesses that need it. Kept as Phase 1
+of the plan, not the end state.
+
+**C. A query language.** Embed filters and predicates
+(JSONPath-style wildcards, jq-like expressions) in CLI and MCP.
+Powerful, but it is a second language to specify, teach, and keep in
+TS/Go parity — surface-area creep of exactly the kind
+[index.md](index.md) warns about, and the survey's agent-usage
+evidence is that path + fixed projections cover the consumption
+pattern. Rejected.
+
+**D. Always-on provenance.** Extend the engine so every `Val`
+carries its ordered conjunct history with sites, unconditionally.
+Best possible UX (hover-provenance with no second evaluation); but
+it taxes every evaluation for a rarely-asked question, collides
+with the lazy-site optimisation the hot path relies on, and grows
+memory with conjuncts × passes. Rejected for v1 — but its *data
+shape* should be designed now so always-on can land later behind a
+flag when incremental evaluation makes it cheap.
+
+**E. Staged surface on today's engine.** Path-scoped `get` with
+lattice-sound projections; provenance-on-demand (`why`
+re-evaluates with an opt-in recorder — the explain pattern with
+sites and a per-path index); patch as overlay-append first,
+format-preserving rewriting later; delivery via a thin MCP server
+over the TS library, a published grammar, a skill, and an
+AGENTS.md generator; the REPL grown into an inspection tool. Costs
+honesty: `get` is not faster than full evaluation, `why` runs the
+evaluator twice, stage-1 patch cannot change pinned values in
+place.
+
+**Recommendation: E, with D's record shape specified up front.**
+It is the only option honest about the engine (global unification,
+single-use trees, lazy sites) that still ships every consumption
+surface the survey identifies. It matches the review's sequencing
+note that G7 depends on nothing and is the cheapest adoption wedge
+— it wraps today's evaluator, and every later capability
+([G2](g2-validation-verb.md) vet,
+[G3](g3-subsumption-evolution.md) breaking) becomes another tool
+on the same server.
+
+## Proposed design
+
+### Query: `aontu get`
+
+```
+aontu get <path> [file] [options]
+
+  -c, --canon      canonical-form fragment (default: JSON)
+  --keys           keys at the node, one level
+  --types          shape view: concrete leaves generalised to kinds
+  --depth <n>      subtree to depth n; elided nodes render as top
+```
+
+Semantics: evaluate the whole document (stated plainly: unification
+is global, so there is no partial evaluation to sell), select the
+node with the `ctx.find` walk promoted to parse `$.a.b` path syntax
+(escaped keys, numeric list indices), and render:
+
+- default: generated JSON of the fragment — which inherits `gen`
+  semantics, including the known `DisjunctVal.gen` fold defect
+  (ts/src/val/DisjunctVal.ts, ~line 263) until it is fixed;
+- `--canon`: the fragment's canonical form — constraint-preserving,
+  deterministic, and for the root path byte-identical to today's
+  `--canon` output (pinned by a spec row).
+
+A missing path is an error reported via the
+[G2](g2-validation-verb.md) contract (a `no_path`-family code with a
+nearest-key suggestion); `get` invents no error format.
+
+### Projections are lattice abstractions
+
+The three projections are defined so that each emits a *valid Aontu
+document that subsumes the truth* — generalisation, never
+distortion:
+
+- `--types` replaces each concrete scalar with its kind:
+  `{"image":"auth:v2.3","replicas":3}` becomes
+  `{"image":string,"replicas":integer}`. When
+  [G1](g1-constraint-algebra.md)'s bounds land, this view renders
+  them via G1's canonical bound syntax — consumed here, defined
+  there.
+- `--depth n` keeps structure to depth n and renders every elided
+  subtree as `top` — "no further information at this tier".
+- `--keys` is `--depth 1 --types` degenerated to a listing.
+
+This gives progressive disclosure the Skills model wants — a
+stub-sized first tier, expansion by path on demand — with a property
+no markdown spec has: every tier is itself checkable, and "view
+subsumes truth" is mechanically verifiable once
+[G3](g3-subsumption-evolution.md)'s `subsume` exists. Projections
+are not canonical form and are never fed to
+[G6](g6-distribution.md)'s hash; the flags are distinct from
+`--canon` to keep that unambiguous.
+
+Caching: single-use trees mean a resident server must never hold
+live `Val`s. The unit of caching is the *rendered* slice, keyed by
+(content hash per [G6](g6-distribution.md), path, projection) —
+which also makes slices prompt-cache-stable, the economics G6
+identifies.
+
+### Provenance: `aontu why`
+
+```
+$ aontu why $.services.auth.replicas service.aon
+$.services.auth.replicas = 3
+  1. *1 | integer   org.aon:2:26    (spread &: at org.aon:2:11)
+  2. 3              service.aon:3:29
+resolved: 3 — literal overrides preference *1
+```
+
+Mechanism: `why` re-runs the evaluator with a provenance recorder
+on the context — the explain pattern, but recording a *contract*,
+not a debug trace. The recorder is keyed by `ctx._pathidx` (the
+path trie in ts/src/ctx.ts already assigns stable per-path
+indices) and captures an ordered entry at each point where
+information currently vanishes: the `update()` site-drop in
+ts/src/unify.ts, the `ConjunctVal` fold, spread application in
+`MapVal`/`ListVal`, `PrefVal` resolution (chosen versus
+overridden), and `RefVal` resolution (ref site plus target path).
+Entries are deduplicated by (pathidx, contributing val id) — ids
+are unique per run (ts/src/val/Val.ts) — so fixpoint revisits
+across up to `maxcc = 9` passes do not multiply the record.
+
+The record shape (the part designed now for a later always-on
+mode):
+
+```json
+{ "path": "$.services.auth.replicas", "value": "3",
+  "conjuncts": [
+    { "canon": "*1|integer", "role": "spread",
+      "site": { "file": "org.aon", "row": 2, "col": 26 } },
+    { "canon": "3", "role": "literal",
+      "site": { "file": "service.aon", "row": 3, "col": 29 } } ] }
+```
+
+`--format json` emits it; sites reuse the G2 site object shape.
+Costs, honestly: `why` is two evaluations (determinism, per
+[G5](g5-trust-contract.md), guarantees the second derives the same
+result); memory is proportional to conjunct events on the queried
+run; the lazy-site getter is untouched on the normal path, and
+instrumented runs pay site materialisation knowingly. LSP
+hover-provenance reuses the recorder: hover already re-unifies the
+whole document per request (ts/src/lsp.ts), so recording during
+that existing re-evaluation is a config-gated increment, not a new
+cost class. `why` is the positive twin of G2's error report:
+errors explain what failed to unify; `why` explains what did.
+
+### Patch: `aontu set`, in stages
+
+**Stage 1 — overlay append (no rewriter needed).**
+
+```
+aontu set $.services.auth.owner=\"identity-2\" \
+  --entry system.aon --overlay changes.aon
+```
+
+Appends a path-flattened conjunct
+(`services: auth: owner: "identity-2"`) to the overlay file
+(creating it if absent), then re-evaluates entry + overlay and
+reports a [G2](g2-validation-verb.md)-shaped verdict. This is
+semantically clean: an overlay entry is just another conjunct, and
+unification is order-independent — no parsing of the target file,
+no comment or layout damage, nothing to preserve. It refines open
+values and fills unpinned fields. What it *cannot* do is change a
+pinned value: the lattice correctly rejects `5` against `3`, and
+the verdict says so with the pinning site — which `why` locates.
+The loop "set → conflict → why → edit the pinning site" is
+coherent even before stage 2, with the last step manual.
+
+**Stage 2 — format-preserving in-place edit (deferred, L).**
+Requires two missing assets: an evaluated-path →
+contributing-source-spans map (a by-product of the provenance
+recorder) and a comment-and-layout-preserving CST for the parser
+stack, which today discards comments. Only then can
+`aontu set --in-place` rewrite the pinning literal where the
+author wrote it. Sibling documents deferring "applying a fix" to
+G7's format-preserving patch surface ([G2](g2-validation-verb.md),
+[G3](g3-subsumption-evolution.md)) are deferring to this stage;
+until it lands, overlay-append is the only patch verb, and the
+docs must say so.
+
+### Delivery: the MCP server
+
+A thin server over the TypeScript library, following the LSP's
+three-layer template (docs/lsp.md): a transport-free tool library
+(ts/src/mcp.ts), a stdio server (ts/src/mcp-server.ts), published
+as a bin (`aontu-mcp`). Tools, all returning the same JSON
+contracts as the CLI:
+
+| Tool    | Backed by                                            |
+|---------|------------------------------------------------------|
+| `vet`   | [G2](g2-validation-verb.md)'s verb and report        |
+| `get`   | the query surface above (path + projection)          |
+| `why`   | the provenance recorder                              |
+| `diff`  | path-addressed diff of two evaluations' canon        |
+| `canon` | normalise a source text to canonical form            |
+
+`diff` is dyff-style — deterministic canon on both sides means no
+phantom noise — and reports *what changed at which paths*; whether
+a change is breaking is [G3](g3-subsumption-evolution.md)'s
+question, exposed later as G3's tool on this same server.
+Resources implement progressive disclosure: a document summary
+(root keys + G6 hash) with resource links to path-scoped slices.
+The server runs with a confined resolver (memory/filesystem
+allowlist) per [G5](g5-trust-contract.md); the package resolver
+leg is never enabled under a server. The Go port ships no separate
+MCP server: its role is gateway/sidecar embedding of the same
+library calls (`get`/`why` land in the Go API for parity), and
+any Go MCP wrapper is left to hosts.
+
+### Grammar, skill, AGENTS.md stanza
+
+- **Published grammar**: `grammar/aontu.lark` and
+  `grammar/aontu.gbnf`, covering the documented emission surface
+  (excluding `@"…"` includes — constrained decoding should not
+  emit source-loading directives). Parity-tested from day one:
+  every canonical-form output in the shared spec suite must parse
+  under the published grammar, and grammar-sampled strings must be
+  accepted by both real parsers. Conservative by construction: it
+  may under-approximate the surface, never over-approximate it.
+- **Official skill**: a ~100-token trigger stub, a one-page grammar
+  card, curated examples (JSON-superset first: agents may write
+  plain JSON and add operators incrementally), and the G2
+  error-code index for repair loops.
+- **`aontu agentsmd`**: generates or updates an AGENTS.md stanza
+  from the definition itself — where the truth lives, how to
+  `vet`, `get`, and `why` it — so the prose entrypoint cannot
+  drift from the formal source.
+
+### REPL as inspection tool
+
+The existing REPL (ts/src/cli.ts) gains `:load <file>` (evaluate
+once and hold the *rendered* document — canon text plus JSON,
+respecting single-use trees), `:get`, `:keys`, `:why`, and a
+`--json` session mode in which every command answers in one JSON
+line, making the REPL drivable by a harness. Human-readable output
+stays the default.
+
+## Boundary: what we will not do
+
+- **No query language.** Path plus fixed projections only; filters
+  and predicates are a second language and surface-area creep
+  toward CUE, a trap named in [index.md](index.md).
+- **No partial-evaluation claims.** `get` evaluates the whole
+  document; incremental evaluation is a later engine project shared
+  with the LSP, and marketing slicing as speed would be false.
+- **No always-on provenance in v1.** On-demand only; the record
+  shape is the forward-compatible part, the collection policy is
+  not.
+- **No format-preserving rewriting in stage 1.** Overlay-append
+  ships first precisely because it needs no rewriter; in-place
+  editing waits for the CST and the source map.
+- **No error-format invention.** Every failure across get/why/set
+  and the MCP tools is reported via the
+  [G2](g2-validation-verb.md) contract.
+- **No fetching or arbitrary writes in the server.** The MCP server
+  evaluates what it is given under a confined resolver
+  ([G5](g5-trust-contract.md)); distribution and pinning are
+  [G6](g6-distribution.md)'s; the only write tool is the overlay
+  append.
+- **No subsumption semantics in `diff`.** Path-level change
+  reporting only; breaking-ness is
+  [G3](g3-subsumption-evolution.md)'s verb.
+- **No LLM components in the surface.** Deterministic, mechanical
+  answers are the entire pitch against the JSON-Schema-plus-prose
+  null hypothesis; an LLM summariser tool would surrender it.
+- **No view/diagram generation in v1.** Model-once-render-many is
+  real (Structurizr) but is an exporter product; the projection
+  ladder is G7's contribution to it.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Provenance instrumentation slows the uninstrumented hot path | Medium | High | Explain-style `ctx` guards (already proven zero-cost when off); benchmark gate in CI before/after Phase 3; lazy-site getter untouched on the normal path |
+| TS/Go divergence: Go has no `find`, no explain, no collect surface | High | High | `get`/`why` land as shared spec rows (query.tsv, provenance.tsv) run by both suites with no skip list; Go port is a dedicated phase, not an afterthought |
+| Resident server misuses single-use trees (stale or corrupted Vals) | Medium | High | Server caches rendered artifacts only, keyed by G6 content hash; a test asserts no `Val` outlives its evaluation |
+| Why-chains explode on large conjunct fan-in (CUE's 30-site pile-up) | Medium | Medium | Dedupe by (pathidx, val id); default chain cap with `--all`; order entries by application, not discovery |
+| Published grammar drifts from the real parsers | Medium | High | CI parity test: all spec-suite canon outputs parse under the grammar; sampled grammar strings accepted by both parsers; grammar versioned with the language |
+| Projections mistaken for canonical form (fed to hashes/pins) | Medium | Medium | Distinct flags; projected output carries no `--canon`; G6 hashes only unify-level canon; docs state it |
+| `get --json` hits the DisjunctVal.gen fold defect | Medium | Medium | Default agent guidance is `--canon`; fix tracked with regression spec rows; JSON output of unresolved disjunctions documented as affected until then |
+| Overlay files accumulate into an unreadable sediment | High | Low | One well-known overlay per entry document; `why` shows overlay sites like any other; consolidation tooling deferred to stage 2 |
+| MCP spec churn breaks the server | Medium | Low | Tool library is transport-free (LSP split); only ts/src/mcp-server.ts tracks protocol versions |
+| Adoption risk: agents read the file instead of calling tools | Medium | High | `aontu agentsmd` writes the stanza that names the tools; skill teaches the get/why/vet loop; slices are cheaper in tokens than the file — measured and stated |
+| Canon round-trip regression via fragment rendering | Low | High | Spec row pins `get $ --canon` == document canon; `parse(canon(v)) == v` stays green in every phase |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows before code; TypeScript (canonical) first, Go follows. Nothing
+may regress in any phase: the 45 existing spec files (~426 rows),
+canon round-trip `parse(canon(v)) == v`, LSP diagnostic parity, and
+the performance of uninstrumented evaluation.
+
+**Phase 1 — `get` and projections, TypeScript (M).**
+Spec: new `test/spec/query.tsv` — columns name, source, path,
+projection, output — including the pins `get $ --canon` ==
+document canon and projection-subsumes-truth examples. Code: new
+ts/src/query.ts (path parsing, projection rendering over the
+`ctx.find` walk); ts/src/ctx.ts (escaped keys, list indices);
+ts/src/cli.ts (`get` verb); docs/reference-api.md. Runner:
+ts/test/spec.test.ts learns the query mode.
+
+**Phase 2 — `get`, Go port (M).**
+Code: new go/query.go; go/ctx.go (find); go/cmd/aontu.
+go/spec_test.go runs query.tsv with no skip list.
+
+**Phase 3 — provenance recorder and `why`, TypeScript (L).**
+Spec: new `test/spec/provenance.tsv` — name, sources (multi-file
+via the memory resolver so file/line assertions are stable), path,
+ordered chain (`canon@file:row:col` entries with roles). Code: new
+ts/src/provenance.ts (recorder, record shape, JSON rendering);
+ts/src/unify.ts (the `update()` site-drop and unite hooks);
+ts/src/val/ConjunctVal.ts, ts/src/val/PrefVal.ts,
+ts/src/val/MapVal.ts, ts/src/val/ListVal.ts, ts/src/val/RefVal.ts
+(record points); ts/src/cli.ts (`why`). Benchmark gate on the
+uninstrumented path.
+
+**Phase 4 — `why`, Go port (L).**
+Code: go/provenance.go (new); go/unify.go, go/conjunct.go,
+go/pref.go, go/mapval.go, go/listval.go, go/ref.go; go/cmd/aontu.
+Byte-identical `--format json` output pinned by provenance.tsv.
+
+**Phase 5 — overlay `set` (M).**
+Spec: new `test/spec/patch.tsv` — source, set expression, overlay
+result, verdict — pinning that overlay-append is semantically
+identical to hand-written conjuncts (order-independence rows).
+Code: new ts/src/patch.ts; ts/src/cli.ts; Go twin go/patch.go
+(S once TS settles). Verdicts via the G2 report.
+
+**Phase 6 — delivery: MCP server, grammar, skill, agentsmd (M).**
+Code: new ts/src/mcp.ts (transport-free tool library) and
+ts/src/mcp-server.ts (stdio), mirroring the LSP split; `agentsmd`
+verb in ts/src/cli.ts; new grammar/aontu.lark and
+grammar/aontu.gbnf with parity tests (ts/test/grammar.test.ts, a
+Go acceptance twin driven by the same sampled corpus); skill
+sources under docs/. The server ships with the memory/filesystem
+resolver only.
+
+**Phase 7 — REPL inspection mode and hover-provenance (S).**
+Code: ts/src/cli.ts (`:load`, `:get`, `:why`, `--json` JSONL
+mode); ts/src/lsp.ts and go/lsp (config-gated provenance in hover
+markdown). LSP diagnostic text is unchanged.
+
+## Open questions
+
+- **Path syntax details.** Escaping for keys containing dots, and
+  list indices (`$.a.0` versus `$.a[0]`); align with reference
+  syntax and [G4](g4-identity-relations.md)'s identity paths before
+  query.tsv freezes the spelling.
+- **Provenance granularity.** Leaf scalars only, or container-level
+  events too (one entry for a spread over `$.services` versus one
+  per child)? Container events are cheaper and often what a
+  reviewer wants; leaf events are what patch stage 2 needs. The
+  recorder likely wants both behind a filter; spec rows decide the
+  default.
+- **One evaluation or two in the server.** A resident server could
+  evaluate with the recorder always on, making `why` free at query
+  time at the cost of memory per document version. Measure on
+  realistic models; the CLI keeps the two-run model regardless.
+- **Fragment canon as a stable contract.** Is the canon of a slice
+  stable across engine versions (making slice and prompt caches
+  durable), or only within a version? Interacts with
+  [G6](g6-distribution.md)'s hash scheme id; needs an explicit
+  statement either way.
+- **Grammar scope versus teaching scope.** Should the emission
+  grammar also exclude rarely-emitted forms (custom marks, `@`
+  directives) to shrink the constrained-decoding surface, with the
+  skill teaching the full language? Small grammars are cheaper to
+  learn; the risk is agents acquiring a dialect.
+- **Overlay conventions.** One well-known overlay per entry
+  document versus per-agent overlays; declared in the entry file
+  (`@"changes.aon"`) or composed by the tool at evaluation time.
+  Composition-by-tool keeps the source honest but hides a conjunct
+  from plain `aontu system.aon`; interacts with
+  [G6](g6-distribution.md) module boundaries.

--- a/docs/capability-review/g8-generation.md
+++ b/docs/capability-review/g8-generation.md
@@ -1,0 +1,522 @@
+# G8: Generation and abstraction, on the total side of the fork
+
+*Status: design proposal, part of the
+[capability review](index.md) (August 2026). This document expands gap
+G8 — producing N similar children from data without copies that drift,
+while keeping the guarantee that Aontu evaluation always terminates.
+It resolves the fork sketched in IDEAS.md: total generator combinators
+(`each`/`pack`/`filter`/`match`), placeholder arguments, and pipe
+sugar are adopted; user-defined functions and recursion are refused.*
+
+## Problem
+
+Producing N similar children from data — one block per service, per
+region, per replica — is the bread-and-butter of systems definition.
+Aontu's spread (`&:`) applies a template to children that already
+exist; nothing in the language can *generate* a child, compute a key
+from data, or select a subset. The result is that humans and agents
+copy-paste, and the copies drift — which defeats ground-truth-ness
+from the inside: a definition whose parts must be kept consistent by
+hand is exactly the markdown failure mode the review's verdict
+describes.
+
+First failing example. A team's ground truth names its services once,
+and wants one deployment block per service:
+
+```aon
+# services.aon — the list is the truth
+names: [web, auth, billing]
+
+# ...but the map must be written by hand, one copy per service
+deploy: {
+  web:     { image: "acme/web:1.4.2",     replicas: 2, port: 8080 }
+  auth:    { image: "acme/auth:1.4.2",    replicas: 2, port: 8080 }
+  billing: { image: "acme/billing:1.4.2", replicas: 2, port: 8080 }
+}
+```
+
+`names` and `deploy` have no mechanical link. Adding `search` to
+`names` changes nothing; an agent asked to "add the search service"
+must edit two places and infer the copy-paste pattern from examples.
+The spread cannot help: `deploy: {&:{replicas:2, port:8080}}` applies
+its template only to keys that exist, and no key exists until someone
+writes it. What the author wants to write — one template, keys drawn
+from the data — is not expressible today.
+
+Second failing example, and this one is *wrong behaviour*, not a
+missing feature. An agent that needs a conditional today reaches for
+the only branching construct the language has, disjunction:
+
+```aon
+# storage.aon — "either local or s3, then pick local"
+store: ({kind: local, path: "/var/data"} | {kind: s3, bucket: b1})
+       & {enabled: true}
+```
+
+Generation of this value is defective: `DisjunctVal.gen` folds the
+disjunct members together instead of distributing the conjunct, so
+`({x:1}|{y:2})&{z:3}` produces the merged chimera `{x:1,y:2,z:3}`
+rather than a choice — the code admits it in a comment
+(ts/src/val/DisjunctVal.ts, ~line 263). A user or agent emulating
+"match" via disjunction can silently receive a map containing *both*
+branches. The language needs a bounded, correct conditional, and the
+defect must be fixed before anything is built near it.
+
+Third, subset selection is inexpressible: "the services with
+`debug: true` get a sidecar" has no spelling. The author enumerates
+the debug services by hand — a second copy of information the
+definition already contains, and a second thing that drifts.
+
+For the agent mission these are one disease. An agent's edits are
+only trustworthy when every fact lives in one place; every manual
+copy is a place where an agent (or a human) can make the definition
+disagree with itself without any conflict being detected.
+
+## Current state
+
+What exists is a solid substrate, and most of it is reusable:
+
+- **Twelve builtins, hard-wired.** The parser's `funcMap`
+  (ts/src/lang.ts, ~line 219) maps `upper`, `lower`, `copy`, `key`,
+  `type`, `hide`, `move`, `path`, `pref`, `close`, `open`, `super` to
+  Val classes. There are no user-defined functions
+  (docs/reference-language.md). Adding a combinator is adding a class
+  and one `funcMap` entry — no grammar change.
+- **Functions already defer.** `FuncBaseVal.unify`
+  (ts/src/val/FuncBaseVal.ts) unifies its arguments each fixpoint
+  pass and calls `resolve()` only when all are done; until then the
+  call survives as itself or inside a `ConjunctVal`. This is
+  proto-residuation: the firing discipline a generator needs already
+  exists in embryo. `OpBaseVal` (ts/src/val/OpBaseVal.ts) does the
+  same for the one operator, `+` (`PlusOpVal`).
+- **The spread machinery.** `MapVal` (ts/src/val/MapVal.ts) holds the
+  template in `spread.cj`, applies it once per child (the `_spr`
+  apply-once marking), clones it per destination with a three-tier
+  `spreadClone`, and snapshots path-dependent ref templates
+  (`snapshotRefSpread`) so `key()`/`path()` resolve at the
+  destination, not the source. This is the most intricate part of the
+  engine, and the most heavily pinned: spread.tsv plus 24
+  spread-*.tsv files — over half of the shared spec suite — are
+  spread variants. Generated children must flow through exactly this
+  machinery.
+- **The strain is visible.** `KeyFuncVal.unify`
+  (ts/src/val/KeyFuncVal.ts) special-cases `ctx.cc < 3` to delay
+  resolution so keys inside spreads and refs resolve at their
+  destination, under a comment: "this delay makes keys in spreads and
+  refs work, but it is a hack - find a better way". Generation will
+  multiply the situations where a value must wait for its
+  surroundings; an ad-hoc pass-count check does not scale to them.
+- **Bounded fixpoint.** The unify loop runs at most `maxcc = 9`
+  passes (ts/src/unify.ts, with `MAXCYCLE = 999` guarding repeated
+  node visits). Generators consume passes; the interaction with the
+  bound is a design obligation, and the budget story is owned by
+  [G5](g5-trust-contract.md).
+- **Trial unification exists.** `ctx._trialMode` (ts/src/ctx.ts) lets
+  `DisjunctVal` try alternatives without recording errors — the
+  mechanism `filter` and `match` need to test unifiability.
+- **Token reservation is already enforced.** test/spec/op-chars.tsv
+  pins `6/2` and `6%2` as plain text and `6-2`/`6*2` as parse errors:
+  the grammar is deliberately holding `-` `*` `/` `%` free, matching
+  IDEAS.md's stated principle — "in general prefer using new
+  functions instead of creating new tokens or syntax!".
+- **IDEAS.md is sketches only.** Placeholder args (`upper(_)`,
+  `_+2`), function ranking, maths-as-functions, `replace()`,
+  namespaced `def()`, `match()`, `each`/`pack`/`filter`, and `|>`
+  piping are all unimplemented, and the recursion the `def()` sketch
+  implies is exactly what this document refuses.
+
+What structurally blocks the capability: (1) no Val can create map
+keys that were not in some source text — `MapVal.unify` only iterates
+its own and its peer's existing keys; (2) `_` is ordinary text to the
+parser, so placeholders do not parse; (3) evaluation staging is
+ad hoc (the `cc < 3` hack) rather than a rule; (4) the Go port
+(go/func.go, go/mapval.go, go/unify.go) mirrors all of the above and
+must move in lockstep.
+
+## Prior art
+
+Every surveyed language that generates structure from data does it in
+one of three ways, and the safety record tracks the choice.
+
+**Comprehension syntax** — CUE (`for x in a if x > 1 { ... }`, with
+interpolated field names), Pkl (`for`/`when` object generators),
+Jsonnet and Starlark (Python-style comprehensions), Terraform
+(`for_each`/`dynamic`). These are total when iteration is over finite
+data, which all of them enforce. The cost is grammar: keywords,
+scoping rules, and — in CUE's documented history — interactions with
+closedness and defaults that contributed to a multi-year evaluator
+rewrite, and a surface area its highest-profile adopter (Dagger)
+cited when dropping it. Terraform contributes the key determinism
+lesson: its index-keyed `count` churns every downstream instance when
+a list reorders, which is why `for_each` over *maps with stable keys*
+replaced it as best practice — generated children must be keyed by
+data, not by position.
+
+**Total combinators** — Dhall (folds, no recursion: "if an expression
+type-checks then evaluating it always succeeds in finite time"),
+Starlark (no recursion, no `while`, deterministic iteration). This is
+the camp whose guarantee — evaluation terminates by construction —
+every credible unattended-evaluation story lands on (Dhall, Starlark,
+CEL, Cedar). CEL adds the backstop: a statically estimated cost
+budget even for total programs, which is G5's territory.
+
+**User-defined functions** — Jsonnet (Turing-complete, by design),
+Nickel, KCL. CUE's deliberate refusal of user functions is the
+counter-position: every file stays analysable without executing
+anything, and evaluation stays hermetic and order-independent. The
+Nickel ecosystem contributes a warning ("union and intersection
+contracts are hard, actually"): the moment function values cross into
+the data plane, otherwise-simple semantics (disjunction, export)
+become subtle. Functions should not become values.
+
+For the placeholder idea specifically, LIFE's residuation (Aït-Kaci &
+Podelski, TOPLAS 1994) is exact prior art: a function whose arguments
+are insufficiently instantiated suspends as a passive constraint and
+fires when unification concretises them. [G1](g1-constraint-algebra.md)
+adopts residuation for bounds with cross-field references; G8 reuses
+the same account rather than inventing a second staging story.
+
+## Design space
+
+**A. Generation lives in tooling, not the language.** The
+[G7](g7-machine-access.md) surface (or any external script) expands a
+data list into children and patches them in; the language stays as it
+is. Rejected: the expanded output is a second artifact, and the copies
+drifting *is the disease* — the moment generated children are
+materialised outside the definition, editing the data no longer
+changes them, and validation (G2) checks the copies rather than the
+rule. Single-source requires the generator to live where the data
+lives.
+
+**B. CUE-style comprehension syntax.** `for`/`if` clauses, computed
+keys via interpolation. Proven semantics, familiar to CUE users.
+Rejected: it adds keywords and string-interpolation tokens to a
+JSON-superset grammar whose smallness the review names as a moat —
+grammar size is acquisition cost for LLMs; it contradicts the
+project's own stated principle (functions over tokens); the spread
+and optional-key grammar already depends on parser internals fragile
+enough that AGENTS.md warns a minor @tabnas bump can silently change
+them; and it walks straight into the trap the index names
+surface-area creep toward CUE.
+
+**C. Total generator combinators as builtin functions.** `each`,
+`pack`, `filter`, `match` join the twelve builtins; placeholder `_`
+gives templates residuated per-child computation; `|>` is optional
+parse-time sugar. Combinators iterate only finite, settled data and
+cannot recurse, so totality is structural; G5's budgets remain a
+backstop, not the guarantee. Costs: argument-position conventions are
+less pretty than syntax; deep nesting of calls is noisier than
+comprehensions; the staging rule must be made principled first.
+
+**D. `def()` — namespaced user functions without recursion.** The
+IDEAS.md sketch, restricted to non-recursive bodies to preserve
+totality. Deferred entirely, not merely postponed to a phase:
+Aontu already has an abstraction mechanism native to its semantics —
+a named, `hide()`-marked template applied by spread, reference, or
+(with this design) a combinator, with `_` supplying the per-use
+argument. `def()` adds call syntax, a namespace scheme, arity errors,
+and a static no-recursion check (including recursion through mutual
+references), for expressive power the combinator-plus-template layer
+already covers. It is the first step onto the complexity clock's
+general-purpose slope, and CUE's refusal of it is one of that
+language's decisions the survey endorses. Revisit criteria are in
+Open questions.
+
+**E. A pre-unification macro stage.** Generation runs as an explicit
+expansion phase before unification, keeping the fixpoint untouched.
+Rejected: the data a generator consumes is itself assembled by
+unification — `names` may be merged from three files, constrained by
+a schema, and completed by a `$var` binding — so generation must be
+able to observe unification results. A separate stage either forbids
+that (crippling) or runs the evaluator twice with subtly different
+semantics (two mental models, two canon stories).
+
+**Recommendation: C.** It honours the language's own design
+principle, adds zero grammar beyond `_` (and optionally `|>`), reuses
+the existing function-deferral and spread machinery, keeps every file
+statically analysable (a combinator call is data — a named node in
+the tree — not code), and keeps the termination guarantee structural.
+A is refused on single-source grounds, B on grammar-size grounds, D
+on complexity-clock grounds, E on staging grounds.
+
+## Proposed design
+
+Four combinators join `funcMap`. Signatures are data-first (the
+subject reads first, as in `close(x)` and `copy(x)` today), and the
+pipe — if adopted — inserts the piped value as *first* argument,
+Elixir-style. This deviates from the IDEAS.md sketch (data-last,
+F#-style); the deviation is deliberate: without pipes, data-first
+calls read as "pack these names into this template", and pipes must
+follow the calls, not the reverse.
+
+**`pack(data, tmpl)` — data to keyed children (map).** For each child
+of `data`, produce one child of the result map. Keys: for a list of
+strings, the strings themselves; for a map, its keys. Each generated
+child is `tmpl` cloned per destination — exactly a spread template
+application, reusing `spreadClone` and the snapshot discipline — so
+`key()` resolves to the generated key and `_` (below) unifies with
+the source child value. Duplicate generated keys are not an error:
+the colliding children unify, exactly as duplicate source keys merge
+today (test/spec/map.tsv), so conflicts surface as located two-site
+errors. The first failing example becomes:
+
+```aon
+# services.aon — single source
+names: [web, auth, billing]
+
+deploy: close(pack($.names, {
+  image: "acme/" + key() + ":1.4.2"
+  replicas: *2 | integer
+  port: *8080 | integer
+}))
+
+# an override composes by ordinary unification
+deploy: billing: replicas: 4
+```
+
+**`each(data, tmpl)` — data to a list.** One element per child of
+`data`, in source order for lists and sorted-key order for maps
+(matching canon's key ordering, `MapVal.canon`, and the Go port's
+JSON marshalling — generated order must be identical across
+implementations and runs). `tmpl` unifies with each element; omitted,
+`each(m)` converts a map's children to a list.
+
+**`filter(data, cond)` — subset by unifiability.** Children of
+`data` that unify with `cond` are kept (keys preserved for maps,
+order preserved for lists); children that fail are dropped, not
+errors — the test runs under trial mode (`ctx._trialMode`,
+ts/src/ctx.ts), the same mechanism disjunction uses. `cond` is any
+Aontu value, so [G1](g1-constraint-algebra.md) atoms compose:
+`filter($.deploy, {replicas: min(3)})` once G1 lands.
+
+```aon
+# sidecars for exactly the debug services — no hand-kept list
+debugged: filter($.services, {debug: true})
+sidecars: pack($.debugged, { image: "acme/debug:1.0" })
+```
+
+(`pack` over a map keys the generated children by the source map's
+keys, so the sidecar map mirrors the debugged service names
+directly.)
+
+**`match(v, p1, r1, p2, r2, ..., d?)` — bounded conditional.**
+Alternating pattern/result arguments, optional trailing default. The
+first pattern (in argument order) that `v` successfully unifies with
+— trial mode again — selects its result, which is `v & p_i & r_i`.
+No pattern matching and no default is a located error whose report
+lists the patterns tried (the admissible-alternatives shape,
+reported via the [G2](g2-validation-verb.md) error contract). The
+bounds that keep `match` from becoming a general conditional: the
+scrutinee is matched by *unifiability only* — there are no boolean
+guards, no comparisons beyond what G1 atoms already are, no
+fallthrough (first match wins, in a spec-pinned order), and the whole
+form is total. `match` is the correct spelling of what the second
+failing example reached for; the `DisjunctVal.gen` distribution
+defect gets fixed independently (it is a bug, not a feature gap), but
+`match` removes the incentive to lean on it.
+
+**Placeholder `_`.** `_` parses to a `PlaceVal`
+(ts/src/val/PlaceVal.ts, new). A function or operator with a
+placeholder argument residuates on its *unification peer*: the peer
+fills the hole, and the call's result is the unification result —
+`upper(_) & foo → "FOO"`, `x:&:{m: _+2} x:a:m:1 → a.m:3`, exactly the
+IDEAS.md sketch. Inside `pack`/`each`/`filter` templates, `_` binds
+the current source child. The semantics are residuation as specified
+by [G1](g1-constraint-algebra.md) (which owns the mechanism for
+bounds); G8 adds no second scheduling story. Two placeheld functions
+meeting (`upper(_) & lower(_)`) is a located error; IDEAS.md's
+`rank()` resolution is refused (Boundary). Note one compatibility
+cost: today `_` is plain text (`a:_` is the string `"_"`), so
+reserving it is a breaking change that must be flagged and
+spec-pinned.
+
+**String construction stays function-based.** `+` concatenation
+already composes with functions and references
+(docs/reference-language.md: `upper(a)+b → "Ab"`), and combined with
+`key()` inside generated children it covers computed names, as in the
+`image` line above. Interpolation syntax (`"acme/\(name)"`) is
+refused: it adds lexer states and canon escaping rules to buy a
+second spelling of something the language has — and `+` chains are
+the easier form for constrained generation of Aontu by models.
+
+**The staging rule (replacing the delay hack).** One rule, spec-
+pinned, governs when generation happens: *a generator residuates
+until its data argument is settled (DONE), then fires exactly once,
+and its output replaces it.* "Fires once" reuses the spread's
+apply-once discipline (`_spr` marking in ts/src/val/MapVal.ts).
+Termination is structural: firing strictly decreases the number of
+unfired generator instances; a template may textually contain further
+generator calls, but clones are one per settled data child and
+nesting depth is fixed by the source text, so total firings are
+bounded by a product of finite, already-settled data sizes — no
+recursion can arise. The same settled-argument rule, stated once in
+ts/src/unify.ts / FuncBaseVal, replaces `KeyFuncVal`'s `cc < 3`
+check; that refactor lands *before* any combinator, as a
+zero-behaviour-change phase gated on the full existing suite.
+Generators consume fixpoint passes; per G5, exhausting the pass
+budget with generators still unfired is a distinct semantic error
+("budget exhausted", G5's contract), never silent truncation. The
+budget itself — whether `maxcc = 9` scales with generator firings —
+is G5's decision.
+
+**Composition with the template machinery.** Once fired, generated
+children are ordinary children: a destination map's `&:` spread
+applies to them (and to children generated later by a sibling
+conjunct — the apply-once marking already handles late-arriving
+keys); `close()` counts them as allowed keys, so `close(pack(...))`
+seals the generated shape; `key()` and relative references resolve at
+the generated paths via the existing snapshot machinery. Each of
+these interactions gets its own spec file, in the style of the
+spread-*.tsv corpus, because 25 shared spec files exist precisely
+because this machinery is where behaviour hides.
+
+**Canonical form.** An unfired generator canons as its call —
+`pack($.names,{"image":...})` — which reparses to the same value, so
+`parse(canon(v)) == v` holds for incomplete models. A fired generator
+canons as its output structure, exactly as `lower(HELLO)` already
+canons as `"hello"` once resolved (test/spec/spread.tsv,
+template-func-canon). `_` canons as `_`. `|>`, if adopted, never
+appears in canon: it is parse-time sugar, desugared before the tree
+exists, so canon and the Go parser are untouched by it.
+
+**API/CLI surface.** None new. The combinators are language-level;
+evaluation, `--canon`, and the G2/G7 verbs see generated children as
+ordinary values. The LSP inherits hover/diagnostics for the new Vals
+through the existing document pipeline (ts/src/lsp.ts).
+
+## Boundary: what we will not do
+
+- **No recursion, anywhere** — the termination guarantee is the
+  product; this is the review's first trap to refuse
+  (Turing-completeness).
+- **No `def()` user functions in this design** — named hidden
+  templates plus `_` cover the demonstrated need at a fraction of the
+  analysability cost; deferred entirely, with revisit criteria below.
+- **No comprehension keywords (`for`/`if`/`in`)** — grammar size is
+  LLM acquisition cost and parser risk; the index's
+  surface-creep-toward-CUE trap.
+- **No string interpolation syntax** — `+` and functions already
+  construct strings; one spelling per meaning.
+- **No computed-key syntax** — keys computed from data are `pack`'s
+  job; a key-position expression grammar is a large change for no
+  added power.
+- **No boolean guards or comparisons in `match`** — matching is by
+  unifiability only, or `match` becomes a general conditional that
+  harms analysability.
+- **No `rank()` for competing placeheld functions** — an ordering
+  channel between functions is a second preference system; the
+  conflict stays an error until real models demand otherwise.
+- **No new operator tokens** — `-` `*` `/` `%` stay reserved
+  (test/spec/op-chars.tsv); maths beyond `+` arrives, if ever, as
+  functions, and is outside G8.
+- **No lazy-evaluation redesign** — generation works inside the
+  existing strict fixpoint; changing the evaluation strategy is a
+  different, larger project.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Generator/spread interaction regresses the spread corpus (25 spec files) | Medium | High | Land the staging refactor (Phase 0) with zero behaviour change first; add gen-x-spread/close/key spec files before code; property-test commutativity and idempotence over generator-bearing values |
+| Fixpoint budget (`maxcc = 9`) exhausted by nested generators, surfacing as wrong "cannot resolve" errors | Medium | High | Settled-argument rule makes firing eager; budget exhaustion is a distinct G5 error, never silence; spec rows pin nesting depths 2-3 |
+| TS/Go divergence in generated key order, trial-mode behaviour, or clone-graph artifacts | Medium | High | Order pinned to sorted keys (already canon's and Go marshalling's order); every behaviour lands as shared TSV rows first; AGENTS.md parity discipline (no Go skip list) unchanged |
+| Canon round-trip breaks for unfired generators or `_` | Low | High | Canon rows in the same TSV files as gen rows from Phase 1; `parse(canon(v)) == v` asserted for unfired forms explicitly |
+| Reserving `_` breaks existing documents using it as text | Low | Medium | Breaking-change flag in CHANGELOG; a spec row pins the new parse; migration is mechanical (quote `"_"`) |
+| `filter`/`match` inherit the DisjunctVal.gen distribution defect through trial unification | Medium | Medium | Fix or fence the defect (ts/src/val/DisjunctVal.ts) before Phase 2; add spec rows for match-over-disjunct scrutinees |
+| Performance: pack/each clone templates per child on large data (the known dominant cost of spread application) | Medium | Medium | Reuse tiered `spreadClone` and apply-once `_spr` discipline; perf-annotate spec fixtures; G5 budgets cap runaway cost |
+| Placeholder parsing destabilises the fragile @tabnas grammar (AGENTS.md warning) | Medium | Medium | `_` lands in its own phase with exact-pinned parser versions; op-chars.tsv-style rows pin every adjacent token interaction |
+| Adoption: combinator calls read worse than comprehensions to CUE-trained users | Medium | Low | Documentation leads with the drift argument; `|>` sugar recovers left-to-right reading; grammar smallness is the trade being bought |
+| `match` grows into a general conditional through user pressure | Medium | Medium | Boundary is explicit; unifiability-only is spec-pinned; feature requests route to G1 atoms, not guards |
+
+## Implementation plan
+
+Spec-first throughout: every behaviour lands as test/spec/*.tsv rows
+agreed before code; TypeScript (canonical) implements; the Go port
+follows to green on the identical rows. At every phase, all existing
+spec rows and the canon round-trip (`parse(canon(v)) == v`) must not
+regress; the spread corpus is the regression canary.
+
+**Phase 0 — staging rule (S).** Replace the `KeyFuncVal` `cc < 3`
+delay with the settled-argument residuation rule in the shared
+function base; zero behaviour change, gated on the full 44-file
+suite. Files: ts/src/val/FuncBaseVal.ts, ts/src/val/KeyFuncVal.ts,
+ts/src/unify.ts; go/func.go, go/unify.go. No new spec rows; the
+existing spread-key*.tsv files are the acceptance test. Fix or fence
+the DisjunctVal.gen distribution defect (ts/src/val/DisjunctVal.ts,
+go/disjunct.go) here, with its own rows in disjunct.tsv.
+
+**Phase 1 — `pack` and `each` (M).** New spec files gen-pack.tsv,
+gen-each.tsv (gen + canon + err rows: list/map data, unfired canon,
+non-bag-data errors, duplicate-key merge), plus composition files
+gen-spread.tsv, gen-close.tsv, gen-key.tsv mirroring the spread-*
+corpus style. Files: ts/src/val/PackFuncVal.ts,
+ts/src/val/EachFuncVal.ts (new), ts/src/lang.ts (`funcMap`),
+ts/src/val/MapVal.ts (generated-children admission and apply-once
+interaction); go/func.go, go/mapval.go, go/lang.go.
+
+**Phase 2 — `filter` and `match` (M).** Requires Phase 0's defect
+fix. Spec files gen-filter.tsv, gen-match.tsv, including
+match-no-arm error rows asserting the tried-alternatives report
+substring (format owned by G2). Files: ts/src/val/FilterFuncVal.ts,
+ts/src/val/MatchFuncVal.ts, ts/src/ctx.ts (trial-mode surface);
+go/func.go, go/ctx.go.
+
+**Phase 3 — placeholder `_` (M/L; the parser phase).** Spec file
+place.tsv: `upper(_) & foo`, `_+2` in spread templates, `_` binding
+inside pack/each templates, the `upper(_) & lower(_)` error, canon of
+unfired placeheld forms, and rows pinning that quoted `"_"` stays a
+string. Files: ts/src/val/PlaceVal.ts (new), ts/src/lang.ts
+(expr-plugin operator config), ts/src/val/FuncBaseVal.ts,
+ts/src/val/OpBaseVal.ts (residuation on peer); go/lang.go, go/op.go,
+go/func.go. Sequenced after G1's residuation machinery so the two
+gaps share one implementation.
+
+**Phase 4 — `|>` sugar (S, optional).** Parse-time desugaring only;
+spec file pipe.tsv whose canon rows all show desugared call forms,
+proving canon never emits the token. Files: ts/src/lang.ts;
+go/lang.go. May be dropped without loss if Phase 1-3 adoption shows
+call nesting is acceptable.
+
+Sequencing within the review: index.md places G8 in Phase C. Phase 0
+here is a pure engine cleanup with independent value (it removes a
+documented hack) and can land earlier without committing to the
+combinators.
+
+## Open questions
+
+- **Keying `pack` over lists of maps.** A list of service *records*
+  (not strings) has no evident key. Options: require a key field by
+  convention (`pack(data, tmpl)` errors unless children carry a
+  designated field), a key-selector argument
+  (`pack(data, keytmpl, tmpl)`), or refuse list-of-maps data and
+  make authors `pack` over the extracted names. Decided by: the
+  Terraform stable-keys lesson (keys must be data, not position)
+  versus keeping the arity small; real model corpora should pick.
+- **`_` scoping under nesting.** When a `pack` template contains an
+  `each`, which generator's child does an inner `_` bind? Innermost-
+  binder lexical scoping is the presumption, but the alternative
+  (an explicit depth argument mirroring `key(n)`) is more
+  Aontu-like. Decided by: whether nested-generator models occur in
+  practice before Phase 3 lands.
+- **What `filter`'s trial observes.** Does `{replicas: *2|integer}`
+  in a candidate satisfy `cond` `{replicas: 2}` (default considered)
+  or not (only asserted structure counts)? Same question for
+  closedness. Decided by: consistency with how disjunct trials treat
+  defaults today, and by G3's subsumption semantics — `filter` must
+  not become an accidental second subsumption with different answers.
+- **Whether generator firings share `maxcc` or get their own budget
+  dimension.** Owned by G5; G8's need is only that exhaustion is a
+  distinct error. Decided by: measurement on nested-generation
+  fixtures once Phase 1 exists.
+- **`match` result shape.** Is the selected result `v & p_i & r_i`
+  (scrutinee flows into the result, as proposed) or `r_i` alone
+  (pure selection)? The former is more lattice-natural and keeps
+  observed-value guarantees; the latter is easier to explain.
+  Decided by: which one composes with `pack` templates without
+  surprises in the Phase 2 spec drafts.
+- **`def()` revisit criteria.** Reopen only if (a) real models show
+  named templates plus `_` failing to express a recurring
+  abstraction, and (b) the proposed `def()` remains checkably
+  non-recursive including through references, and (c) G5's budget
+  and G6's module identity stories are in place to carry it. Absent
+  all three, the refusal stands.

--- a/docs/capability-review/index.md
+++ b/docs/capability-review/index.md
@@ -1,0 +1,340 @@
+# Capability review: Aontu as a systems ground truth for agents
+
+*Status: review (August 2026). This document records a survey of the
+literature, comparable languages, and industry practice, asking one
+question: what fundamental capabilities does Aontu lack to fulfil its
+stated purpose — a systems-definition language and ground truth for
+agents? Each identified gap has a companion design document (G1–G8,
+linked below) with alternatives, boundaries, risks, and an
+implementation plan.*
+
+Method: a ten-agent survey — three codebase analysts over this
+repository, six researchers (CUE; Nickel/Dhall/Pkl/KCL/Jsonnet/Starlark;
+refinement types and formal methods; ontologies and MBSE; agent-industry
+practice; developer tooling and visualisation), plus an adversarial
+fact-checking pass over the combined findings.
+
+## The verdict in brief
+
+Aontu's kernel is the right bet, and the survey validates it from
+several independent directions. The lattice guarantee — any observed
+field value holds for the final result; merging is commutative,
+idempotent, and fails loudly on conflict — is exactly the property that
+makes a definition trustworthy in a way markdown can never be. The
+closed-world validation stance is the one the semantic-web community
+needed two separate languages (OWL, then SHACL) to reach; Aontu has it
+as a per-node dial. The JSON-superset surface means agent-emitted JSON
+is already valid Aontu. And the dual TypeScript/Go implementation with a
+shared machine-readable spec suite is an unusual asset: the same
+semantics embeddable in Node agent harnesses and Go gateways.
+
+But today, "type safety through unification" cashes out as **five
+scalar kinds, literal equality, disjunction-enums, and closedness** —
+`a: number > 0` is a parse error (verified live), there is no regex, no
+length or cardinality constraint, no cross-field invariant. And the
+language is an *evaluator of its own files*, not yet a *service other
+things are checked against*: the CLI evaluates one file to JSON; there
+is no way to validate external data, query a path, ask why a value
+holds, or check that v2 of a schema still honours v1.
+
+The industry context sharpens the stakes. The 2024–26
+spec-driven-development movement (GitHub Spec Kit, AWS Kiro, OpenAI's
+Model Spec, AGENTS.md, Agent Skills) chose structured *markdown* — and
+its acknowledged weakness is that prose specs cannot detect
+contradiction, drift, or type error; OpenAI had to build an entire
+LLM-graded eval harness just to measure compliance with its own spec.
+The enforcement camp (OPA/Rego, Cedar, Kubernetes CEL) proves that
+deterministic, non-Turing-complete, analysable languages are what
+actually gets deployed at decision boundaries — AWS chose Cedar for
+agent authorisation explicitly for determinism and analysability.
+**Nobody has fused the two: a language that is simultaneously the spec
+agents read and the gate that validates their output.** That is the
+position Aontu targets, and the survey's clearest conclusion is that
+the fusion is won or lost on the capabilities below — mostly
+infrastructure around the lattice, not syntax on top of it.
+
+## The eight fundamental gaps
+
+| # | Gap | Why it changes what the language is | Design doc |
+|---|-----|-------------------------------------|------------|
+| G1 | A real constraint algebra | Makes "type safety through unification" true beyond five kinds; everything else is downstream | [g1-constraint-algebra.md](g1-constraint-algebra.md) |
+| G2 | The validation verb | Turns Aontu from expression evaluator into agent guardrail (emit → validate → repair) | [g2-validation-verb.md](g2-validation-verb.md) |
+| G3 | Subsumption as a query; schema evolution | Ground truth is a claim about time; the lattice makes compatibility checking nearly free | [g3-subsumption-evolution.md](g3-subsumption-evolution.md) |
+| G4 | Identity and typed relations | Systems are graphs; Aontu documents are trees with document-scoped paths | [g4-identity-relations.md](g4-identity-relations.md) |
+| G5 | A specified trust contract | Hermeticity, termination, determinism, sandboxing — constitutive for unattended agent evaluation | [g5-trust-contract.md](g5-trust-contract.md) |
+| G6 | A distribution layer | Versioned, integrity-hashed, pinnable modules; truth must be shareable and tamper-evident | [g6-distribution.md](g6-distribution.md) |
+| G7 | A machine-facing access surface | Query, provenance, patch, MCP — agents consume slices, not whole evaluated blobs | [g7-machine-access.md](g7-machine-access.md) |
+| G8 | Generation, on the total side of the fork | N children from data without copies that drift — and without losing the termination guarantee | [g8-generation.md](g8-generation.md) |
+
+## What Aontu already has right
+
+These are assets the review recommends protecting — several have no
+equivalent in CUE:
+
+- **The lattice kernel** — schema, defaults, and data as one kind of
+  value; order-independent merge engineered deliberately (conjunct-term
+  sorting, canonical closed-map unify direction) and pinned by the
+  shared spec.
+- **Closed-world validation with a per-node dial** — `close()`/`open()`,
+  including closed *lists*, which CUE's structs don't cover.
+- **JSON-superset surface** — any JSON document is valid Aontu, so
+  agent output can be unified directly against a definition with no
+  conversion. This is the substrate for a `vet` operation (G2) and
+  dramatically lowers the LLM learning cliff for a low-resource
+  language.
+- **Canonical form** — a deterministic, reparseable normal form. The
+  research upgrades this from a convenience to an economic asset: it is
+  the seed of semantic hashing (G6), semantic diff, and
+  prompt-cache-stable serialisation.
+- **Dual TS + Go implementations with the TSV spec contract** — 44 spec
+  files, ~410 rows, run identically by both. The suite is itself a
+  machine-readable ground truth an LLM can be taught from, and the
+  parity method (spec rows first, both implementations follow) is
+  exactly how every capability below should land.
+- **Ranked preferences** — defaults of defaults (`**` outranks `*`),
+  richer than CUE's single level and a natural fit for layered system
+  definitions (org < team < service).
+- **Spreads** (`&:`) that work on lists, cross-statement, and via
+  referenced templates — beyond CUE's pattern constraints in several
+  directions.
+- **Native variant modelling** — disjunction is a variation point,
+  preference is the default variant. SysML v2 had to bolt on
+  `variation`/`variant` keywords for what Aontu's core already
+  expresses compositionally.
+- **In-memory resolver and host-injected `$name` variables** — good
+  bones for sandboxed, parameterised agent evaluation.
+
+## The gaps, in summary
+
+Each summary below is expanded — with alternatives considered, an
+explicit boundary of things we will not do, a risk assessment, and an
+implementation plan — in its companion document.
+
+### G1 — A real constraint algebra
+
+The single highest-leverage gap, and the one the language's central
+claim rests on. What is needed is not just `number > 0` but a
+*vocabulary of constraint atoms that are lattice citizens*: numeric
+bounds, regex patterns, string/list/map length and cardinality
+("between 2 and 5 replicas", "exactly one primary"), scalar negation,
+and cross-field inequalities via existing path references. The
+liquid-types lesson: no SMT solver is needed — a closed vocabulary of
+predicate constructors, each with meet, emptiness, and subsumption
+rules written down. Interval intersection decides `>5 & <3 → nil` at
+schema-composition time — something evaluate-only systems (CEL, KCL,
+Nickel contracts) can never do. For arbitrary domain rules beyond the
+algebra, the escape hatch is an evaluate-only predicate with an
+author-attached failure message, honestly reported as evaluate-only.
+A related defect: both implementations pin numbers to IEEE-754 double
+semantics, so int64-scale values silently lose precision; CUE
+deliberately uses arbitrary-precision decimals.
+
+### G2 — The validation verb
+
+The canonical agent loop — *emit, validate, repair* — currently has no
+entry point: the CLI evaluates one file to JSON, full stop. Because
+Aontu is a JSON superset, `aontu vet schema.aon candidate.json` is
+nearly free to implement (unify + closedness + report), and it changes
+the language's identity from evaluator to gate. The same verb, pointed
+at a live system dump, is drift detection. The output contract matters
+as much as the verb: stable error codes, JSON and SARIF output,
+severities, author-attached messages, and errors that state **what
+would have unified** — repair-loop studies find admissible
+alternatives, not failure location, drive an agent's ability to
+self-correct.
+
+### G3 — Subsumption as a first-class query; schema evolution
+
+Ground truth is a claim about *time*: agents act on stale snapshots,
+and the truth evolves. Aontu's lattice makes the principled version of
+compatibility checking nearly free: new schema subsumes old ⇒ backward
+compatible; the reverse ⇒ forward compatible; both ⇒ full. Exposing
+subsumption — as a builtin, a CLI verb
+(`aontu breaking --against git#main system.aon`), and a library call —
+powers versioned evolution, default-validity checking, CUE-style trim,
+and the entailment queries agents actually need. Paired with a
+deprecation mark surfaced at point of use, it gives shared schemas a
+complete evolution story. The fact-check pass ranked this Aontu's most
+defensible differentiator.
+
+### G4 — Cross-document identity and first-class typed relations
+
+Systems are graphs; Aontu documents are trees with document-scoped
+paths. Today the language cannot say "this `dependsOn` target must
+exist and be a Service", cannot declare or check an inverse relation,
+cannot forbid a cyclic dependency path, and cannot merge two files
+that describe the same real-world entity unless they share a tree
+path. The adoptable shape, without abandoning the JSON tree: a stable
+identity mark on any node, a reference constraint with referential
+integrity checked at unification time, and path constraints. Notably,
+unification gives cross-document identity cleaner semantics than the
+semantic web ever had: declaring two nodes the same entity means
+unifying them, so a contradiction is a hard, located error rather than
+the silent corruption of `owl:sameAs`. Ports/interfaces/connections —
+the recurring MBSE primitives — need no new syntax: ship them as a
+blessed standard-library schema vocabulary.
+
+### G5 — A specified trust contract
+
+For an artifact that agents evaluate unattended, safety guarantees are
+not hardening — they are constitutive. Today the gap is real: the
+default resolver makes opening an untrusted file equivalent to running
+it (`@"pkg"` can `require()` arbitrary modules; the LSP inherits
+this), and the fixpoint's hard 9-pass bound means models that need a
+tenth pass silently stop refining rather than erroring distinctly.
+Hermeticity — same file set + same `$` bindings ⇒ identical output —
+is probably true de facto but is undocumented and untested. The work:
+write the guarantees down, pin them in the spec suite (including
+byte-identical canonical output across TS and Go), give the evaluator
+API a capability surface, adopt import-sandbox rules before `@"…"`
+ever goes remote, and make evaluation bounds semantic errors rather
+than silent truncation.
+
+### G6 — A distribution layer
+
+Textual file inclusion is a single-project mechanism. Ground truth
+must be shareable across repos, teams, and agent sessions, and
+tamper-evident when it travels. The ecosystem default is settled —
+versioned modules with lockfiles, distributed over OCI registries.
+The differentiator on top: Dhall-style **semantic integrity hashes
+computed over Aontu's canonical form**. A pin hashes the *meaning*,
+not the bytes — refactors and comments don't break it; any semantic
+change anywhere in the transitive closure does. Aontu's existing canon
+makes this nearly free, and no unification-family language has it.
+
+### G7 — A machine-facing access surface
+
+Agents do not consume ground truth by evaluating whole files into one
+JSON blob — they retrieve task-sized slices and patch by path. Three
+surfaces are missing: **query** (`aontu get $.services.auth --canon`
+returning the evaluated fragment, plus token-efficient projections),
+**positive provenance** (`aontu why $.path` — today sites are tracked
+only for errors; extending site-tracking to successful unifications is
+far easier to build now than to retrofit later, as CUE's history
+shows), and **semantic patch** (set a path through unification with
+re-validation — which also requires a comment-preserving,
+format-preserving rewrite story that canon alone cannot provide).
+Delivery matters as much as capability: an official MCP server
+(validate/query/why/diff/canon), an AGENTS.md stanza, an official
+skill, and a published machine-consumable grammar for constrained
+decoding.
+
+### G8 — Generation and abstraction, resolved on the total side
+
+Producing N similar children from data — one block per service, per
+region, per replica — is the bread-and-butter of systems definition.
+Without it, humans and agents copy-paste, and the copies drift, which
+defeats ground-truth-ness from inside. Aontu's spread applies a schema
+to children that exist; nothing can *generate* children, compute a
+key, or interpolate a string. This is also the language's deepest
+identity question: every credible safety story surveyed (Dhall,
+Starlark, CEL, Cedar) lands on the same side — a ground truth
+evaluated unattended by agents must terminate by construction. Take
+comprehension power from total combinators
+(`each`/`pack`/`filter`/`match`) and bounded evaluation budgets, and
+treat "Aontu evaluation always terminates, deterministically" as a
+headline, spec-guaranteed feature.
+
+## Traps to refuse
+
+The survey found as much evidence about what *not* to build. Each of
+these is a documented failure mode in an adjacent system:
+
+- **Turing-completeness.** Recursive user functions trade away the
+  termination guarantee that makes unattended agent evaluation safe.
+- **SMT solvers in the checker.** Documented proof flakiness and
+  solver-version nondeterminism (F*) are disqualifying for a
+  dual-implementation language whose product is deterministic answers.
+- **Temporal/behavioural logic in the language.** "Replicas eventually
+  converge" is inexpressible in a value lattice by construction.
+  Represent state machines as ordinary Aontu data and export to
+  TLA+/P — be the structural front end, not the model checker.
+- **General negation/complement.** Sound only atop semantic-subtyping
+  machinery that costs months across two implementations. Scalar-level
+  negation (`!=`, not-in-set) composes fine within the bounds algebra.
+- **Surface-area creep toward CUE.** Every stratum CUE added raised
+  its floor; its highest-profile adopter (Dagger) dropped it as users'
+  number-one complaint. Aontu's small, JSON-superset surface is a
+  moat — especially for LLMs, where grammar size is acquisition cost.
+  Also heed CUE's deepest scar before deepening types: pin down the
+  interactions of `*`, closedness, and spreads in the spec suite
+  first; those are the non-lattice-pure features that forced CUE's
+  multi-year evaluator rewrite.
+- **Ignoring the null hypothesis.** The strongest competitor for
+  "ground truth for agents" is JSON Schema 2020-12 plus prose. Aontu's
+  answer must be stated explicitly and delivered mechanically:
+  merge-as-unification, subsumption-as-compatibility, located two-site
+  conflicts, semantic hashing — the things JSON Schema structurally
+  cannot do.
+
+## Sequencing
+
+| Phase | Capabilities | Rationale |
+|-------|--------------|-----------|
+| A — make the claim true | G1 constraint algebra core (bounds, regex, length/count) · G2 `vet` with structured reports, stable codes, admissible-alternative errors · G5 trust contract written and spec-pinned | These convert "type safety through unification" from positioning into fact, and open the emit → validate → repair loop |
+| B — differentiate | G3 `subsume`/`breaking` · G6 canon-hash pinning · G7 `get`/`why` + MCP server + published grammar + skill | Each is nearly free given the lattice and canon, and no competitor has the principled version |
+| C — scale | G4 identity/relations + stdlib vocabulary · G6 full module registry · G8 total generation combinators · incremental LSP · views/diagram exporters · JSON Schema interop | Ecosystem weight; several depend on Phase A |
+
+The exception: the G7 query/MCP surface depends on nothing and is the
+cheapest adoption wedge — it could ship first, wrapping today's
+evaluator, and every later capability becomes another tool on the same
+server. Throughout, the existing method is the right one: every
+capability lands as TSV spec rows first, both implementations follow,
+and property-based differential testing guards the algebra as the Val
+zoo grows.
+
+## Verified codebase facts referenced by the design documents
+
+Checked against this repository at review time (TS v0.49.0 line):
+
+- Exactly 12 builtin functions, hard-wired in the parser's `funcMap`
+  (`ts/src/lang.ts`): `upper`, `lower`, `copy`, `key`, `type`, `hide`,
+  `move`, `path`, `pref`, `close`, `open`, `super`. (`ExpectVal` is
+  internal spread-required machinery, not a user-callable function.)
+- Scalar constraints are kind-only; `a: number > 0` fails to parse
+  (verified by running the CLI).
+- 44 shared spec files under `test/spec/` (~410 rows; modes
+  `canon`/`gen`/`err`); the Go runner executes every row with no skip
+  list.
+- The fixpoint is bounded at `maxcc = 9` passes (`ts/src/unify.ts`);
+  `MAXCYCLE = 999`.
+- The resolver security posture is documented in code
+  (`ts/src/lang.ts`, "treat opening an untrusted source as running
+  it").
+- Disjunct generation has a known distribution defect, acknowledged in
+  a code comment (`ts/src/val/DisjunctVal.ts`).
+- Both implementations use IEEE-754 double number semantics (Go
+  reproduces JS `Number.toString`).
+- Parsed/unified trees are single-use (documented mutation caveat);
+  the LSP re-parses and re-unifies whole documents per change.
+
+## Key sources
+
+- CUE: language spec, "The Logic of CUE", modules design,
+  evaluator-rewrite discussions, error-message threads; Dagger's
+  "Ending CUE support".
+- Config languages: Nickel manual and programmable-LSP posts; Dhall
+  safety guarantees and semantic integrity checks; Pkl language
+  reference and evaluator allowlists; KCL validation/package docs;
+  Jsonnet design; Starlark design; NixOS module system; Hadlow's
+  Configuration Complexity Clock.
+- Formal methods: Liquid Types (PLDI '08) and the Jhala–Vazou
+  refinement-types tutorial; PVS predicate subtyping; Dependent ML;
+  Kubernetes CEL admission policy; semantic subtyping
+  (Frisch/Castagna); LIFE residuation (Aït-Kaci & Podelski); Ivy's
+  decidable-fragment discipline; Alloy; the S3 ShardStore
+  lightweight-formal-methods paper; "Union and intersection contracts
+  are hard, actually".
+- KR & systems modelling: JSON-LD, SHACL, OWL; the `owl:sameAs`
+  literature; SysML v2 spec and API; Structurizr (incl. its MCP
+  server); Azure DTDL; AADL; Confluent schema evolution; buf breaking;
+  Open Data Contract Standard; GraphRAG grounding literature.
+- Agent industry: GitHub Spec Kit; AWS Kiro; OpenAI Model Spec and
+  evals; AGENTS.md / Agent Skills / llms.txt post-mortems; Anthropic
+  context-engineering and code-execution-with-MCP; grammar-constrained
+  decoding (llguidance, XGrammar, CFG tools); structured-feedback
+  repair studies; OPA/Cedar/CEL at the agent boundary; Context7.
+- DevX: CUE LSP wiki; Nickel nls; gopls scalability; rust-analyzer
+  inlay hints; Elm and Rust error-message design; `nix why-depends`;
+  Terraform plan/phantom-diff analyses; D2/Mermaid; Backstage catalog;
+  difftastic/dyff; SARIF.

--- a/docs/capability-review/index.md
+++ b/docs/capability-review/index.md
@@ -91,8 +91,8 @@ equivalent in CUE:
   research upgrades this from a convenience to an economic asset: it is
   the seed of semantic hashing (G6), semantic diff, and
   prompt-cache-stable serialisation.
-- **Dual TS + Go implementations with the TSV spec contract** — 44 spec
-  files, ~410 rows, run identically by both. The suite is itself a
+- **Dual TS + Go implementations with the TSV spec contract** — 45 spec
+  files, ~426 rows, run identically by both. The suite is itself a
   machine-readable ground truth an LLM can be taught from, and the
   parity method (spec rows first, both implementations follow) is
   exactly how every capability below should land.
@@ -310,7 +310,7 @@ Checked against this repository at review time (TS v0.49.0 line):
   internal spread-required machinery, not a user-callable function.)
 - Scalar constraints are kind-only; `a: number > 0` fails to parse
   (verified by running the CLI).
-- 44 shared spec files under `test/spec/` (~410 rows; modes
+- 45 shared spec files under `test/spec/` (~426 rows; modes
   `canon`/`gen`/`err`); the Go runner executes every row with no skip
   list.
 - The fixpoint is bounded at `maxcc = 9` passes (`ts/src/unify.ts`);

--- a/docs/capability-review/index.md
+++ b/docs/capability-review/index.md
@@ -30,12 +30,17 @@ semantics embeddable in Node agent harnesses and Go gateways.
 
 But today, "type safety through unification" cashes out as **five
 scalar kinds, literal equality, disjunction-enums, and closedness** —
-`a: number > 0` is a parse error (verified live), there is no regex, no
-length or cardinality constraint, no cross-field invariant. And the
-language is an *evaluator of its own files*, not yet a *service other
-things are checked against*: the CLI evaluates one file to JSON; there
-is no way to validate external data, query a path, ask why a value
-holds, or check that v2 of a schema still honours v1.
+`a: number > 0` is a parse error (verified live), there is no regex,
+and no length or cardinality constraint. Cross-field *equality* is
+expressible through references (`b: $.a` conflicts if `b` is pinned
+elsewhere), but no cross-field inequality or general predicate is.
+And the language is an *evaluator of its own files*, not yet a
+*service other things are checked against*: `@"file"` can load and
+unify external data and the TS API exposes `ctx.find(path)`, but
+there is no dedicated validation verb with a structured report
+contract, no CLI query surface or token-efficient projections, no way
+to ask why a value holds, and no check that v2 of a schema still
+honours v1.
 
 The industry context sharpens the stakes. The 2024–26
 spec-driven-development movement (GitHub Spec Kit, AWS Kiro, OpenAI's
@@ -183,7 +188,12 @@ it (`@"pkg"` can `require()` arbitrary modules; the LSP inherits
 this), and the fixpoint's hard 9-pass bound means models that need a
 tenth pass silently stop refining rather than erroring distinctly.
 Hermeticity — same file set + same `$` bindings ⇒ identical output —
-is probably true de facto but is undocumented and untested. The work:
+is currently *false* under the default resolver: a package include
+can execute a module whose export derives from time, environment, or
+filesystem state, so identical sources can produce different results.
+It holds only under confined resolvers (memory/filesystem), and
+resolver confinement is therefore part of *establishing* the
+guarantee, not merely documenting it. The work:
 write the guarantees down, pin them in the spec suite (including
 byte-identical canonical output across TS and Go), give the evaluator
 API a capability surface, adopt import-sandbox rules before `@"…"`
@@ -199,8 +209,15 @@ versioned modules with lockfiles, distributed over OCI registries.
 The differentiator on top: Dhall-style **semantic integrity hashes
 computed over Aontu's canonical form**. A pin hashes the *meaning*,
 not the bytes — refactors and comments don't break it; any semantic
-change anywhere in the transitive closure does. Aontu's existing canon
-makes this nearly free, and no unification-family language has it.
+change anywhere in the transitive closure does. One honest caveat the
+design must resolve: canon today is deterministic *syntax*, not a
+unique semantic normal form (`number|integer` denotes the same value
+set as `number` — `DisjunctVal` drops only `same()` alternatives —
+yet the two canon differently), so hashing requires either a
+subsumption-based minimisation step before the hash or the weaker,
+clearly-labelled claim of a canonical-text hash. Aontu's existing
+canon still makes either variant nearly free, and no
+unification-family language has it.
 
 ### G7 — A machine-facing access surface
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,14 @@ live in [`design/`](design/):
   — a Go-port parity defect (and its workaround) where a colon-chain
   imported value is dropped.
 
+Forward-looking design work lives in
+[`capability-review/`](capability-review/index.md): a survey of what
+Aontu lacks to serve as a systems-definition ground truth for agents,
+with eight companion design documents (G1–G8) covering the constraint
+algebra, the validation verb, subsumption and schema evolution,
+identity and relations, the trust contract, distribution, the
+machine-facing access surface, and generation.
+
 ### Why the split?
 
 The four kinds of document answer four different questions and are kept


### PR DESCRIPTION
## What this adds

A new `docs/capability-review/` directory answering one question: **what fundamental capabilities does Aontu lack to fulfil its stated purpose — a systems-definition language and ground truth for agents?**

- `docs/capability-review/index.md` — the review itself: a survey of the literature, comparable languages (CUE, Nickel, Dhall, Pkl, KCL, Jsonnet, Starlark), formal methods (refinement types, residuation, decidable-fragment discipline), knowledge representation and systems modelling (SHACL, JSON-LD, SysML v2, DTDL), and 2024–26 agent-industry practice (spec-driven development, MCP, constrained decoding, policy-as-code). It identifies eight fundamental gaps (G1–G8), records what Aontu already has right, lists evidence-backed traps to refuse, and proposes a sequencing.
- `docs/capability-review/g1…g8-*.md` — one full design document per gap (deeper examination, prior art, design space with alternatives, proposed design, explicit boundary of non-goals, risk table, spec-first implementation plan, open questions):
  - G1 constraint algebra — function-form constraint atoms (`min`/`max`/`above`/`below`, `neq`, `re`, `len`, `unique`) as lattice citizens with meet/emptiness/subsumption rules; `must(c, msg)` evaluate-only escape hatch; residuation as staging semantics
  - G2 the validation verb — `aontu vet` with a frozen machine contract (JSON + SARIF, stable codes, invalid/incomplete verdict split, admissible-alternative fields)
  - G3 subsumption as a query and schema evolution — three-valued `subsume`, `aontu breaking`, per-document compat policy, `deprecate()`
  - G4 cross-document identity and typed relations — `id()` and `refer()` split by monotonicity; `std/system` vocabulary for global graph properties
  - G5 the trust contract — capability-scoped trust profiles, deterministic budgets replacing silent pass exhaustion, byte-exact determinism as a spec mode
  - G6 distribution — OCI modules + lockfile with dual pins (byte digest + canon hash over a closedness/mark-aware hash form)
  - G7 machine-facing access — `aontu get` projections, opt-in `why` provenance, overlay-append patching, MCP server, published grammar
  - G8 generation on the total side of the fork — total combinators `pack`/`each`/`filter`/`match`; `def()`/recursion refused
- `docs/index.md` — linked the new directory.

## Notes for review

- Documentation only — no code, no spec rows, no behaviour changes.
- All codebase claims were verified against the current tree, including live probes of both implementations (12 builtins, kind-only scalar constraints, `maxcc = 9`, 45 shared spec files / ~426 rows, IEEE-754 number model, resolver security posture, the `DisjunctVal.gen` distribution defect).
- Each design document defers to sibling ownership (e.g. G2 owns the error-report contract; G5 owns evaluation budgets) so the set composes into one coherent plan.
- The earlier automated review feedback on this PR has been addressed in `86d529b` (review-claim accuracy) and `7182012` (the design documents whose links were previously dangling).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAeXAzwK6EncK7CMWrPFtF)_