### PR TITLE
v0.52.0

### DIFF
--- a/ts/dist/aontu.d.ts
+++ b/ts/dist/aontu.d.ts
@@ -5,7 +5,7 @@ import { Decimal } from './val/Decimal';
 import { exactJSON } from './exactjson';
 import { formatExplain } from './utility';
 import { AontuError } from './err';
-declare const VERSION = "0.51.0";
+declare const VERSION = "0.52.0";
 declare class Aontu {
     opts: AontuOptions;
     lang: Lang;

--- a/ts/dist/aontu.js
+++ b/ts/dist/aontu.js
@@ -24,7 +24,7 @@ Object.defineProperty(exports, "AontuError", { enumerable: true, get: function (
 // Kept in step with package.json by the `version` npm lifecycle script,
 // which runs on `npm version` / `npm run repo-bump`. version.test.ts
 // fails if the two ever drift.
-const VERSION = '0.51.0';
+const VERSION = '0.52.0';
 exports.VERSION = VERSION;
 class Aontu {
     constructor(popts) {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aontu",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "main": "dist/aontu.js",
   "type": "commonjs",
   "types": "dist/aontu.d.ts",

--- a/ts/src/aontu.ts
+++ b/ts/src/aontu.ts
@@ -22,7 +22,7 @@ import { makeNilErr, descErr, AontuError } from './err'
 // Kept in step with package.json by the `version` npm lifecycle script,
 // which runs on `npm version` / `npm run repo-bump`. version.test.ts
 // fails if the two ever drift.
-const VERSION = '0.51.0'
+const VERSION = '0.52.0'
 
 
 class Aontu {


### PR DESCRIPTION
Minor bump, 0.51.0 → 0.52.0, to release what landed in #36.

## What is in the release

- **Go parity** — #34 (bag operands carry source positions), #27 (the spread-required distinction), #26 (ref chains resolve one link per pass in both engines).
- **100 % coverage in both implementations**, with `make cov` as a gate rather than a report: TypeScript 11331/11331 lines, 2527/2527 branches, 466/466 functions; Go 100.0 % statements across all four packages.
- **`ADR.md`** — the register of fundamental decisions (ADR-001 parity via the shared spec, ADR-002 the coverage floor).

Minor rather than patch because the Go port gained behaviour it did not have before and the shared spec grew from 1264 to 1592 rows. No breaking change to the TypeScript API.

## The diff

Four lines, all version:

| File | Change |
|------|--------|
| `ts/package.json` | `"version": "0.52.0"` |
| `ts/src/aontu.ts` | `const VERSION = '0.52.0'` — written by the `version` npm lifecycle script |
| `ts/dist/aontu.js`, `ts/dist/aontu.d.ts` | rebuilt, since `dist` is committed |

`version.test.ts` fails if `package.json` and `src/aontu.ts` ever drift, so the two cannot separate silently.

## How it publishes

Merging this and pushing the `v0.52.0` tag triggers `.github/workflows/publish.yml`: npm **trusted publishing over OIDC**, with `id-token: write` exchanging a GitHub OIDC token for a short-lived credential. No `NPM_TOKEN` is involved and provenance is attached automatically.

The Go module is unaffected — it versions independently on its own `go/v*` tags (currently 0.1.9) and has no OIDC path.

## Verification

`make test`: TypeScript 1952/1952, all four Go packages green. `ts/dist/aontu.js` rebuilt and confirmed carrying `0.52.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011d7i6rMnP2WxYMHEWQpmuY

---
_Generated by [Claude Code](https://claude.ai/code/session_011d7i6rMnP2WxYMHEWQpmuY)_