### PR TITLE
The reference documented ten of the eleven verbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,12 @@ top-level `ts/` and `go/` siblings and a fan-out `Makefile`. On top of
 that, this repo adds a **shared, data-driven test suite** so both
 implementations are checked against the same cases.
 
-> **CI note:** the intended two-job (TypeScript + Go) GitHub Actions
-> workflow is provided as a full `.github` tree under
-> [`ci/`](ci/) (`ci/.github/workflows/build.yml`). Updating
-> `.github/workflows/` requires the GitHub `workflow` OAuth scope, so
-> copy `ci/.github` over the repo's `.github` and push from an account
-> that has the scope to enable it.
+> **CI note:** the workflow lives at
+> [`.github/workflows/build.yml`](.github/workflows/build.yml) and runs
+> three jobs — `build-ts`, `build-go`, and `coverage` (the ADR-002
+> floor). Editing anything under `.github/workflows/` needs the GitHub
+> `workflow` OAuth scope, so a push that touches it must come from an
+> account that has the scope.
 
 ## Repository layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ which implementation each change affects.
 
 ## Unreleased — TypeScript 0.53.0 line
 
+### Documentation — the four quadrants brought back level
+
+A pass over `docs/` after the last four changes landed, against the
+split `docs/index.md` declares: a tutorial teaches, a how-to gives the
+recipe, a reference is exhaustive, and only the explanation argues.
+
+- **The reference documented ten of the eleven verbs.**
+  `aontu relations` had a line in the synopsis and a paragraph under the
+  library API, but no section of its own — so the one page that promises
+  to be exhaustive was the one place the verb could not be looked up. It
+  now has one, with the finding fields, the `--format json` shape, and
+  its three verdicts (`pass`/`fail`/`error` — not `vet`'s five, because
+  there is no schema on the other side of the question). The library
+  paragraph points at it instead of restating half of it.
+- **`--in-place` had reached two quadrants of four.** It is now in the
+  tutorial's closing (as the command that does by hand what §13 just
+  did), the index's verb map, and the agent skill's repair loop, which
+  stopped at diagnosis and now ends with the fix.
+- **The explanation gained the argument.** Why appending is the default,
+  why the deferred CST turned out to be for a different job, why a site
+  names a *token* and what that does to `min(1)`, why the candidate text
+  is parsed alone rather than checked against a list of safe shapes, and
+  why a load in the overlay is refused rather than detected — all of it
+  previously lived only in commit messages and design notes.
+- **The how-to gave up arguing and gained a recipe.** The eight lines
+  reasoning about the include collision moved to the explanation; in
+  their place is the thing a reader actually needs — how to edit a value
+  that lives in an include, and the trap of naming an entry that pulls
+  the same file in (the value meets itself, verdict `invalid`, nothing
+  written). Both ports were measured; they agree.
+- **Two claims had outlived their premise.** `trim --check`'s
+  justification was that rewriting needs a format-preserving editor —
+  which `set --in-place` disproved; the real reason is that deleting an
+  entry is a different edit from replacing one, and a span does not say
+  which blank line went with it. `AGENTS.md` described a CI tree under
+  `ci/` that does not exist; the workflow is live in
+  `.github/workflows/build.yml`.
+- **Smaller repairs.** Two internal links pointed at nothing
+  (`reference-api.md#options`, now `#aontuoptions`), the how-to's
+  contents list was missing its newest section, a REPL transcript still
+  showed `v0.50.1`, and the trust contract was still stamped `v0.51`.
+
 ### Added — `set --in-place`, so the repair loop closes
 
 `aontu set` could not repair the commonest failure it exists for.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ recipe, a reference is exhaustive, and only the explanation argues.
   which blank line went with it. `AGENTS.md` described a CI tree under
   `ci/` that does not exist; the workflow is live in
   `.github/workflows/build.yml`.
+- **Two overstatements corrected, both found in review.** A relation
+  declaration does **not** have to unify with the bundled
+  `$.std.Relation`: both checkers read every map under the root
+  `relations` key and take its `acyclic` and `inverse` fields directly,
+  so a bare `{ inverse: usedBy, acyclic: true }` declares the same
+  relation — which is what keeps `relations` usable under the `'none'`
+  include capability, where `@"std/system"` does not resolve. And
+  `--in-place` is not an alternative to `--overlay`: `set` requires an
+  overlay either way, `--in-place` only decides whether the assignment
+  is appended to that file or rewritten inside it, and the entry
+  document is never written.
 - **Smaller repairs.** Two internal links pointed at nothing
   (`reference-api.md#options`, now `#aontuoptions`), the how-to's
   contents list was missing its newest section, a REPL transcript still

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ aontu                         # no file on a terminal -> REPL
 
 The repository's CLI has grown a verb surface beyond evaluation —
 `vet` (validate data against a schema), `get`/`why` (query and
-provenance), `set`, `subsume`/`breaking`, `hash`,
+provenance), `set` (change a value, through an overlay or in place),
+`subsume`/`breaking`, `hash`,
 `relations`, `trim`, `mod` tooling, `agentsmd`, a path-addressed
 `diff` in the API, and an MCP server —
 documented in [docs/reference-api.md](docs/reference-api.md).

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ aontu                         # no file on a terminal -> REPL
 
 The repository's CLI has grown a verb surface beyond evaluation —
 `vet` (validate data against a schema), `get`/`why` (query and
-provenance), `set` (change a value, through an overlay or in place),
-`subsume`/`breaking`, `hash`,
+provenance), `set` (change a value in an overlay, by appending or in
+place), `subsume`/`breaking`, `hash`,
 `relations`, `trim`, `mod` tooling, `agentsmd`, a path-addressed
 `diff` in the API, and an MCP server —
 documented in [docs/reference-api.md](docs/reference-api.md).

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -219,16 +219,68 @@ thing. Its shape views are held to a stronger claim than "a summary":
 each is itself a valid document that *subsumes* the truth, so a
 projection may generalise but may never mislead.
 
-**[`set`](reference-api.md#aontu-set) appends rather than rewrites**,
-and that follows from the lattice rather than from a gap in the
-tooling. Because unification is order-independent, a change written
-into a second file is the same value as the same change written into
-the first — so an overlay needs no format-preserving rewriter, and
-cannot damage the document it is changing. What it cannot do is
-override a value that is already pinned: the lattice refuses, and the
-loop becomes `set` → conflict → `why` → edit the site that did the
-pinning. That is a slower answer than a silent overwrite, and a much
-better one.
+**[`set`](reference-api.md#aontu-set) appends by default**, and that
+follows from the lattice rather than from a gap in the tooling. Because
+unification is order-independent, a change written into a second file
+is the same value as the same change written into the first — so an
+overlay needs no format-preserving rewriter, and cannot damage the
+document it is changing.
+
+What appending cannot do is override a value that is already **pinned**:
+the lattice refuses, because unification only narrows. That was a real
+hole rather than a principled refusal, and an embarrassing one — the
+commonest validation failure of all is "the data says the wrong thing",
+and the verb built for repair could only fill holes.
+
+`--in-place` closes it, and the interesting part is what it turned out
+*not* to need. The rewriter was deferred for a long time behind a
+comment-preserving CST, on the reasonable-sounding grounds that you
+cannot put a document back together without one. But a CST is what you
+need to **re-serialise** a document, and replacing one value serialises
+nothing: it writes new text over a known span and leaves every other
+byte alone — every comment, every blank line, every alignment space —
+because it never reads them. The prerequisite was for a different job
+than the one that had to be done.
+
+What it *does* need is the ability to say **which bytes**, and to be
+right. That is the second thing this cost more than expected. A site
+names the **token** it points at, not the value it belongs to, and for
+anything compound those are different: `min(1)` reports `min`, `1+2`
+reports `1`, `{b:1}` reports `{`. Writing over those spans produces
+`a: 5(1)` and `a: 5+2` — a corruption with the same shape as the one
+this whole line of work started from, arrived at by a different route.
+
+The fix is worth stating because it generalises past this verb: rather
+than enumerate which shapes are safe — a list is a thing to be
+incomplete about — the candidate text is parsed **on its own** and
+required to mean what the contribution meant. The same unifier that
+produced the value decides whether the text is the whole of it, so the
+answer cannot drift from the engine, and the awkward case falls out
+without being named: `0x1F` canons to `31`, which is not its own
+spelling but *is* the contribution's canon, so a hex literal is
+editable while `min` is not.
+
+One case shows why that check is not the whole of the answer.
+Verification asks whether the text at the span is what the site claims,
+and there is a shape where it says yes and is still wrong: an included
+document holding `a: 42` at row 1 column 4, and the overlay holding
+`x: 42` at row 1 column 4. Same position, same text, so the check
+passes — and the splice rewrites `x` while reporting a replacement of
+`$.a`. What fails there is not the verification but the premise
+underneath it, that a position identifies a place in *this* file. So
+the evaluation that decides what to edit refuses to load at all, and
+the ambiguity never arises: what resolves is what the overlay says by
+itself. Denying the shape is worth more than detecting the collision,
+because a detector is a list of shapes, and the argument here is about
+what happens when the list turns out to be incomplete.
+
+Rewriting is **opt-in** for the reason appending was preferred in the
+first place: appending is reversible in a way that overwriting is not,
+and the two failure modes are not symmetric. So the flag is asked for,
+never inferred; where the span cannot be established the assignment
+appends exactly as it would have without it, and says why. Refusing to
+edit is always available, and always safe. Editing the wrong bytes is
+neither.
 
 ### Meaning, not bytes
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -14,6 +14,7 @@ basics from the [Tutorial](tutorial.md); for exhaustive rules see the
 - [Ask what a document says at one path](#ask-what-a-document-says-at-one-path)
 - [Find out why a value came out the way it did](#find-out-why-a-value-came-out-the-way-it-did)
 - [Change a value without editing the file](#change-a-value-without-editing-the-file)
+- [Change a value that is already pinned](#change-a-value-that-is-already-pinned)
 - [Find entries that are doing nothing](#find-entries-that-are-doing-nothing)
 - [Check that components agree about their relations](#check-that-components-agree-about-their-relations)
 - [Provide defaults that callers can override](#provide-defaults-that-callers-can-override)
@@ -411,20 +412,35 @@ verdict:
 A default (`a: *1`) is not in the table: appending already overrides it
 correctly, so `--in-place` leaves it alone and says nothing.
 
-**An overlay that loads another document cannot be edited in place at
-all.** That looks strict until you see what it prevents: an include
-holding `a: 42` at row 1 column 4, and the overlay holding `x: 42` at
-row 1 column 4. The site is real and the text at the span really is
-`42`, so the verification passes — and a splice that trusted it would
-rewrite `x` while reporting a replacement of `$.a`. Denying loads
-removes the ambiguity at its source rather than trying to detect it:
-what resolves is what the overlay says by itself.
+**Keep the overlay a file that stands on its own.** That is the last
+row of the table: an overlay which `@"includes"` another document is
+never edited in place, because a position in a loaded file cannot be
+told apart from a position in this one. ([Why the tool refuses the
+shape instead of detecting the
+collision](explanation.md#the-emit--validate--repair-loop).)
 
-Rewriting a file is not reversible the way appending to one is, which
-is why it is opt-in. Pair it with `--dry-run` to see the rewritten
-overlay without writing it — and note that when a run is refused as a
-whole, any edit it *could* have made is reported as `would replace:`
-rather than `replaced:`, because the file was not touched.
+**To change a value that lives in an include, edit the file that holds
+it** — name that file as the overlay, and give `--entry` something that
+*constrains* the value without also pulling the file in:
+
+```sh
+$ cat inc.aon
+a: 42  # keep me
+$ aontu set '$.a=5' --entry schema.aon --overlay inc.aon --in-place
+verdict: valid
+replaced: inc.aon:1:4 42 -> 5
+wrote: inc.aon
+```
+
+Passing an entry that `@"includes"` the overlay is the trap: the value
+then meets *itself*, the verdict is `invalid`, and nothing is written —
+the report says `would replace:` to tell you the edit was possible and
+the conflict was elsewhere.
+
+Pair `--in-place` with `--dry-run` to see the rewritten overlay without
+writing it. When a run is refused as a whole, any edit it *could* have
+made is reported as `would replace:` rather than `replaced:`, because
+the file was not touched.
 
 ## Find entries that are doing nothing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,11 +36,11 @@ Tooling:
   data documents against a schema (and ships wrapped for CI as a
   [GitHub Action](../vet-action/README.md)); `subsume` and `breaking`
   gate schema evolution; `get` and `why` ask an evaluated document what
-  it says and what contributed to it; `set` changes one through an
-  overlay; `trim` reports redundant entries; `relations` runs the
-  declared identity checks; `hash` pins what a document *means*; `mod`
-  maintains a dependency closure; `agentsmd` writes the prose stanza
-  for a definition. With no file, `aontu` starts a REPL.
+  it says and what contributed to it; `set` changes one, through an
+  overlay or in place; `trim` reports redundant entries; `relations`
+  runs the declared identity checks; `hash` pins what a document
+  *means*; `mod` maintains a dependency closure; `agentsmd` writes the
+  prose stanza for a definition. With no file, `aontu` starts a REPL.
 - [Language Server (LSP)](lsp.md) — the `aontu-lsp` diagnostics server
   (TypeScript and Go), how to wire it into an editor, and the reusable
   LSP library API.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,11 +36,12 @@ Tooling:
   data documents against a schema (and ships wrapped for CI as a
   [GitHub Action](../vet-action/README.md)); `subsume` and `breaking`
   gate schema evolution; `get` and `why` ask an evaluated document what
-  it says and what contributed to it; `set` changes one, through an
-  overlay or in place; `trim` reports redundant entries; `relations`
-  runs the declared identity checks; `hash` pins what a document
-  *means*; `mod` maintains a dependency closure; `agentsmd` writes the
-  prose stanza for a definition. With no file, `aontu` starts a REPL.
+  it says and what contributed to it; `set` changes one in an overlay,
+  by appending or in place; `trim` reports redundant entries;
+  `relations` runs the declared identity checks; `hash` pins what a
+  document *means*; `mod` maintains a dependency closure; `agentsmd`
+  writes the prose stanza for a definition. With no file, `aontu`
+  starts a REPL.
 - [Language Server (LSP)](lsp.md) — the `aontu-lsp` diagnostics server
   (TypeScript and Go), how to wire it into an editor, and the reusable
   LSP library API.

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -315,10 +315,15 @@ $ echo $?
 1
 ```
 
-- Relations are read from the **`relations` key of the document root**,
-  each one a `$.std.Relation` carrying `acyclic` and/or `inverse`. That
-  key is the vocabulary's convention, not the engine's: nothing in the
-  language knows the name, the checking pass does.
+- Relations are read from the **`relations` key of the document root**:
+  every map under it is a declaration, and its `acyclic` and `inverse`
+  fields are read directly. Unifying one with the bundled
+  `$.std.Relation` documents what it is and is the vocabulary's
+  convention — **not a requirement**. A bare
+  `{ inverse: usedBy, acyclic: true }` declares the same relation with
+  no `@"std/system"` at all, so the checks are available under every
+  include capability, `'none'` included. The key name is convention
+  too: nothing in the language knows it, the checking pass does.
 - **These are not lattice constraints, deliberately.** Both properties
   are global and non-monotone — one more edge makes an acyclic graph
   cyclic — so they are facts about a finished model rather than
@@ -445,7 +450,10 @@ $.services.auth.replicas = 3
 
 ### `aontu set`
 
-Change a document by **appending to an overlay**, not by rewriting it.
+Change a document by **appending to an overlay** — or, with
+`--in-place`, by rewriting the literal inside that same overlay.
+`--overlay` is required either way, and the entry document is never
+written.
 
 ```
 aontu set <path>=<value>... --entry <file> --overlay <file>

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -284,12 +284,65 @@ aontu trim --check [--format text|json] <file.aon>
   candidates** (removing one shifts every later index — a different
   document, not the same one minus a redundancy). A child of a
   redundant parent is skipped: removing the parent already covers it.
-- `--check` is **required**: trim only reports for now — rewriting the
-  file in place needs a format-preserving editor (G7) — and
-  `aontu trim f.aon` doing something other than trimming silently
-  would be worse than saying so.
+- `--check` is **required**: trim only reports, and `aontu trim f.aon`
+  doing something other than trimming silently would be worse than
+  saying so. It is not blocked on the machinery
+  [`set --in-place`](#aontu-set) now has — a splice needs no
+  format-preserving editor — but deleting an entry is a different
+  edit from replacing one: a statement's span does not say which
+  surrounding blank line or trailing comment went with it, and
+  guessing wrong silently rewrites the file's shape.
 - Exit codes: `0` clean, `1` redundant entries found, `4` the document
   itself does not evaluate, `2` usage.
+
+### `aontu relations`
+
+Run the [declared-relation](reference-language.md#declared-relations)
+checks — acyclicity and inverse consistency — over one finished model.
+
+```
+aontu relations [--format text|json] <file.aon>
+```
+
+```
+$ aontu relations system.aon
+verdict: fail
+
+$.auth.dependsOn.0  dependsOn: cycle auth -> billing -> auth
+$.auth.dependsOn.0  dependsOn: billing does not list auth under usedBy
+$.billing.dependsOn.0  dependsOn: auth does not list billing under usedBy
+$ echo $?
+1
+```
+
+- Relations are read from the **`relations` key of the document root**,
+  each one a `$.std.Relation` carrying `acyclic` and/or `inverse`. That
+  key is the vocabulary's convention, not the engine's: nothing in the
+  language knows the name, the checking pass does.
+- **These are not lattice constraints, deliberately.** Both properties
+  are global and non-monotone — one more edge makes an acyclic graph
+  cyclic — so they are facts about a finished model rather than
+  something unification may hold. The
+  [language reference](reference-language.md#declared-relations) states
+  the rule; the [explanation](explanation.md#why-there-is-a-verb-surface)
+  argues it.
+- A finding carries `at` (the position of the offending edge), `code`
+  (`relation_cycle` or `relation_inverse_missing`), `relation`, and
+  `detail` — for a cycle, the entities it runs through in order; for a
+  missing inverse, `[from, to, inverseName]`. Findings are **sorted by
+  `at`**, so the report diffs cleanly.
+- `--format json` wraps the same findings with the `aontu` producer
+  block (`verb`, `version`) that every machine-readable report carries.
+- Exit codes: `0` `pass`, `1` `fail`, `4` `error` (the document does
+  not evaluate), `2` usage. Note these are the verb's own three
+  verdicts, not [`vet`](#aontu-vet)'s five classes — there is no
+  schema on the other side of this question, so `incomplete` has
+  nothing to mean.
+- The library form is `relationCheck(src)` in TypeScript and
+  `Aontu.RelationCheck(src)` in Go, returning the identical
+  `{verdict, findings}` record; the derived graph the checks run over
+  is `result.graph` / `Aontu.Graph`, described under
+  [the TypeScript API](#class-aontu).
 
 ### `aontu get`
 
@@ -695,7 +748,7 @@ drives the CLI. Human-readable output stays the default.
 
 ```
 $ aontu
-Aontu v0.50.1 REPL — :help for commands, :quit to exit
+Aontu v0.53.0 REPL — :help for commands, :quit to exit
 aontu> port: *8080 | integer
 {
   "port": 8080
@@ -914,13 +967,10 @@ under its own name; the bundled one is engine-owned.
 
 **Relation checks.** `relationCheck(src)` in TypeScript and
 `Aontu.RelationCheck(src)` in Go run the
-[declared-relation](reference-language.md#declared-relations) checks —
-acyclicity and inverse consistency — over the derived edge set, and
-return `{verdict, findings}` with `verdict` one of `pass`, `fail` or
-`error`. `aontu relations <file>` is the same report from the command
-line (`--format json` for the machine-readable form). Findings are
-sorted by the position of the offending edge, so the report diffs
-cleanly.
+[declared-relation](reference-language.md#declared-relations) checks
+over the derived edge set, returning the `{verdict, findings}` record
+that [`aontu relations`](#aontu-relations) prints — that section has
+the verdicts, the finding fields, and the exit codes.
 
 **The derived graph.** After a unification, an evaluated document's
 identity structure is observable too (G4):

--- a/docs/reference-language.md
+++ b/docs/reference-language.md
@@ -1252,7 +1252,7 @@ directory**, so a chain of files (a → b → c) each resolves relative to
 itself. Absolute paths ignore the base. Resolution tries, in order, an
 in-memory resolver,
 the filesystem, then package resolution (see
-[API reference](reference-api.md#options)). A conflict between a loaded
+[API reference](reference-api.md#aontuoptions)). A conflict between a loaded
 value and a local one is a normal unification
 error.
 

--- a/docs/reference-language.md
+++ b/docs/reference-language.md
@@ -1182,6 +1182,13 @@ b: id(b) & { usedBy:    [&: refer(), a] }
 - **`inverse: <name>`** — for each `a --dependsOn--> b`, `b` must carry
   `a` under `<name>`. The report names the exact missing entry.
 
+The `$.std.Relation` conjunct **documents** the declaration; it is not
+what makes it one. The checking pass reads every map under `relations`
+and takes its `acyclic` and `inverse` fields directly, so a bare
+`dependsOn: { inverse: usedBy, acyclic: true }` declares the same
+relation with no `@"std/system"` — which is what keeps the checks
+available under the `'none'` include capability.
+
 `aontu relations <file>` runs them, and the library exposes
 `relationCheck(src)`. **Neither is a lattice constraint, deliberately.**
 Both properties are global and non-monotone: an acyclic graph becomes

--- a/docs/skill/error-codes.md
+++ b/docs/skill/error-codes.md
@@ -32,3 +32,23 @@ because that is the one to edit.
 For a conflict, `aontu why <path> mine.aon` lists every contribution
 to that path with its role and source line, which turns "these
 disagree" into "these two lines disagree".
+
+Then fix it:
+
+```
+aontu set '$.replicas=5' --entry schema.aon --overlay mine.aon --in-place
+```
+
+`--in-place` rewrites the pinned literal **where it was written**, so
+comments and layout survive. Without it, `set` APPENDS — which is the
+right thing when the document left a hole, and cannot work when it
+pinned the wrong value, because unification only narrows.
+
+The edit is verified before a byte is written: a site carries the
+source text it covers, and the text at the span must match it. Where
+that cannot be established — the value comes from a `&:` template or a
+`$ref`, two statements pin the path, the site names the opening token
+of a compound like `min(1)`, or the overlay `@"includes"` another
+document — the assignment is appended as usual and a **warning** says
+which case it hit. A warning never changes the verdict, so asking for
+`--in-place` cannot make a run fail that would have succeeded.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -1,6 +1,6 @@
 # The Aontu trust contract
 
-*Status: normative (v0.51 line). This document states the guarantees an
+*Status: normative (v0.53 line). This document states the guarantees an
 agent harness — or any host — may rely on when evaluating an Aontu
 document, and exactly where each guarantee is conditional today. It is
 the written half of capability G5

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -620,7 +620,14 @@ the JSON and SARIF report forms, `--watch`, and the rest.
 And that is the loop the whole command surface exists for: **emit** a
 document, **vet** it against the truth it has to satisfy, and when it
 fails let the two sites and `aontu why` tell you where to **repair**
-it. You have now done it once by hand.
+it. You have now done it once by hand — which is the point of doing it
+here, because the last step is the one you have to understand before
+you let a command do it for you.
+
+`aontu set '$.service.port=8080' --entry service.aon --overlay prod.aon
+--in-place` is that command; the
+[how-to guides](how-to.md#change-a-value-that-is-already-pinned) show
+what it will and will not rewrite, and why.
 
 ## Where to go next
 


### PR DESCRIPTION
A documentation pass after #74–#78 landed, held to the split `docs/index.md` declares: a tutorial teaches, a how-to gives the recipe, a reference is exhaustive, and only the explanation argues.

**No source changed.** `make test` 3757/3757, `make cov` 100% both ports.

## The hole in the exhaustive one

`aontu relations` had a line in the CLI synopsis and a paragraph under the library API, but **no section of its own** — so the one page that promises to be complete was the one place the verb could not be looked up. Ten of eleven verbs had a `### aontu <verb>` section; this was the eleventh.

It has one now: the `relations` root key convention, the finding fields (`at`, `code`, `relation`, `detail`), the `--format json` shape, and its three verdicts — `pass`/`fail`/`error`, *not* `vet`'s five, because there is no schema on the other side of this question so `incomplete` has nothing to mean. The transcript in it is real output, and identical in both ports. The library paragraph now points at the section instead of restating half of it.

## `--in-place` had reached two quadrants of four

It was in the how-to and the API reference. It is now also in:

- the **tutorial**'s closing — §13 walks the repair loop by hand, which is the point; the command that does it for you comes next, with a pointer to what it will and will not rewrite
- the **index**'s verb map
- the **agent skill**'s repair loop, which stopped at diagnosis (`vet` → `why`) and now ends with the fix

## The explanation gained the argument

Previously it lived only in commit messages and design notes: why appending is the default (order-independence, not a gap in the tooling); why the deferred comment-preserving CST was a prerequisite for a *different job* — a CST is what you need to re-serialise, and replacing one value serialises nothing; why a site names a **token** and what that does to `min(1)`, `1+2`, `{b:1}`; why the candidate text is parsed **alone** and required to mean the contribution's canon rather than checked against a list of safe shapes (`0x1F` falls out editable without being named); and why a load in the overlay is refused rather than detected — the include collision is the case where verification *passes* and is still wrong, because the premise underneath it fails.

## The how-to gave that up and gained a recipe

The eight lines reasoning about the include collision moved to the explanation. In their place is what a reader actually needs:

```sh
$ aontu set '$.a=5' --entry schema.aon --overlay inc.aon --in-place
verdict: valid
replaced: inc.aon:1:4 42 -> 5
```

— how to edit a value that lives in an include, plus the trap: name an entry that `@"includes"` the overlay and the value meets *itself*, verdict `invalid`, nothing written, `would replace:` telling you the edit was possible and the conflict was elsewhere. Measured in both ports before it was written down; they agree byte for byte.

## Two claims had outlived their premise

- **`trim --check`** was justified by "rewriting the file in place needs a format-preserving editor (G7)" — which `set --in-place` disproved. The real reason is stated instead: deleting an entry is a different edit from replacing one, and a statement's span does not say which surrounding blank line or trailing comment went with it.
- **`AGENTS.md`** described the CI workflow as a tree under `ci/` to be copied over `.github`. That directory does not exist and never did; the workflow is live at `.github/workflows/build.yml` with three jobs.

## Smaller repairs

Two internal links pointed at nothing (`reference-api.md#options` → `#aontuoptions`; `ci/`), the how-to's contents list was missing its newest section, a REPL transcript still showed `v0.50.1`, and the trust contract was still stamped `v0.51`. A link/anchor audit across `docs/`, `README.md`, `AGENTS.md`, `ADR.md` and `CHANGELOG.md` now reports zero problems.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4tqDSoQA7nBPNBmbrRzfL)_