### PR TITLE
Plan aontu.dev, and rename the Go module to aontu-lang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ implementations are checked against the same cases.
 │   ├── dist/            # committed compiled JS + .d.ts (incl. cli.js)
 │   └── dist-test/       # committed compiled tests (the run target)
 └── go/                  # Go port
-    ├── go.mod           # module github.com/rjrodger/aontu/go
+    ├── go.mod           # module github.com/aontu-lang/aontu/go
     ├── *.go             # package aontu (incl. check.go: Check -> []Problem)
     ├── lsp/             # LSP library (Diagnostics + Handler)
     ├── cmd/aontu/       # `aontu` CLI (package main, file/stdin/REPL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here. The TypeScript
 package (`ts/`, npm `aontu`) and the Go module (`go/`,
-`github.com/rjrodger/aontu/go`) are versioned independently; entries note
+`github.com/aontu-lang/aontu/go`) are versioned independently; entries note
 which implementation each change affects.
 
 ## Unreleased — TypeScript 0.53.0 line

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Aontu ships two implementations, kept in parity (structure inspired by
 
 - **TypeScript** in [`ts/`](ts/) — the canonical implementation
   (published to npm as `aontu`).
-- **Go** in [`go/`](go/) — a port (`github.com/rjrodger/aontu/go`) that
+- **Go** in [`go/`](go/) — a port (`github.com/aontu-lang/aontu/go`) that
   mirrors the core unification semantics.
 
 Both are checked against a single, language-agnostic test suite in
@@ -71,7 +71,7 @@ what is currently published, and the
 exactly what has landed.
 
 Install with `npm i -g aontu` (Node) or
-`go install github.com/rjrodger/aontu/go/cmd/aontu@latest` (Go). From a
+`go install github.com/aontu-lang/aontu/go/cmd/aontu@latest` (Go). From a
 clone: `node ts/dist/cli.js …` or, inside `go/`, `go run ./cmd/aontu …`.
 
 ## Documentation

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -66,7 +66,7 @@ it drives the CLI (full table in the
 [API reference](reference-api.md#command-line-interface)).
 
 Get the command with `npm i -g aontu` (or `npx aontu`) for Node, or
-`go install github.com/rjrodger/aontu/go/cmd/aontu@latest` for Go. From a
+`go install github.com/aontu-lang/aontu/go/cmd/aontu@latest` for Go. From a
 clone, use `node ts/bin/aontu.js …` or `go run ./cmd/aontu …`.
 
 ## Call Aontu from TypeScript
@@ -88,7 +88,7 @@ unresolved or schema-bearing result rather than a final value.
 ## Call Aontu from Go
 
 ```go
-import aontu "github.com/rjrodger/aontu/go"
+import aontu "github.com/aontu-lang/aontu/go"
 
 a := aontu.New()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,12 @@ documents argue and specify; what each verb actually does is in the
 been built phase by phase is recorded in the
 [progress register](capability-review/progress.md).
 
+The project site — [aontu.dev](https://aontu.dev), not yet live — is
+planned in [`site/`](site/index.md): what it serves, and where each
+page's content comes from (this documentation set is *rendered* there,
+not rewritten). The steps that stand it up outside a session are in
+[`site/manual-tasks.md`](site/manual-tasks.md).
+
 ### Why the split?
 
 The four kinds of document answer four different questions and are kept

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ This repository ships **two implementations kept in parity**:
 - **TypeScript** in [`../ts/`](../ts/) — the canonical implementation,
   published to npm as [`aontu`](https://npmjs.com/package/aontu).
 - **Go** in [`../go/`](../go/) — a port
-  (`github.com/rjrodger/aontu/go`) that mirrors the core semantics.
+  (`github.com/aontu-lang/aontu/go`) that mirrors the core semantics.
 
 Both are checked against one language-agnostic test suite in
 [`../test/spec/`](../test/spec/).

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -114,7 +114,7 @@ The library (layers 1–2) does **not** depend on the bundled stdio server,
 so a third party can build a server on a different transport while reusing
 all the analysis and protocol logic:
 
-- **Go**: import `github.com/rjrodger/aontu/go/lsp`. The package has no
+- **Go**: import `github.com/aontu-lang/aontu/go/lsp`. The package has no
   dependency on `cmd/aontu-lsp` (verifiable with
   `go list -deps ./lsp | grep cmd` → empty). Drive `lsp.NewHandler()` with
   decoded `lsp.Message` values and write back the returned `lsp.Out`s over
@@ -313,10 +313,10 @@ without real stdio. Most users want the `aontu-lsp` binary instead.
 
 ### Go library
 
-Import `github.com/rjrodger/aontu/go/lsp`.
+Import `github.com/aontu-lang/aontu/go/lsp`.
 
 ```go
-import "github.com/rjrodger/aontu/go/lsp"
+import "github.com/aontu-lang/aontu/go/lsp"
 ```
 
 #### `func Diagnostics(src string) []Diagnostic`

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -845,7 +845,7 @@ one that does not pays nothing. Diagnostics are unchanged either way.
 - **TypeScript:** the npm package declares a `bin` named `aontu`
   (`dist/cli.js`), so `npm install -g aontu` (or `npx aontu`) provides
   it. From a clone: `node ts/dist/cli.js …`.
-- **Go:** `go install github.com/rjrodger/aontu/go/cmd/aontu@latest`, or
+- **Go:** `go install github.com/aontu-lang/aontu/go/cmd/aontu@latest`, or
   from a clone: `go run ./cmd/aontu …` (inside `go/`).
 
 Both commands accept the same options and produce the same results.
@@ -1291,10 +1291,10 @@ eventually forgets, and the forgetting is silent.
 
 ## Go API
 
-Module `github.com/rjrodger/aontu/go`, package `aontu`.
+Module `github.com/aontu-lang/aontu/go`, package `aontu`.
 
 ```go
-import aontu "github.com/rjrodger/aontu/go"
+import aontu "github.com/aontu-lang/aontu/go"
 ```
 
 ### type `Aontu`

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -241,17 +241,22 @@ sync machinery has proven itself on the simpler docs.
 None of these are website work, but the site is where each becomes
 visible, so they want settling before launch rather than after:
 
-- **The GitHub org moved to `aontu-lang`, and the repo has not caught
-  up.** `README.md`'s badges point at `rjrodger/aontu`;
-  `ts/scripts/prepack.js` rewrites a link into
-  `https://github.com/rjrodger/aontu/blob/main/`; `docs/index.md` names
-  the Go module as `github.com/rjrodger/aontu/go` and `go/go.mod`
-  declares it. A site that links its own source has to pick one, and
-  every one of those is a link the site would inherit.
-- **The Go module path** is the sharp end of the same question. Renaming
-  it to `github.com/aontu-lang/aontu/go` breaks every importer, which
-  pre-1.0 is a cost worth paying once and never again — but it is a
-  deliberate decision, not a find-and-replace.
+- **The Go module path is renamed** — `github.com/aontu-lang/aontu/go`,
+  in `go/go.mod` and in every import, install line and doc that stated
+  it. Deliberate, not a find-and-replace: it breaks every importer,
+  which pre-1.0 is a cost worth paying once and never again. Existing
+  `go/v*` tags keep resolving under the old path, because their own
+  `go.mod` still declares it; tags cut after the rename require the new
+  one.
+- **Two references to the old owner remain, by choice.** `README.md`'s
+  badges, and the `REPO` constant in `ts/scripts/prepack.js` that is
+  baked into every published tarball's `skill/error-codes.md`. Both are
+  *repository URLs* rather than module paths, and GitHub redirects them.
+  The badges additionally point at services — Coveralls, Snyk, DeepScan,
+  CodeClimate — registered against the old path, so rewriting the URL
+  without re-pointing the service breaks the badge rather than fixes it.
+  A site that links its own source still has to pick one, and each of
+  those is a link the site would inherit.
 - **npm stays unscoped.** `aontu` is published and the name is held;
   there is no reason to move to `@aontu/aontu`. Worth *reserving* the
   `aontu` npm org anyway so `@aontu/*` cannot be squatted (see

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,0 +1,421 @@
+# aontu.dev — the project site
+
+*Status: plan. Nothing here is built yet. This document decides what the
+site is and where every piece of its content comes from; the maintainer
+steps that have to happen outside a session — Cloudflare, GitHub, npm,
+DNS — are broken out in [`manual-tasks.md`](manual-tasks.md).*
+
+The domain `aontu.dev` is owned. The site it should serve is the
+project site for [`aontu-lang/aontu`](https://github.com/aontu-lang/aontu):
+what Aontu is, the documentation set, and — with equal weight — the
+machine surfaces an agent needs to use Aontu without a human in the
+loop.
+
+The template is **[tabnas.dev](https://tabnas.dev)** (`tabnas/web`): an
+Astro site, statically rendered, deployed to Cloudflare Workers, with a
+hand-written request Worker in front of the assets for content
+negotiation. That stack is not being re-evaluated here. What this
+document decides is the part a copy cannot decide for you: which of
+tabnas.dev's answers are about tabnas and which are about running a
+project site at all.
+
+**Colour, logo and typography are deliberately out of scope.** Launch
+on tabnas.dev's neutral structure with its brand tokens replaced by
+greys, and treat the visual identity as a later, separable change. The
+seam for that is real, not aspirational — see [Theming](#theming).
+
+## The two audiences
+
+tabnas.dev is written for humans and agents at once, and aontu has the
+stronger claim to that shape: the
+[capability review](../capability-review/index.md) exists precisely
+because the question was "what does Aontu lack in order to serve as
+ground truth *for agents*". G7 built the machine-facing access surface —
+`get`, `why`, `set`, the delivery skin. A site that documents that work
+in prose alone would be answering its own brief in the wrong format.
+
+So the site has two front doors, and neither is a courtesy version of
+the other:
+
+- **A reader** gets pages: what unification is, a tutorial, how-to
+  recipes, the language and API references, the trust contract.
+- **An agent** gets the same content as markdown at the same URLs
+  (`Accept: text/markdown`), plus the things prose cannot carry — the
+  error-code registry as JSON, the published grammar for constrained
+  decoding, the skill pack, the MCP handshake, an `llms.txt` map.
+
+## Decisions
+
+### D1 — The site lives in a new repo, `aontu-lang/web`
+
+Mirrors `tabnas/web` — org-scoped, so the name needs no adjectives.
+
+Not a directory inside `aontu-lang/aontu`: the site depends on the
+*published* `aontu` package (see D3), so keeping it in the engine repo
+would put a consumer of version N beside the source of version N+1 and
+invite the two to be silently wired together. It also keeps the engine
+repo's `make test` free of an Astro build, and lets the site deploy on
+merge without every engine commit triggering a deploy.
+
+Consequence: the site is a **fourth thing to keep in step** with the
+engine, alongside `ts/`, `go/` and the shared spec. D3 is how that stays
+honest rather than aspirational.
+
+### D2 — The site *renders* the documentation; it does not *author* it
+
+This is the decision that most differs from the template, and it is
+forced by something aontu already has and tabnas does not.
+
+`ts/test/docs.test.ts` requires every `aontu`-fenced block in
+`docs/index.md`, `tutorial.md`, `how-to.md` and `reference-language.md`
+to parse, and every one followed by a `json` fence to evaluate to
+exactly that. `ts/test/skill.test.ts` does the same for `docs/skill/`.
+The documentation set is *already* held to the engine, in the repo where
+the engine lives, by a gate that runs on every `make test`.
+
+tabnas/web authors its documentation in the site repo and executes its
+examples there (`examples/<id>/`, `tools/test-examples.mjs`). Copying
+that model here would mean writing a second copy of the tutorial, the
+how-to guides and the reference — and this project has already written
+down what happens next, in
+[`AGENTS.md`](../../AGENTS.md#known-tsgo-divergences):
+
+> Kept in one place deliberately: the same divergence had been described
+> in an AGENTS.md section, a ledger comment and an upstream doc, and they
+> drifted apart — the ledger claimed a behaviour was still divergent for
+> some time after it had been aligned.
+
+The [progress register](../capability-review/progress.md) exists for the
+same reason. A hand-written second copy of the docs on a website is that
+failure with a public URL on it.
+
+**So: `docs/*.md` is synced into the site repo, generated and committed,
+and rendered.** Site-only pages — the landing page, "why Aontu", the
+community and comparison pages — are authored in the site repo, because
+they have no counterpart in the engine repo to drift from.
+
+The rule to hold: *if a page states what the engine does, the engine
+repo is where it is written.* The site may frame it, link it, and set it
+in type; it may not restate it.
+
+### D3 — What comes from npm, what comes from git, and what is committed
+
+`ts/scripts/prepack.js` stages two out-of-package trees into the tarball
+at pack time — `grammar/` and `docs/skill/` → `skill/` — and rewrites
+their relative links so they resolve inside the package. So the
+published `aontu` package really does carry the grammar and the skill.
+It does **not** carry `docs/` or `test/spec/`: the same script rewrites
+`skill/error-codes.md`'s link to `test/spec/errcodes.tsv` into an
+absolute repository URL, precisely because that tree "the tarball does
+not ship at ALL".
+
+That splits the sources three ways:
+
+| Content | Source | How it reaches the site |
+|---|---|---|
+| The engine itself (examples on site-authored pages, `/versions.json`) | `aontu` npm package, pinned exactly | `npm ci` |
+| `grammar/aontu.gbnf`, `grammar/aontu.lark` | `node_modules/aontu/grammar/` | read at build time |
+| The skill pack (`SKILL.md`, `grammar-card.md`, `examples.md`, `error-codes.md`) | `node_modules/aontu/skill/` | read at build time |
+| The Diátaxis docs (`index`, `tutorial`, `how-to`, `reference-language`, `reference-api`, `explanation`, `trust`, `lsp`, `shared-spec`) | `aontu-lang/aontu` git, at the tag matching the pin | **synced and committed** |
+| The error-code registry (297 rows, code/class/since) | `test/spec/errcodes.tsv` in git | **synced and committed**, emitted as JSON |
+| Capability review G1–G8 + progress register | git | **synced and committed** (optional; see D6) |
+
+"Synced and committed" is the template's own idiom, not an invention:
+`tabnas/web` commits generated `src/data/*.json` "because neither source
+can be imported", regenerates with `npm run gen-ax-data`, and fails the
+build on staleness with `npm run check-ax`. The same two scripts here:
+
+```sh
+npm run sync-docs     # rewrite src/content/** and src/data/** from a sibling
+                      # ../aontu checkout at the pinned tag
+npm run check-sync    # fail if what is committed is not what that tag holds
+```
+
+`check-sync` says nothing when the sibling is absent, so a Cloudflare
+build — which clones only the site repo — is unaffected. It is a
+contributor-side and CI-side gate, in the same shape as `check-ax`.
+
+**Pin the version exactly** (`"0.53.0"`, never `"^0.53.0"`).
+`tabnas/web`'s README records what a caret range costs pre-1.0: the site
+"sat on a stale `abnf` pin long enough to document a *fixed compiler bug*
+as intended behaviour."
+
+Two things the sync must do that a copy would get wrong, both of which
+`prepack.js` has already had to solve for the tarball:
+
+1. **Rewrite relative links.** `docs/index.md` links `../ts/`,
+   `skill/SKILL.md`, `../../grammar/aontu.gbnf`. On the web those are
+   URLs on the site or on GitHub, and which of the two is a per-link
+   decision (a link into `ts/src/` is a source link; a link to
+   `tutorial.md` is a site route).
+2. **Assert every rewrite applied.** `prepack.js` throws when a link it
+   means to rewrite is no longer present, on the grounds that shipping
+   it unrewritten is exactly the failure the script exists to prevent.
+   The sync takes the same line: an unmatched rewrite fails the sync, it
+   does not warn.
+
+### D4 — Deployment is copied verbatim from the template
+
+Cloudflare Workers, `output: "static"`, Cloudflare's own Git
+integration. **Merging to `main` is the deploy step**; there is no
+workflow file, and its absence is not an oversight. `npm run deploy` is
+the Builds pipeline's own command and must not be run from a working
+tree — that is how a stale `dist/` reaches production.
+
+Copy as-is: `wrangler.json` (rename the Worker to `aontu-web`, routes
+`aontu.dev` and `www.aontu.dev` as custom domains, both recorded in the
+file rather than left in the dashboard), `.assetsignore`,
+`upload_source_maps`, observability.
+
+The hand-written `src/worker.ts` carries over whole, because all four
+behaviours it exists for are wanted here:
+
+1. `Accept: text/markdown` on a page URL serves that page's markdown
+   twin from the same URL, with `Vary: Accept`.
+2. Structured JSON errors on the machine surface (`/api/`,
+   `/.well-known/`, anything ending `.json`/`.yaml`/`.tsv`).
+3. A recoverable 404 — markdown for a bare client, the designed page
+   for a browser, an error object for a program, all three offering the
+   same entry points.
+4. Headers the files cannot carry: a content type for
+   `/.well-known/mcp`, CORS on the public descriptions.
+
+Plus the `www` → apex 301, without which both hosts serve every page.
+
+Two traps the template already documents and a fresh copy would walk
+into: Astro middleware cannot do any of this (the Cloudflare adapter
+short-circuits prerendered routes to `ASSETS` before middleware runs),
+and a static route's response headers are discarded at build time.
+
+### D5 — The playground is phase 4, behind a spike
+
+tabnas.dev's playground imports `@tabnas/parser` into a browser script
+tag and runs the real engine client-side. The same move for aontu does
+not work off the shelf: `ts/src/lang.ts` imports `existsSync`,
+`readFileSync` and `realpathSync` from `node:fs`, `ts/src/type.ts`
+imports `node:fs`, and `ts/src/hcanon.ts` imports `node:crypto`.
+
+It is not obviously hard, either. `lang.ts` already takes a `hostfs`
+injection point — `null == hostfs ? { existsSync, readFileSync } : {…}` —
+which is exactly the seam a browser build needs, and `memfs` is already
+a devDependency of the engine. So the shape of the answer is a bundler
+alias plus an injected filesystem, and `hcanon`'s `createHash` is the
+one genuinely awkward import.
+
+Two candidate resolutions, and the spike decides:
+
+- **Site-side**: Vite aliases for `node:fs`/`node:path`/`node:crypto`,
+  with the playground evaluating single in-memory sources only (no
+  `@"file"` includes). Cheap, but the site owns a shim for someone
+  else's module graph.
+- **Engine-side**: the `aontu` package grows a browser export condition
+  with the node-only paths excluded. More work, benefits every
+  downstream browser consumer, and belongs to the engine repo where the
+  test suites are.
+
+Engine-side is the better answer if the spike says it is affordable. It
+is not on the launch path either way: a REPL is one `npx` away, and the
+site links it.
+
+### D6 — What ships at launch, and what is a page too far
+
+The engine repo holds a great deal of material that is *about the
+project* rather than *about using it*: the capability review's eight gap
+documents, the progress register, `DIVERGENCE.md`, `ADR.md`,
+`use-cases/` with its eleven executed cases, `REVIEW.md`, `BUGS.md`.
+
+Launch renders the **user-facing** set (D3's table, rows 1–5) and links
+the rest to GitHub. The capability review is a strong candidate for the
+site later — it is the most direct evidence that the agent-facing claims
+were designed rather than asserted — but it is a large, cross-linked
+corpus whose sync rules are its own problem, and it does not block a
+launch.
+
+`use-cases/` is the interesting middle case: eleven executed,
+enterprise-shaped models are the best "does this actually work at scale"
+evidence the project has. Phase 4, as a `/use-cases` section, once the
+sync machinery has proven itself on the simpler docs.
+
+### D7 — The identity questions the site will force
+
+None of these are website work, but the site is where each becomes
+visible, so they want settling before launch rather than after:
+
+- **The GitHub org moved to `aontu-lang`, and the repo has not caught
+  up.** `README.md`'s badges point at `rjrodger/aontu`;
+  `ts/scripts/prepack.js` rewrites a link into
+  `https://github.com/rjrodger/aontu/blob/main/`; `docs/index.md` names
+  the Go module as `github.com/rjrodger/aontu/go` and `go/go.mod`
+  declares it. A site that links its own source has to pick one, and
+  every one of those is a link the site would inherit.
+- **The Go module path** is the sharp end of the same question. Renaming
+  it to `github.com/aontu-lang/aontu/go` breaks every importer, which
+  pre-1.0 is a cost worth paying once and never again — but it is a
+  deliberate decision, not a find-and-replace.
+- **npm stays unscoped.** `aontu` is published and the name is held;
+  there is no reason to move to `@aontu/aontu`. Worth *reserving* the
+  `aontu` npm org anyway so `@aontu/*` cannot be squatted (see
+  manual task D3).
+- **The Voxgig sponsorship banner** in `README.md` — decide whether it
+  appears on the site, and where. tabnas.dev's answer is a `/sponsors`
+  page rather than a masthead.
+
+### D8 — Publishing and npm trust are already solved, with one catch
+
+`.github/workflows/publish.yml` already publishes `aontu` over OIDC
+trusted publishing — no `NPM_TOKEN`, provenance attached automatically.
+The site repo publishes nothing and needs no npm trust of its own.
+
+The catch is the org rename. A trusted-publisher record names a
+repository and a workflow filename, and the workflow's own header says
+so: "the trusted publisher must be registered on npmjs.com against THIS
+filename (publish.yml) — renaming this file breaks publishing until the
+npm-side config is updated to match." If the record still says
+`rjrodger/aontu` while the workflow now runs in `aontu-lang/aontu`, the
+next release fails at the publish step — after the tag has been pushed.
+Manual task D1 is to check that before it is discovered by a release.
+
+## Route map
+
+Reader-facing:
+
+| Route | Content |
+|---|---|
+| `/` | What Aontu is, the 30-second taste, install |
+| `/why` | Why unification rather than merge/override — site-authored |
+| `/docs` | The Diátaxis set, synced (D3) |
+| `/docs/tutorial`, `/docs/how-to`, `/docs/reference-language`, `/docs/reference-api`, `/docs/explanation` | ditto |
+| `/docs/trust` | The trust contract |
+| `/docs/lsp` | Language server + editor wiring |
+| `/tools` | CLI verbs, LSP, MCP server, `vet-action`, editor plugins |
+| `/comparisons` | Aontu vs CUE, JSON Schema, Jsonnet, Dhall — site-authored |
+| `/community`, `/faq`, `/sponsors` | Site-authored |
+
+Agent-facing, all generated, none hand-edited:
+
+| Route | Built from |
+|---|---|
+| `/llms.txt`, `/llms-full.txt` | nav + the synced docs collection |
+| `/<page>.md` | the built HTML, converted (`tools/gen-markdown.mjs`) |
+| `/errors`, `/errors/<code>`, `/errors.json`, `/errors/<code>.json` | `test/spec/errcodes.tsv` → `src/data/error-codes.json` |
+| `/skills`, `/skills/aontu` | `node_modules/aontu/skill/` |
+| `/.well-known/mcp` | the six `aontu-mcp` tools — `vet`, `get`, `why`, `diff`, `canon`, `summary` |
+| `/grammar/aontu.gbnf`, `/grammar/aontu.lark` | `node_modules/aontu/grammar/` |
+| `/versions.json` | the pin, plus the engine's own `VERSION`, spec-suite size and error-code count |
+| `/openapi.json`, `/openapi.yaml`, `/api` | `src/openapi.ts` |
+| `/robots.txt`, `/sitemap-index.xml` | routes / `@astrojs/sitemap` |
+
+Two of these are aontu-specific and worth calling out as the reason an
+agent would come to this domain at all rather than to GitHub:
+
+**`/grammar/aontu.gbnf` is a stable URL for a constrained-decoding
+grammar.** The repo holds it and a test pins it to accept every
+canonical form the shared suite produces; a model host that wants to
+emit valid Aontu needs to *fetch* it, and a raw GitHub URL is not a
+contract.
+
+**`/errors/<code>` is the registry, not a copy of it.** 297 rows with a
+class and a `since` version, held to both engines by set equality in
+`ts/test/spec.test.ts` and `go/spec_test.go`. Serve the class and the
+version; serve the *message text* nowhere — tabnas's rule that a
+plugin's message stays in its own catalogue applies with more force
+here, where the engines are the catalogue and the test suite proves it.
+
+Follow the template's other standing rule too: **do not restate a
+version**. The pin and the engine's own `VERSION` are different facts;
+where both are visible, state both.
+
+## Theming
+
+Colour and identity are deferred, and the template makes deferring cheap:
+`src/styles/tokens.css` is a three-layer system — raw brand scales, then
+semantic tokens (`--bg`, `--ink`, `--primary`, …) that components
+actually use, then back-compat aliases. Components never reference a raw
+scale.
+
+So launch replaces layer 1 with a neutral grey scale and leaves layers 2
+and 3 untouched. Adopting a real identity later is an edit to one file.
+
+Carry over the accessibility discipline with it: tabnas's tokens record
+which pairs meet WCAG AA and which colour is decorative-only. A grey
+launch palette should be AA by construction so that the later brand work
+is a change against a known-good baseline rather than a first attempt.
+
+Fonts: the template self-hosts (`public/fonts/`, `src/styles/fonts.css`)
+and preloads three faces. Launch with a system font stack — no files, no
+preloads, no decision — and revisit with the identity.
+
+## Phases
+
+**Phase 0 — decisions and prerequisites.** D1, D2, D7 settled. Manual
+tasks A1–A2, B1, C1 done (domain into Cloudflare, `aontu-lang/web`
+created). Nothing to build until the repo exists.
+
+**Phase 1 — the site stands up.** Scaffold from `tabnas/web`; strip
+every tabnas-specific page and asset; neutral tokens; `astro.config.mjs`
+with `site: "https://aontu.dev"`; `wrangler.json` as `aontu-web`; the
+landing page and one synced doc page end to end. *Exit:* it builds, and
+Cloudflare serves it on a `workers.dev` subdomain.
+
+**Phase 2 — content and the sync.** `sync-docs` + `check-sync`; the full
+Diátaxis set rendered; the error registry emitted as JSON; Pagefind
+search; `src/worker.ts` and the markdown twins; the site-authored pages.
+*Exit:* `npm run check` passes — `check-sync`, `test-examples`, build,
+`tsc`, `npm test`, `wrangler deploy --dry-run`.
+
+**Phase 3 — the agent surfaces and cutover.** `llms.txt`, `/skills`,
+`/.well-known/mcp`, `/grammar/*`, `/versions.json`, OpenAPI. Then the
+custom domains, the `www` → apex 301, and analytics. *Exit:* `aontu.dev`
+serves the site; `curl -H 'Accept: text/markdown' https://aontu.dev/docs`
+returns markdown.
+
+**Phase 4 — the rest.** Playground (D5), brand identity, `/use-cases`,
+the capability review, MCP registry listing.
+
+## Gates
+
+`npm run check` is the gate and it runs locally, exactly as in the
+template — where the README is blunt that green PR checks "are not
+evidence the site works". Its steps here:
+
+```
+check-sync       committed docs/registry == the pinned tag
+test-examples    every fenced aontu/json pair on a SITE-AUTHORED page,
+                 run through the pinned engine — the same rule
+                 ts/test/docs.test.ts applies in the engine repo
+build            astro build + pagefind + gen-markdown
+tsc              types
+test             node --test test/*.test.mjs (worker + artifacts)
+wrangler deploy --dry-run
+```
+
+`test-examples` covers site-authored pages *only*. Synced pages are
+already held by `ts/test/docs.test.ts` upstream, and re-running them here
+would be a second gate on the same fact — which is the thing D2 exists to
+prevent. It is worth a comment in the script saying so, because the
+absence looks like an oversight.
+
+## Risks
+
+- **The sync goes stale in the gap between an engine release and a site
+  bump.** `check-sync` catches a mismatch against the *pin*, not against
+  the newest release. The template has the same hole and answers it with
+  a standing rule ("always use the latest modules") plus Renovate; adopt
+  both.
+- **Rendering someone else's markdown breaks in ways authoring does
+  not** — heading levels, relative links, `@"…"` includes in fences that
+  reference sibling files the site does not ship. `ts/test/docs.test.ts`
+  already excludes multi-file examples for this reason; the site's
+  renderer needs the same exclusion and should say why.
+- **The identity questions in D7 get answered by the site instead of by
+  a decision** — whichever org and module path the site ships with
+  becomes the de facto answer.
+
+## Recording the decision
+
+When the site is built, D2 — *the site renders, it does not author* —
+belongs in [`ADR.md`](../../ADR.md) as a new entry at the next free
+number. It is exactly the kind of decision that file exists for: cheap
+to reverse by accident, expensive to have reversed, and invisible in the
+diff that reverses it. The other decisions here are implementation
+choices and stay in this document.

--- a/docs/site/manual-tasks.md
+++ b/docs/site/manual-tasks.md
@@ -189,21 +189,27 @@ Match the template's posture:
 
 Not site work, but the site will publish whichever answer it finds
 ([plan D7](index.md#d7--the-identity-questions-the-site-will-force)).
-Three places still name the old owner:
 
-| Where | What it says |
-|---|---|
-| `README.md` badges | `rjrodger/aontu` — build, coverage, Snyk, DeepScan, CodeClimate |
-| `ts/scripts/prepack.js` | `REPO = 'https://github.com/rjrodger/aontu/blob/main/'`, baked into every published tarball's `skill/error-codes.md` |
-| `go/go.mod`, `docs/index.md`, `README.md` | module `github.com/rjrodger/aontu/go` |
+**The module path is done** — `github.com/aontu-lang/aontu/go`, in
+`go/go.mod` and every import, install line and doc that stated it. Two
+references to the old owner are left standing, and both want a
+credential or a click before the URL can honestly change:
 
-The first two are edits a session can make on your word. **The third is
-your decision**: renaming the Go module to
-`github.com/aontu-lang/aontu/go` breaks every importer, and pre-1.0 is
-the cheapest this will ever be.
+| Where | What it says | Why it is still yours |
+|---|---|---|
+| `README.md` badges | `rjrodger/aontu` — build, coverage, Snyk, DeepScan, CodeClimate | Each badge is a *service* registered against the old path. Rewriting the URL first breaks the badge; re-point the project in Coveralls, Snyk, DeepScan and CodeClimate, then the URL follows. |
+| `ts/scripts/prepack.js` | `REPO = 'https://github.com/rjrodger/aontu/blob/main/'`, baked into every published tarball's `skill/error-codes.md` | A repository URL, not a module path, and GitHub redirects it. Safe to change on your word — it just wants a release to take effect. |
 
-**Hand back:** rename the module, or keep it and have the site document
-`github.com/rjrodger/aontu/go` as the import path.
+A third sits alongside them: `go/report_sarif.go` and its TypeScript
+twin both emit `informationUri: "https://github.com/rjrodger/aontu"`,
+held byte-identical across the two ports by the golden
+`test/spec/files/vet-sarif/expect.sarif`. Changing it means all three
+files plus a rebuild of the committed `ts/dist` — a deliberate edit, not
+a sweep.
+
+**Hand back:** say the word and the `prepack.js` constant and the SARIF
+URI go in one commit; the badges after you have re-pointed the four
+services.
 
 ### C5. Decide the sponsorship treatment
 
@@ -290,6 +296,7 @@ Blocking, in order:
 
 Then B4 at cutover, and D1 before the next engine release.
 
-Decisions I need from you before the scaffold can be written: the repo
-name (C1), which Cloudflare account (A1), the Go module path (C4), the
-sponsorship treatment (C5), and the analytics token or a "no" (B5).
+Decisions I need from you before the scaffold can be written: which
+Cloudflare account (A1), the sponsorship treatment (C5), and the
+analytics token or a "no" (B5). The repo name (C1) is settled as
+`aontu-lang/web`, and the Go module path (C4) is renamed.

--- a/docs/site/manual-tasks.md
+++ b/docs/site/manual-tasks.md
@@ -1,0 +1,295 @@
+# aontu.dev — maintainer tasks
+
+The steps for standing up [aontu.dev](index.md) that **cannot** be done
+from an agent session: they need credentials, a web UI, DNS control, or
+a decision that is yours. Everything else is session work and is not
+listed here.
+
+Order matters in two places only, and both are marked. The rest can be
+done in any order, and several can wait until the phase that needs them.
+
+Each task says what to do, how to check it worked, and — where relevant
+— **what to hand back**, meaning a value or a decision a session needs
+before it can write the corresponding config.
+
+---
+
+## A. Domain and DNS
+
+### A1. Add `aontu.dev` as a zone in Cloudflare
+
+Cloudflare dashboard → *Add a site* → `aontu.dev` → Free plan is
+sufficient (the site is static assets on Workers).
+
+**Decide first:** the same Cloudflare account as `tabnas.dev`, or a
+separate one? Same account is simpler — one dashboard, one set of build
+credentials, and the Workers Builds GitHub App is already installed.
+Separate is cleaner if aontu is ever to be owned or transferred
+independently. There is no technical reason the Worker and the zone must
+share an account with tabnas; there *is* a requirement that the zone and
+the Worker share an account with **each other**, because a
+`custom_domain` route can only bind to a zone in the Worker's own
+account.
+
+**Hand back:** which account, and whether it is the tabnas one.
+
+### A2. Point the registrar's nameservers at Cloudflare
+
+At whoever `aontu.dev` is registered with, replace the nameservers with
+the two Cloudflare gives you in A1.
+
+**Verify:** the zone flips to *Active* in the Cloudflare dashboard
+(minutes to a few hours), and:
+
+```sh
+dig +short NS aontu.dev        # expect the two ns.cloudflare.com names
+```
+
+> **Ordering constraint.** A1 and A2 must complete before the deploy
+> that carries the custom-domain routes (B4). They do **not** block
+> anything earlier: phase 1 deploys to a `workers.dev` subdomain and
+> needs no DNS at all. So start A1/A2 now and let them propagate while
+> the site is being built.
+
+### A3. Decide the canonical host
+
+`aontu.dev` apex, with `www.aontu.dev` 301-ing to it — matching
+tabnas.dev, and matching what `src/worker.ts` already implements. Both
+are registered as custom domains on the same Worker; the redirect is
+code, not DNS.
+
+Say so explicitly if you want the opposite (`www` canonical), because it
+inverts the redirect at the top of the Worker's `fetch()`.
+
+**Hand back:** confirmation, or the other choice.
+
+---
+
+## B. Cloudflare
+
+### B1. Authorize the Workers Builds GitHub App on `aontu-lang`
+
+Cloudflare dashboard → *Workers & Pages* → *Create* → *Import a
+repository*. If the GitHub App is installed for `tabnas` but not
+`aontu-lang`, you will be prompted to install it; grant it access to
+`aontu-lang/web` **only**, not all repositories.
+
+*Depends on C1 — the repo must exist to be selected.*
+
+### B2. Create the Worker and connect the build
+
+Same flow: pick `aontu-lang/web`, production branch `main`.
+
+| Setting | Value |
+|---|---|
+| Worker name | `aontu-web` |
+| Build command | `npm run build` |
+| Deploy command | `npm run deploy` |
+| Root directory | `/` |
+| `NODE_VERSION` (build env var) | `24` |
+
+Two notes on that table. The deploy command is `npm run deploy` **on
+purpose**: it is the pipeline's own deploy step, which is why the same
+script must never be run from a working tree — doing so publishes
+whatever `dist/` happens to be sitting there. And `NODE_VERSION=24`
+rather than the Astro minimum, because the `aontu` package declares
+`engines: {"node": ">=24"}` and the build imports it.
+
+**Verify:** merging to `main` produces a build in *Workers & Pages →
+aontu-web → Deployments*, and the site answers on
+`aontu-web.<subdomain>.workers.dev`.
+
+### B3. Confirm no stale secrets on the Worker
+
+New Worker, so there should be none. Worth one look at *Settings →
+Variables and Secrets* after the first deploy: the template carries a
+note that `tabnas-web` was left holding an inert `SITE_PASSWORD` from a
+since-removed Basic-Auth gate. Don't inherit a habit of leaving them.
+
+### B4. Attach the custom domains — *phase 3, after A2 is Active*
+
+`wrangler.json` declares them:
+
+```json
+"routes": [
+  { "pattern": "aontu.dev", "custom_domain": true },
+  { "pattern": "www.aontu.dev", "custom_domain": true }
+]
+```
+
+so they are attached by the deploy, not by clicking — provided the zone
+is active in the same account (A1). Nothing to do in the dashboard
+except watch it work. Keeping the routes in the file is deliberate:
+tabnas's lived in the dashboard until August 2026, "which meant nothing
+in this repo recorded what actually served the site."
+
+**Verify:**
+
+```sh
+curl -sI https://aontu.dev/            | head -1   # 200
+curl -sI https://www.aontu.dev/        | head -1   # 301 -> https://aontu.dev/
+curl -s -H 'Accept: text/markdown' https://aontu.dev/docs | head -5
+```
+
+### B5. Web Analytics beacon — optional
+
+*Analytics → Web Analytics → Add a site* → `aontu.dev`. Copy the beacon
+token and set it as a **build** environment variable in B2:
+
+```
+PUBLIC_CF_BEACON = <token>
+```
+
+Cookieless, so no consent banner. If it is unset the analytics component
+renders nothing at all, so skipping this is a supported state rather
+than a broken one.
+
+**Hand back:** the token, or "no analytics".
+
+---
+
+## C. GitHub
+
+### C1. Create `aontu-lang/web`
+
+Public, empty (no auto-generated README — the scaffold brings its own),
+MIT to match the org. Description: *Source of aontu.dev — the project
+site and documentation for Aontu.*
+
+**This blocks B1/B2 and all site work.** It is the one task that gates
+everything.
+
+**Hand back:** confirmation of the name. `web` mirrors `tabnas/web`; say
+so now if you would rather have `site` or `aontu.dev`, because it is
+cheap today and a rename later moves the Cloudflare build connection
+with it.
+
+### C2. Grant this Claude session access to the new repo
+
+The session's repository scope is fixed at start. Once C1 exists, either
+grant access at <https://claude.ai/admin-settings/claude-tag> (org
+owner) or reconnect GitHub under *Settings → Connectors*, and tell me —
+I can then attach it to a session and push the scaffold.
+
+Until then, no session can write to it.
+
+### C3. Repository settings on `aontu-lang/web`
+
+Match the template's posture:
+
+- Branch protection / ruleset on `main`: require a pull request, no
+  force-push, no deletion.
+- CodeQL **default setup** (*Settings → Code security*) — one click.
+- Disable Issues if the engine repo is the intended front door for bug
+  reports, or leave them on and say in the README which repo takes what.
+- Actions: nothing to enable. The site has **no** workflows by design;
+  the build is Cloudflare's.
+
+### C4. Settle the org-rename leftovers in `aontu-lang/aontu`
+
+Not site work, but the site will publish whichever answer it finds
+([plan D7](index.md#d7--the-identity-questions-the-site-will-force)).
+Three places still name the old owner:
+
+| Where | What it says |
+|---|---|
+| `README.md` badges | `rjrodger/aontu` — build, coverage, Snyk, DeepScan, CodeClimate |
+| `ts/scripts/prepack.js` | `REPO = 'https://github.com/rjrodger/aontu/blob/main/'`, baked into every published tarball's `skill/error-codes.md` |
+| `go/go.mod`, `docs/index.md`, `README.md` | module `github.com/rjrodger/aontu/go` |
+
+The first two are edits a session can make on your word. **The third is
+your decision**: renaming the Go module to
+`github.com/aontu-lang/aontu/go` breaks every importer, and pre-1.0 is
+the cheapest this will ever be.
+
+**Hand back:** rename the module, or keep it and have the site document
+`github.com/rjrodger/aontu/go` as the import path.
+
+### C5. Decide the sponsorship treatment
+
+`README.md` carries a Voxgig banner. Does it appear on the site, and
+where? tabnas.dev's answer is a `/sponsors` page rather than anything in
+the masthead.
+
+**Hand back:** page, masthead, footer, or nothing.
+
+---
+
+## D. npm
+
+### D1. Verify the trusted-publisher record survived the org rename
+
+**Do this before the next release, not after.** `publish.yml` publishes
+`aontu` over OIDC with no token, and a trust record names a *repository*
+and a *workflow filename*. If the record still says `rjrodger/aontu`,
+the next release fails at the publish step — after the version bump and
+the tag have already been pushed.
+
+```sh
+npm i -g npm@latest        # need >= 11.15.0 for `npm trust`
+npm login                  # account-level 2FA required
+npm trust list aontu
+```
+
+Expect a record naming repository `aontu-lang/aontu` and file
+`publish.yml`. If it names the old repo, add the correct one:
+
+```sh
+npm trust github aontu --file publish.yml --repo aontu-lang/aontu --allow-publish
+```
+
+Three things the fleet already learned the hard way, from
+`tabnas/admin`'s `rollout/setup-npm-trusted-publishing.sh`:
+
+- `npm trust` is **interactive** — it prints a summary, asks to proceed,
+  and on first use prints an auth URL and waits on ENTER. Do not pipe or
+  capture it; it will look frozen while it blocks on stdin.
+- A `409` means a record already exists. That is success, not failure.
+- `npm trust list`'s output format has changed between npm majors and
+  broken scripts that parsed it. Read it yourself here rather than
+  grepping.
+
+The first call prompts for a 2FA OTP and then lets you skip 2FA for
+about five minutes.
+
+### D2. The site repo needs no npm anything
+
+`aontu-lang/web` publishes nothing — no package, no Go module, no
+trusted publisher, no `NPM_TOKEN`. It only *consumes* `aontu` from the
+public registry. Listed so its absence reads as a decision.
+
+### D3. Reserve the `aontu` npm org — optional
+
+The package `aontu` is unscoped and yours, and the plan keeps it that
+way. Creating the free `aontu` org anyway costs nothing and stops
+someone else publishing `@aontu/anything` with your name on it.
+
+---
+
+## E. Later, and explicitly not blocking
+
+| Task | When |
+|---|---|
+| Register the MCP server in the public registry (`registry.modelcontextprotocol.io`) so agents can discover `aontu-mcp` by name | After `/.well-known/mcp` is live (phase 3) |
+| Install Renovate on `aontu-lang` so the exact `aontu` pin gets a bump PR on each release | Phase 2+, once the pin exists to bump |
+| A status/measure dashboard, as `tabnas/status` does via GitHub Pages | Phase 4 |
+| Decide whether `docs.aontu.dev` or `mcp.aontu.dev` are ever wanted as separate Workers | Not now — the apex serves both |
+| Brand: logo, palette, typography | Deliberately deferred; see [Theming](index.md#theming) |
+
+---
+
+## The short version
+
+Blocking, in order:
+
+1. **C1** — create `aontu-lang/web`.
+2. **C2** — grant session access to it.
+3. **A1 + A2** — `aontu.dev` into Cloudflare, nameservers switched. Start
+   these now; they propagate while the site is built.
+4. **B1 + B2** — connect the repo to Workers Builds as `aontu-web`.
+
+Then B4 at cutover, and D1 before the next engine release.
+
+Decisions I need from you before the scaffold can be written: the repo
+name (C1), which Cloudflare account (A1), the Go module path (C4), the
+sponsorship treatment (C5), and the analytics token or a "no" (B5).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -52,7 +52,7 @@ package main
 
 import (
 	"fmt"
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 func main() {

--- a/go/cmd/aontu-lsp/main.go
+++ b/go/cmd/aontu-lsp/main.go
@@ -5,7 +5,7 @@
 // diagnostics as you edit `.aontu` files.
 //
 // This binary is intentionally thin: all protocol logic lives in the
-// reusable library github.com/rjrodger/aontu/go/lsp (Handler +
+// reusable library github.com/aontu-lang/aontu/go/lsp (Handler +
 // Diagnostics). Editors typically launch it with no arguments:
 //
 //	aontu-lsp
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rjrodger/aontu/go/lsp"
+	"github.com/aontu-lang/aontu/go/lsp"
 )
 
 func main() { //coverage:ignore run under GOCOVERDIR by `make cov-go`

--- a/go/cmd/aontu-lsp/serve_test.go
+++ b/go/cmd/aontu-lsp/serve_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rjrodger/aontu/go/lsp"
+	"github.com/aontu-lang/aontu/go/lsp"
 )
 
 // A non-EOF read error is logged and stops the loop with exit 1.

--- a/go/cmd/aontu/agentsmd.go
+++ b/go/cmd/aontu/agentsmd.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const agentsMdHelp = "aontu agentsmd <file> (try --help)"

--- a/go/cmd/aontu/get.go
+++ b/go/cmd/aontu/get.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const getHelp = "aontu get <path> <file> (try --help)"

--- a/go/cmd/aontu/hash.go
+++ b/go/cmd/aontu/hash.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const hashHelp = "aontu hash <file> (try --help)"

--- a/go/cmd/aontu/main.go
+++ b/go/cmd/aontu/main.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const helpText = `Usage: aontu [options] [file]

--- a/go/cmd/aontu/main_test.go
+++ b/go/cmd/aontu/main_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 func TestRenderJSON(t *testing.T) {

--- a/go/cmd/aontu/mod.go
+++ b/go/cmd/aontu/mod.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const modHelp = "aontu mod tidy|vendor|manifest [dir] (try --help)"

--- a/go/cmd/aontu/mod_test.go
+++ b/go/cmd/aontu/mod_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const modToolSource = "name: string\nport: *8080 | integer\n"

--- a/go/cmd/aontu/relations.go
+++ b/go/cmd/aontu/relations.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const relationsHelp = "aontu relations <file> (try --help)"

--- a/go/cmd/aontu/repl.go
+++ b/go/cmd/aontu/repl.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 type replState struct {

--- a/go/cmd/aontu/run_test.go
+++ b/go/cmd/aontu/run_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 func TestRunHelpVersionAndBadOption(t *testing.T) {

--- a/go/cmd/aontu/set.go
+++ b/go/cmd/aontu/set.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const setHelp = "aontu set <path>=<value> --entry <file> --overlay <file> (try --help)"

--- a/go/cmd/aontu/subsume.go
+++ b/go/cmd/aontu/subsume.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const subsumeHelp = "aontu subsume <general> <specific> (try --help)"

--- a/go/cmd/aontu/trim.go
+++ b/go/cmd/aontu/trim.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const trimHelp = "aontu trim --check <file> (try --help)"

--- a/go/cmd/aontu/vet.go
+++ b/go/cmd/aontu/vet.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const vetHelp = "aontu vet <schema> <data> [more-data...] (try --help)"

--- a/go/cmd/aontu/why.go
+++ b/go/cmd/aontu/why.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const whyHelp = "aontu why <path> <file> (try --help)"

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/rjrodger/aontu/go
+module github.com/aontu-lang/aontu/go
 
 go 1.24.7
 

--- a/go/lsp/handler.go
+++ b/go/lsp/handler.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 // Version is reported to the client in the initialize response. It is

--- a/go/lsp/hover_test.go
+++ b/go/lsp/hover_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 func TestHoverScalar(t *testing.T) {

--- a/go/lsp/lsp.go
+++ b/go/lsp/lsp.go
@@ -21,7 +21,7 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 // Severity values (a subset of the LSP DiagnosticSeverity enum).

--- a/ts/README.md
+++ b/ts/README.md
@@ -68,7 +68,7 @@ root — whenever the source is not yours. See
 ## Two implementations, one specification
 
 TypeScript (this package) is canonical; a Go port
-(`github.com/rjrodger/aontu/go`) mirrors it. Both are checked against
+(`github.com/aontu-lang/aontu/go`) mirrors it. Both are checked against
 one language-agnostic suite of `.tsv` rows, so the same document means
 the same thing in a Node agent harness and a Go gateway.
 


### PR DESCRIPTION
Two commits. The first is documents only; the second is a breaking module rename that the first one's C4 asked for.

## 1 — `9a426cc` The aontu.dev plan

`docs/site/index.md` (the plan), `docs/site/manual-tasks.md` (the maintainer steps), and a link to both from `docs/index.md`.

The domain is owned and **tabnas.dev is the template** — Astro, `output: "static"`, Cloudflare Workers, Cloudflare's own Git integration, and a hand-written request Worker in front of the assets for markdown content negotiation. That stack carries over whole and is not re-litigated here.

### The site renders the documentation; it does not author it

`tabnas/web` authors its docs in the site repo and executes its examples there. Here the documentation set is **already** held to the engine, in the engine's own repo: `ts/test/docs.test.ts` requires every `aontu`-fenced block in `index.md`, `tutorial.md`, `how-to.md` and `reference-language.md` to parse, and every one followed by a `json` fence to evaluate to exactly that; `ts/test/skill.test.ts` does the same for `docs/skill/`.

A second, hand-written copy on a website is the drift this project has diagnosed in writing and refused more than once — the divergence ledger, the capability-review progress register, and AGENTS.md's own "kept in one place deliberately". So the site syncs `docs/*.md` and renders it, and only pages with no upstream counterpart (landing, why, comparisons, community) are authored in the site repo. That decision earns an `ADR.md` entry at the next free number when the site is built.

### Where each piece comes from is already decided by `prepack.js`

`ts/scripts/prepack.js` stages `grammar/` and `docs/skill/` into the npm tarball at pack time, so those reach the site as an ordinary dependency of the pinned `aontu` package. It ships neither `docs/` nor `test/spec/` — which is precisely why the same script rewrites `skill/error-codes.md`'s link to `errcodes.tsv` into an absolute repository URL. So those two are synced from git and committed, in the same generated-and-committed shape `tabnas/web` already uses for `src/data/*.json`, with a `check-sync` staleness gate that stays quiet when the sibling checkout is absent.

Also recorded: the playground is phase 4 behind a spike (`lang.ts` and `type.ts` import `node:fs`, `hcanon.ts` imports `node:crypto`; `lang.ts`'s existing `hostfs` seam is the way in, but a `browser` export condition on this package is probably the better fix); `/errors/<code>` serves the registry's class and `since` and never the message text; the published grammar gets a stable URL, because a constrained-decoding host needs to fetch it and a raw GitHub link is not a contract.

## 2 — `f9f96cf` Rename the Go module

`github.com/rjrodger/aontu/go` → `github.com/aontu-lang/aontu/go`, in `go/go.mod` and in every import, install line and doc that stated it. Breaking, and deliberately so: pre-1.0 is the cheapest this will ever be, and the planned site would otherwise publish the old path as the project's own answer to "how do I import this".

Existing `go/v*` tags keep resolving under the old path — their own `go.mod` still declares it — so nothing already published moves. Tags cut after this require the new path.

The rule was narrow on purpose: **every occurrence of `github.com/rjrodger/aontu/go` changes and nothing else does.** `rjrodger/aontu` also appears as a *repository URL* in the README badges, the editor plugins, the `vet-action` `uses:` lines, `ts/package.json`'s homepage and the SARIF `informationUri` — none of those is a module path, and three stay put for a reason now recorded in `manual-tasks.md` C4:

- the README badges point at Coveralls, Snyk, DeepScan and CodeClimate projects registered against the old path, so rewriting the URL first breaks the badge instead of fixing it;
- `prepack.js`'s `REPO` constant and `ts/package.json`'s homepage are URLs GitHub already redirects;
- `go/report_sarif.go`'s `informationUri` is held byte-identical to its TypeScript twin by the golden `test/spec/files/vet-sarif/expect.sarif`, so it moves as its own commit with a `ts/dist` rebuild attached.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — clean under the new path, shared spec suite included.
- `cd ts && npm test` — 3757 tests, 0 failures.
- `node --test dist-test/docs.test.js` — passes against the edited `docs/index.md`; the plan commit's addition there is prose and links only, and the file's fenced-block count is unchanged, which is all `docs.test.ts` reads.

One thing found in passing and **not** touched: `go/aontu` is a 5.4 MB compiled Linux binary committed in `fda55ee`. It still carries the old module path in its debug info and cannot be fixed by a text edit. Deleting it is its own decision.