### PR TITLE
Fix the build main is currently red on, and correct the plan

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ vulnerability by definition.
 | Distribution | Package | Supported |
 |---|---|---|
 | npm (TypeScript, canonical) | [`aontu`](https://npmjs.com/package/aontu) | the latest published release only |
-| Go module | `github.com/rjrodger/aontu/go` (tags `go/vX.Y.Z`) | the latest published tag only |
+| Go module | `github.com/aontu-lang/aontu/go` (tags `go/vX.Y.Z`) | the latest published tag only |
 
 The project is pre-1.0 with a single maintainer. There are no
 long-term-support branches: a fix ships as a new release of each

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -359,8 +359,17 @@ created). Nothing to build until the repo exists.
 **Phase 1 — the site stands up.** Scaffold from `tabnas/web`; strip
 every tabnas-specific page and asset; neutral tokens; `astro.config.mjs`
 with `site: "https://aontu.dev"`; `wrangler.json` as `aontu-web`; the
-landing page and one synced doc page end to end. *Exit:* it builds, and
-Cloudflare serves it on a `workers.dev` subdomain.
+landing page and one synced doc page end to end. *Exit:* `npm run check`
+passes and Cloudflare's build of `main` succeeds.
+
+> **This exit criterion originally read "Cloudflare serves it on a
+> `workers.dev` subdomain", and that was wrong.** That route is off for
+> Workers on this account, and the 404 it returns is indistinguishable
+> from a broken Worker — `tabnas-web.<subdomain>.workers.dev` answers
+> `error code: 1042` while `tabnas.dev` serves every page. So phase 1
+> has no externally reachable URL to check, and the first real
+> end-to-end verification is the cutover in phase 3. Which is how it
+> actually went.
 
 **Phase 2 — content and the sync.** `sync-docs` + `check-sync`; the full
 Diátaxis set rendered; the error registry emitted as JSON; Pagefind

--- a/docs/site/manual-tasks.md
+++ b/docs/site/manual-tasks.md
@@ -12,6 +12,38 @@ Each task says what to do, how to check it worked, and — where relevant
 — **what to hand back**, meaning a value or a decision a session needs
 before it can write the corresponding config.
 
+## Where this stands
+
+**aontu.dev is live.** Verified against the running Worker on
+2026-08-27: markdown negotiation returns `text/markdown` with
+`Vary: Accept`, `www` 301s to the apex, `/nope` answers markdown and
+`/nope.json` a structured error with CORS, `POST` answers 405.
+
+| | Task | State |
+|---|---|---|
+| A1 | Cloudflare zone (same account as tabnas) | **done** |
+| A2 | Nameservers → `fred`/`sofia.ns.cloudflare.com` | **done** |
+| A3 | Apex canonical, `www` redirects | **done** |
+| B1 | Workers Builds GitHub App on `aontu-lang` | **done** |
+| B2 | Worker `aontu-web` + build connection | **done** |
+| B3 | No stale secrets | not checked |
+| B4 | Custom domains attached | **done** |
+| B5 | Web Analytics beacon | open — needs a token or a "no" |
+| C1 | `aontu-lang/web` created | **done** |
+| C2 | Claude GitHub App on the org | **done** |
+| C3 | Repository settings, branch protection, CodeQL | open |
+| C4 | Org-rename leftovers | Go module **renamed**; badges + `prepack.js` open |
+| C5 | Sponsorship treatment | open — needs a decision |
+| D1 | npm trusted-publisher record after the rename | **open, and has a deadline** |
+
+D1 is the one that bites if left: a stale record fails the next release
+*after* the tag is pushed.
+
+One thing the build carries that this file did not ask for: the build
+token is `tabnas-web-01`, reused rather than minted, because a build
+token is account-scoped and A1 chose one account. Nothing is broken, but
+the name now lies about what it serves — see the note under B2.
+
 ---
 
 ## A. Domain and DNS
@@ -47,9 +79,12 @@ dig +short NS aontu.dev        # expect the two ns.cloudflare.com names
 
 > **Ordering constraint.** A1 and A2 must complete before the deploy
 > that carries the custom-domain routes (B4). They do **not** block
-> anything earlier: phase 1 deploys to a `workers.dev` subdomain and
-> needs no DNS at all. So start A1/A2 now and let them propagate while
-> the site is being built.
+> anything earlier: the phases before it never resolve the hostname. So
+> start A1/A2 now and let them propagate while the site is built.
+>
+> They do, however, gate the first VERIFICATION — see B2, which
+> originally promised a `workers.dev` URL that this account does not
+> serve.
 
 ### A3. Decide the canonical host
 
@@ -95,9 +130,23 @@ whatever `dist/` happens to be sitting there. And `NODE_VERSION=24`
 rather than the Astro minimum, because the `aontu` package declares
 `engines: {"node": ">=24"}` and the build imports it.
 
-**Verify:** merging to `main` produces a build in *Workers & Pages →
-aontu-web → Deployments*, and the site answers on
-`aontu-web.<subdomain>.workers.dev`.
+**Verify:** merging to `main` produces a successful build in *Workers &
+Pages → aontu-web → Deployments*. **That is the whole check available at
+this point** — do not reach for a `workers.dev` URL.
+
+That route is off for Workers on this account, and its 404 is
+indistinguishable from a broken Worker. Established by comparison rather
+than assumed:
+
+```
+tabnas-web.<subdomain>.workers.dev  ->  404, "error code: 1042"   # live site
+aontu-web.<subdomain>.workers.dev   ->  404, "error code: 1042"   # identical
+tabnas.dev                          ->  200
+```
+
+A known-healthy Worker returns byte-identical garbage, so the response
+says nothing about health. The first URL that can actually be checked is
+the custom domain, at B4.
 
 ### B3. Confirm no stale secrets on the Worker
 
@@ -286,17 +335,21 @@ someone else publishing `@aontu/anything` with your name on it.
 
 ## The short version
 
-Blocking, in order:
+The blocking chain — C1, C2, A1+A2, B1+B2, then B4 — is **done**, and
+the site is serving from the apex.
 
-1. **C1** — create `aontu-lang/web`.
-2. **C2** — grant session access to it.
-3. **A1 + A2** — `aontu.dev` into Cloudflare, nameservers switched. Start
-   these now; they propagate while the site is built.
-4. **B1 + B2** — connect the repo to Workers Builds as `aontu-web`.
+What is left, in the order it will hurt if ignored:
 
-Then B4 at cutover, and D1 before the next engine release.
+1. **D1** — check the npm trusted-publisher record survived the org
+   rename. Before the next release, not after: a stale record fails at
+   the publish step once the tag is already pushed.
+2. **C4** — the README badges and `prepack.js`'s `REPO` constant still
+   name the old owner. The badges need their services re-pointed first;
+   the constant is a word from you.
+3. **B5 / C5** — the analytics token (or a "no"), and where the
+   sponsorship goes.
+4. **C3** — branch protection and CodeQL on `aontu-lang/web`. It has no
+   workflows by design, so a Cloudflare build check is its only CI.
 
-Decisions I need from you before the scaffold can be written: which
-Cloudflare account (A1), the sponsorship treatment (C5), and the
-analytics token or a "no" (B5). The repo name (C1) is settled as
-`aontu-lang/web`, and the Go module path (C4) is renamed.
+None of these block the site. All of them are cheaper now than after
+they are forgotten.

--- a/go/cmd/aontu/color_test.go
+++ b/go/cmd/aontu/color_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 func TestColorForDestination(t *testing.T) {

--- a/go/cmd/aontu/jsonschema.go
+++ b/go/cmd/aontu/jsonschema.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const jsonSchemaHelp = "aontu jsonschema [--at <path>] [--strict] <file> (try --help)"

--- a/go/cmd/aontu/reaches.go
+++ b/go/cmd/aontu/reaches.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"strings"
 
-	aontu "github.com/rjrodger/aontu/go"
+	aontu "github.com/aontu-lang/aontu/go"
 )
 
 const reachesHelp = "aontu reaches <from> <to> [--relation <name>] <file> (try --help)"


### PR DESCRIPTION
**`main` does not build right now, and this fixes it.** That turned up because this PR's CI went red — it was opened as docs-only.

## 1 — `48a1242` Finish the module rename over the files #81 added

```
cmd/aontu/jsonschema.go:25:2: no required module provides package github.com/rjrodger/aontu/go
```

A semantic merge conflict between [#81](https://github.com/aontu-lang/aontu/pull/81) and [#82](https://github.com/aontu-lang/aontu/pull/82) that neither git nor CI could see, and the cause is mine.

#82 was cut from `8d892a4` and renamed every occurrence of the module path **in the tree as it then stood**. #81 merged in between — 78 files, 6660 insertions — adding three `cmd/aontu` files that import the old path. The two diffs touch disjoint files, so git merged both without a conflict, and #82's checks ran against a head that predated #81 entirely.

Textually clean, semantically broken: **26 green checks on a change that could not build once it landed.**

The fix is the original rule applied to the files it never saw — `color_test.go`, `jsonschema.go`, `reaches.go` — plus `SECURITY.md`, which documents the module path and is one by the same rule.

Reproduced before fixing, per the CI-fix discipline:

```
# stashed:  cmd/aontu/jsonschema.go:25:2: no required module provides package …
# restored: build OK
```

`go build ./...`, `go vet ./...`, `go test ./...` all clean, shared spec suite included.

**The lesson, since the same trap is set for the next wide mechanical change:** a rename verified against its own branch proves nothing about the merge result once the base has moved. What would have caught it is running checks against the *merge* rather than the head — which is what a merge queue does, and what this repository does not have.

## 2 — `23af2ab` The plan promised a URL this account does not serve

Phase 1's exit criterion read *"Cloudflare serves it on a `workers.dev` subdomain"*, and manual task B2 said to verify there. Both wrong — that route is off for Workers on this account, and its 404 is indistinguishable from a broken Worker:

```
tabnas-web.<subdomain>.workers.dev  →  404, "error code: 1042"
aontu-web.<subdomain>.workers.dev   →  404, "error code: 1042"
tabnas.dev                          →  200
```

A demonstrably healthy Worker returns byte-identical garbage. So phase 1 has no externally reachable URL, and the first end-to-end check is the cutover — which is how it went.

`manual-tasks.md` now opens with where the rollout stands, since a checklist reading as entirely to-do is worse than none. **aontu.dev is live**, verified against the running Worker: markdown negotiation with `Vary: Accept`, `www` → apex 301, `/nope` as markdown and `/nope.json` as a structured error with CORS, `POST` → 405. What remains is ordered by cost of forgetting, with **D1** first — a stale npm trusted-publisher record fails the next release *after* the tag is pushed.

Also noted: the Workers Builds token is `tabnas-web-01`, reused rather than minted because build tokens are account-scoped. Nothing broken, but the name now lies about what it serves.