### PR TITLE
The plan said npm ships the grammar; that became true later

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -114,11 +114,27 @@ That splits the sources three ways:
 | Content | Source | How it reaches the site |
 |---|---|---|
 | The engine itself (examples on site-authored pages, `/versions.json`) | `aontu` npm package, pinned exactly | `npm ci` |
-| `grammar/aontu.gbnf`, `grammar/aontu.lark` | `node_modules/aontu/grammar/` | read at build time |
-| The skill pack (`SKILL.md`, `grammar-card.md`, `examples.md`, `error-codes.md`) | `node_modules/aontu/skill/` | read at build time |
-| The Diátaxis docs (`index`, `tutorial`, `how-to`, `reference-language`, `reference-api`, `explanation`, `trust`, `lsp`, `shared-spec`) | `aontu-lang/aontu` git, at the tag matching the pin | **synced and committed** |
-| The error-code registry (297 rows, code/class/since) | `test/spec/errcodes.tsv` in git | **synced and committed**, emitted as JSON |
+| The Diátaxis docs (`index`, `tutorial`, `how-to`, `reference-language`, `reference-api`, `explanation`, `trust`, `lsp`) | git | **synced and committed** |
+| The error-code registry (111 codes, code/class/since) | `test/spec/errcodes.tsv` in git | **synced and committed**, emitted as JSON |
+| `grammar/aontu.gbnf`, `grammar/aontu.lark` | git | **synced and committed**, byte-identical |
+| The skill pack | not yet served — see the phase list |
 | Capability review G1–G8 + progress register | git | **synced and committed** (optional; see D6) |
+
+> **Built differently from what this table first said, and the difference
+> is worth recording.** The original split the sources: npm for the
+> grammar and the skill, git for the docs and the registry, on the
+> strength of `ts/scripts/prepack.js` staging the first two into the
+> tarball. That staging is real — but it landed *after* `0.52.1` was
+> cut, so at the version the site first pinned the tarball held
+> `["bin","src","dist","LICENSE"]` and the npm route did not exist.
+>
+> `0.53.0` ships them, so the split is now possible. It was still not
+> taken. The sync already checks staleness, already fails on a broken
+> link, and already fails when the registry and its class table
+> disagree; a second npm-shaped path would add a mechanism without
+> adding a guarantee, and leave two answers to "where did this file come
+> from". `test/spec/errcodes.tsv` is in no tarball at any version in any
+> case. **npm stays the runtime dependency, not a content source.**
 
 "Synced and committed" is the template's own idiom, not an invention:
 `tabnas/web` commits generated `src/data/*.json` "because neither source
@@ -319,7 +335,7 @@ canonical form the shared suite produces; a model host that wants to
 emit valid Aontu needs to *fetch* it, and a raw GitHub URL is not a
 contract.
 
-**`/errors/<code>` is the registry, not a copy of it.** 297 rows with a
+**`/errors/<code>` is the registry, not a copy of it.** 111 codes with a
 class and a `since` version, held to both engines by set equality in
 `ts/test/spec.test.ts` and `go/spec_test.go`. Serve the class and the
 version; serve the *message text* nowhere — tabnas's rule that a
@@ -382,6 +398,28 @@ search; `src/worker.ts` and the markdown twins; the site-authored pages.
 custom domains, the `www` → apex 301, and analytics. *Exit:* `aontu.dev`
 serves the site; `curl -H 'Accept: text/markdown' https://aontu.dev/docs`
 returns markdown.
+
+> **What actually landed, and in what order.** The phases were not run
+> as written. Cutover (phase 3's tail) came *before* the agent surfaces,
+> because this account serves no `workers.dev` URL and the custom domain
+> was the first place anything could be verified at all. The surfaces
+> then followed onto a live site.
+>
+> Done: the sync and its link checker, the full Diátaxis set, the
+> markdown twins and the request Worker, both custom domains,
+> `/llms.txt` and `/llms-full.txt`, the error registry as pages and
+> JSON, `/grammar/*`, `/versions.json`. Still open from phases 2 and 3:
+> **Pagefind search**, **`/skills`** and **`/.well-known/mcp`**, the
+> **OpenAPI** document, and the site-authored pages beyond the landing
+> page (`/why`, comparisons, community).
+>
+> One thing the phase list never anticipated, and which cost the most:
+> the site pinned the newest *published* engine while rendering docs
+> from `main`, and for a while those were `0.52.1` and the `0.53.0`
+> line — an engine with no verbs at all, documenting thirteen. Closed
+> by the release on 2026-08-28. **A plan that syncs docs from one place
+> and runs code from another needs to say what happens while the two
+> disagree.** This one did not, and the gap it left was not small.
 
 **Phase 4 — the rest.** Playground (D5), brand identity, `/use-cases`,
 the capability review, MCP registry listing.

--- a/docs/site/manual-tasks.md
+++ b/docs/site/manual-tasks.md
@@ -14,10 +14,18 @@ before it can write the corresponding config.
 
 ## Where this stands
 
-**aontu.dev is live.** Verified against the running Worker on
-2026-08-27: markdown negotiation returns `text/markdown` with
-`Vary: Accept`, `www` 301s to the apex, `/nope` answers markdown and
-`/nope.json` a structured error with CORS, `POST` answers 405.
+**aontu.dev is live, and runs the engine it documents.** Verified
+against the running Worker on 2026-08-27: markdown negotiation returns
+`text/markdown` with `Vary: Accept`, `www` 301s to the apex, `/nope`
+answers markdown and `/nope.json` a structured error with CORS, `POST`
+answers 405.
+
+The machine surfaces followed — `/errors` and `/errors/<code>` over the
+111-code registry, `/errors.json`, `/grammar/*` byte-identical to
+source, `/versions.json`, `/llms-full.txt` — and the pin moved to
+`0.53.0` the day it shipped. Until then the site had been describing a
+verb surface `0.52.1` did not have; the landing page said so, and the
+test that made it say so deleted the caveat when the pin caught up.
 
 | | Task | State |
 |---|---|---|
@@ -352,12 +360,12 @@ What is left, in the order it will hurt if ignored:
    the constant is a word from you.
 2. **B5 / C5** — the analytics token (or a "no"), and where the
    sponsorship goes.
+3. **C3** — branch protection and CodeQL on `aontu-lang/web`. It has no
+   workflows by design; connecting Workers Builds gave it the one check
+   it does have, a real `npm ci && npm run build` on every pull request.
 
-**D1 is closed** — the 0.53.0 release published over OIDC on
-2026-08-28, which proves the trusted-publisher record survived the
-rename.
-4. **C3** — branch protection and CodeQL on `aontu-lang/web`. It has no
-   workflows by design, so a Cloudflare build check is its only CI.
+**D1 is closed** — the 0.53.0 release published over OIDC on 2026-08-28,
+which proves the trusted-publisher record survived the rename.
 
 None of these block the site. All of them are cheaper now than after
 they are forgotten.


### PR DESCRIPTION
Documents only — `docs/site/`. Brings the plan into line with the site that was actually built, now 0.53.0 has shipped.

## D3's source table was right, but early

It said the grammar and skill reach the site from npm, on the strength of `ts/scripts/prepack.js`. That staging is real — and landed *after* `0.52.1` was cut, so at the version the site first pinned there was no npm route at all: the tarball held `["bin","src","dist","LICENSE"]`.

`0.53.0` ships them and the split is finally possible. It was still not taken, and the table now says why: the sync already checks staleness, already fails on a broken link, and already fails when the registry and its class table disagree — a second path adds a mechanism without adding a guarantee, and `test/spec/errcodes.tsv` is in no tarball at any version regardless.

Also corrects **297 rows → 111 codes**. The 297 was the file's line count, comments and all.

## The phases were not run as written

Cutover came *before* the agent surfaces, because this Cloudflare account serves no `workers.dev` URL and the custom domain was the first place anything could be verified. The note now lists what is done and what is still open — Pagefind, `/skills`, `/.well-known/mcp`, OpenAPI, `/why` — rather than leaving it to be inferred from a phase number.

## And the omission that cost the most

The plan had the site pin the newest **published** engine while rendering documentation from **main**, and never said what happens while those disagree. For a while they were `0.52.1` and the `0.53.0` line — an engine with *no verbs at all*, documenting thirteen. The site shipped saying "run `aontu vet`" against a binary that could not.

A plan that reads code from one place and prose from another has to state that. This one did not, and it is now written down where the next such plan will find it.

## manual-tasks.md

Repairs the numbered list `e9a823c` left at 1, 2, 4 when D1 was lifted out of it; notes that `aontu-lang/web` is no longer without CI (Workers Builds runs on every pull request now); records the machine surfaces and the pin bump in the status block.

**D1's closure is left exactly as you wrote it.** "Proven by a green OIDC release" is a better argument than re-reading `npm trust list`, and I'd have written something weaker.

## Verification

`node --test dist-test/docs.test.js` passes (2/2). Prose, links and a table — no fenced `aontu` blocks added, which is all that test reads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6JJFKLqr2Ci1HwWTSK7iZ)_