### PR TITLE
Reconcile the orphaned constraint design; defer N3; two live defects

### DIFF
--- a/docs/capability-review/g1-constraint-algebra.md
+++ b/docs/capability-review/g1-constraint-algebra.md
@@ -4,7 +4,10 @@
 shared spec rows. Per-phase status, pins, the departures from this
 design and the corrections this document still needs are in the
 [progress register](progress.md), which is authoritative for status;
-this document is authoritative for design.
+this document is authoritative for design. A second, independent
+constraint design arrived on 2026-08-27 and is reconciled against what
+landed in [Reconciliation with the 2026-08-27 constraint design
+note](#reconciliation-with-the-2026-08-27-constraint-design-note).
 Part of the
 [capability review](index.md) (August 2026). This document expands the
 G1 entry in the review index: the vocabulary of constraint atoms, their
@@ -806,3 +809,96 @@ applied to the language itself.
   alternatives drive agent self-correction; the exact shape should
   be settled jointly with G2's report schema so the data is produced
   once, correctly.)
+
+## Reconciliation with the 2026-08-27 constraint design note
+
+[`docs/design/AONTUCONSTRAINTS.0.md`](../../docs/design/AONTUCONSTRAINTS.0.md)
+is a second, independent constraint design, uploaded to `main` on
+2026-08-27 in commit `8d892a4` — the only content of that commit. It was
+written downstream, from an empirical survey run through boru's
+`boru:parselang` module against **Go port v0.1.6**, and cross-checked
+against real `cue export` rather than against CUE's documentation. Until
+this section it was referenced by nothing in the repository.
+
+It is not a competing design. It surveyed a tree that predates most of
+G1's landing, and read as current it is misleading in both directions:
+it reports as broken two things that are now fixed, and it names one
+defect that is still live and that no phase here ever claimed.
+
+**Its §2 baseline, re-run 2026-08-28 against `aontu@0.53.0` and
+`go/v0.1.11`, both ports byte-identical unless noted.** Five of the
+twelve rows have changed since it was written:
+
+| Row | Note's finding (v0.1.6) | Today | Disposition |
+|-----|-------------------------|-------|-------------|
+| 1, 2, 6 | default selection, override, struct defaults OK | unchanged | — |
+| **3** | **D1**: `*"i"\|"d"\|"w"` & `"nope"` → `{a:'nope'}`, no validation | `[aontu/\|:empty]` "Empty disjunction" | **fixed** before the note was written, by the preference admission gate (ADR-004) |
+| **4** | **D2**: defaultless disjunct reports a *conflict* | `[aontu/disjunct_no_gen]`, "supply a value that selects one alternative, or write a preference (\*)" | **fixed** by ADR-007 |
+| **5** | D1 again via explicit `&` | `[aontu/\|:empty]` | fixed with row 3 |
+| **7** | **N1**: `a: >10` lexes as the string `">10"` | *unchanged* — `{"a":">10"}`, exit 0 | **still live**; see below |
+| **8** | **N2**: `a: =~"^ab"` is a lex error | *changed, still wrong* — lexes as a bare string | still live, with row 7 |
+| 9, 10, 11 | `&:` spreads and optional keys exist | unchanged | — |
+| 12 | `a: $.a` correctly refused | now `path_cycle` | — |
+
+**D1 and D2 were fixed independently, one day before the note landed.**
+The note root-caused D1 to `PrefVal.Unify`'s concrete-peer branch
+unifying the peer against the default's *kind* rather than its payload,
+and proposed fixing the disjunct trial. ADR-004 reached the same place
+from the other direction — an override must be *admitted by* its
+disjunction — and the note's `D1-a` recommendation (keep soft standalone
+`*x`, fix only the disjunct trial) is what the engine does:
+`a: *1  a: 2` gives `2`, and `a: *1  a: "x"` conflicts.
+
+**N1 and N2 landed as capabilities under different syntax.** The note
+proposed CUE's operators — `>10`, `>=10`, `=~"p"` — and budgeted a
+lexing break for them (§10: "N1 is a lexing break"). G1 phases 1–2 had
+already chosen **function atoms**: `min`, `max`, `above`, `below`, `neq`,
+`re`. That choice makes the note's headline compatibility risk moot —
+nothing had to break, because nothing was reused — and it is why phases
+1 and 2 shipped in a minor release. The note's `D6-a` ("string bounds:
+recommend yes-but-later") is also already in: `a: string & min("m")`
+admits `"zebra"` and refuses `"apple"`.
+
+**What the note asked for that this design did not, and still does not:**
+
+- **N3, key-pattern constraints** (`&"^env_": …`, scoping a constraint
+  to keys matching a pattern). **DEFERRED — 2026-08-28, maintainer
+  decision.** Not implemented; `&"…"` is a parse error in both ports,
+  identically. This is a deferral, not a blockage: it is the note's
+  most substantial unbuilt proposal, and it depends on nothing that is
+  missing — `re` gives the pattern machinery and `&:` spreads give the
+  scoping point, so the work is available whenever it is wanted.
+  Recorded so that a later reader finds a decision rather than an
+  oversight, and so that nobody re-derives the dependency analysis to
+  discover it was never the obstacle.
+- **Sized integer kinds** (`int8`, `uint16` as sugar for a bounded
+  `integer`). Not implemented; `a: int8` is the bare string `"int8"`.
+  The note called this a free win once bounds exist, and bounds exist.
+- **Row 7's defect itself.** The atom vocabulary landed; the silent
+  mislex the note called "worse than unsupported, since it produces a
+  well-formed wrong config" was never in a phase's scope, because
+  choosing function syntax removed the *need* to reuse `>` without
+  removing what `>` currently does. `port: >=1024` still evaluates to
+  `{"port":">=1024"}` and exits 0. Recorded as
+  [`use-cases/BUGS.md` §45](../../use-cases/BUGS.md).
+
+**What this design has that the note does not.** The note scoped the gap
+to "exactly three things" — D1, D2, and bounds/regex plus key patterns.
+G1 landed `length`, `unique` (with the `unique(k)` projector), `must`,
+cross-field residuation with a settle discipline, subsumption rules per
+atom, and the ADR-003 normalisation posture for `re` — which is stronger
+than the note's N2-a, and reached the opposite way. N2-a proposed pinning
+a portable **subset** and refusing outside it; three leaks in one day
+established that a blacklist cannot work, and `re` now *normalises* the
+pattern before either host engine sees it. The note's instinct (RE2 as
+the common denominator, to keep a hostile pattern from stalling a
+terminating language) is the same instinct ADR-003 acts on; the
+mechanism is not.
+
+**The note's method is worth keeping.** Its cross-check column ran real
+`cue export` rather than quoting CUE's documentation, and that is what
+let it state row 4's divergence precisely. Nothing in this repository
+does that today. If the compatibility story with CUE matters — and §1's
+positioning argument says it does — a differential corpus against a
+pinned `cue` binary belongs beside `regex-corpus.tsv`, and neither this
+document nor the register has ever proposed one.

--- a/docs/capability-review/index.md
+++ b/docs/capability-review/index.md
@@ -144,6 +144,19 @@ A related defect: both implementations pin numbers to IEEE-754 double
 semantics, so int64-scale values silently lose precision; CUE
 deliberately uses arbitrary-precision decimals.
 
+A **second, independent constraint design** —
+[`docs/design/AONTUCONSTRAINTS.0.md`](../design/AONTUCONSTRAINTS.0.md),
+written downstream from a boru survey and cross-checked against real
+`cue export` — arrived on 2026-08-27, after most of G1 had landed. Its
+disposition against the shipped engine is in
+[g1-constraint-algebra.md](g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note):
+the two defects it root-caused were already fixed, its bounds and regex
+landed under function syntax rather than the CUE operators it proposed,
+and its key-pattern constraints — the substantial piece still unbuilt —
+are deferred by decision rather than blocked.
+Read its §2 baseline as a snapshot of Go v0.1.6, not as current
+behaviour.
+
 ### G2 — The validation verb
 
 The canonical agent loop — *emit, validate, repair* — currently has no

--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -89,12 +89,18 @@ the divergence ledger, `Accepted`/`Superseded` in the ADR register).
    gap documents froze a row count into a "nothing may regress" clause;
    all eight are now wrong, by roughly 1,400 to 1,500 rows. A gap
    document should link this line instead: as of this
-   register's last update the suite is **86 `.tsv` files, 85
-   row-bearing, 3,099 rows**, in eighteen modes — `canon` 715, `gen`
-   545, `errc` 545, `gens` 491, `err` 246, `errcode` 100, `subsume` 94,
-   `query` 92, `vet` 55, `why` 43, `hcanon` 43, `graph` 28,
-   `diff` 28, `patch` 23, `relation` 21, `hash` 12, `trim` 11,
-   `agentsmd` 7.
+   register's last update the suite is **90 `.tsv` files, 89
+   row-bearing, 3,478 rows**, in twenty modes — `canon` 799, `errc`
+   612, `gen` 579, `gens` 523, `err` 246, `errcode` 111, `subsume` 101,
+   `query` 92, `vet` 88, `why` 54, `jsonschema` 54, `hcanon` 43,
+   `patch` 42, `relation` 35, `graph` 28, `diff` 28, `reaches` 13,
+   `hash` 12, `trim` 11, `agentsmd` 7.
+   (Re-derived 2026-08-28. The figures this line carried before —
+   86/85/3,099 in eighteen modes — were stale by four files and 379
+   rows, and omitted `jsonschema` and `reaches` entirely. They were
+   falsifiable in the two commands below, which is the point of
+   carrying them; nobody ran them. `status-2026-08-27.md` had the
+   right counts.)
    Reproduce with
    `ls test/spec/*.tsv | wc -l` and
    `cat test/spec/*.tsv | grep -P '\t' | grep -vc '^#'`.
@@ -170,9 +176,12 @@ Against the review's own [sequencing](index.md#sequencing):
   examples are executed. **G7 is complete** (G7.7):
   the REPL loads a document and answers `:get`, `:keys` and `:why`
   about it in both ports, and LSP hover can carry the provenance record
-  behind a config gate — but the `--jsonl` session mode that makes it
-  machine-drivable is unreachable in the Go CLI and TTY-gated in the
-  TypeScript one, so the phase stands PARTIAL.
+  behind a config gate. The `--jsonl` session mode that makes it
+  machine-drivable was the reason this phase read PARTIAL on 2026-08-21
+  — unreachable in the Go CLI, TTY-gated in the TypeScript one — and
+  was closed on 2026-08-24. Re-checked 2026-08-28: piping
+  `:load <file>` and `:get $.b.c` into `aontu --jsonl` answers one JSON
+  object per line, byte-identical in both ports.
 - **Phase C — scale.** G4 is complete, and so are G6 and G8. **G8**
   is the generation combinators: **G8.0**, the staging rule they all
   share, which replaced the pass-count hack the review named as the
@@ -342,6 +351,59 @@ preference meeting a constraint inside a conjunct (`min(1024) & *8080`)
 does not resolve to the default; the disjunct form does. See
 `docs/reference-language.md` and the comment above
 `constraint-bound.tsv:bound-pref-disjunct`.
+
+**A second constraint design landed on `main` and is now reconciled,
+2026-08-28.** [`docs/design/AONTUCONSTRAINTS.0.md`](../design/AONTUCONSTRAINTS.0.md)
+was uploaded in commit `8d892a4` as that commit's only content, written
+downstream from a boru survey of **Go port v0.1.6** and cross-checked
+against real `cue export`. Nothing in this repository referenced it. It
+is not a competing design — it surveyed a tree predating most of G1's
+landing — but read as current it misleads in both directions, so its
+disposition is recorded item by item in
+[g1-constraint-algebra.md](g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note)
+and its own header now says which parts are stale. In summary, with all
+twelve of its §2 rows re-run against `aontu@0.53.0` and `go/v0.1.11`:
+its **D1** and **D2** were fixed one day before it landed (ADR-004,
+ADR-007), and its `D1-a` recommendation is what the engine does; its
+**N1**/**N2** landed as capabilities under function syntax
+(`min`/`max`/`above`/`below`/`neq`/`re`) rather than the CUE operators
+it proposed, which is why the lexing break its §10 budgeted for never
+happened; its `D6-a` string bounds are in. **N3** key-pattern constraints
+(`&"^env_"` is a parse error in both ports) are **DEFERRED as of
+2026-08-28 by maintainer decision** — a choice, not a blockage: `re`
+supplies the pattern machinery and `&:` spreads the scoping point, so
+nothing is missing but the decision to build it. The sized-integer sugar
+(`int8` is the bare string `"int8"`) is likewise unbuilt and likewise
+unblocked, but carries no such decision. This phase set never scoped
+either.
+
+**One defect the note named is still live, and this register should not
+imply otherwise.** Its row 7 — `a: >10` lexing as the string `">10"`,
+which it called "worse than unsupported, since it produces a
+well-formed wrong config" — is unchanged: `port: >=1024` evaluates to
+`{"port":">=1024"}` and exits 0, in both ports. Choosing function
+syntax removed the *need* to reuse `>` without changing what `>`
+currently does, so the capability landed while the defect that motivated
+it went unaddressed. [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45.
+
+**And one this review found while reconciling.** A `&:` element spread
+occupies an index slot in the TypeScript port's error paths and not in
+Go's, so `l: [&: integer, 10, 20, "bad"]` reports `$.l.3` in TypeScript
+and `$.l.2` in Go — an ADR-001 divergence, with the canonical port on
+the wrong side of it: both ports' `get` answers `$.l.2` with the
+element, so TypeScript rejects, through `get`, the path its own
+`vet --format json` emits. It is the §41 defect (right site, wrong path)
+in the container §41's fix did not reach. Not entered in
+`test/spec/divergent.tsv`, which is for divergences that cannot be fixed
+here; this one can. [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §44.
+
+The structural reason both gates missed it is worth recording against
+protocol rule 5: **the shared suite pins error codes and message
+substrings, but almost never the path.** Of 7,679 `err` rows, 15 include
+a `$.` path in their expectation; `errc` asserts the code alone. Both
+ports emit `no_scalar_unify` here, so every gate agrees while the paths
+differ. The path is the field G7's machine surface hands to agents, and
+it is the least-asserted thing in the report.
 
 ## G2 — the validation verb
 

--- a/docs/capability-review/status-2026-08-28.md
+++ b/docs/capability-review/status-2026-08-28.md
@@ -1,0 +1,174 @@
+# Status report — 2026-08-28
+
+*A dated snapshot of one assessment, not a register.*
+[`progress.md`](progress.md) remains **authoritative** for per-phase
+status. This file records what was found while reconciling
+[`docs/design/AONTUCONSTRAINTS.0.md`](../design/AONTUCONSTRAINTS.0.md)
+— a constraint design that had been sitting on `main`, referenced by
+nothing — against the engine that actually shipped. Where the two
+disagree, the register is right and this file is stale.
+
+## Headline
+
+**The programme is done and released; its record had drifted, and the
+drift was hiding two live defects.**
+
+[`status-2026-08-27.md`](status-2026-08-27.md) opened on the gap
+between a finished review and an unreleased engine. That gap is closed:
+`aontu@0.53.0` and `go/v0.1.11` published on 2026-08-28 from commit
+`2cec558`, so every verb, the MCP server, and all of G1–G8 are
+installable. Forty-eight of forty-nine phases are complete; the one
+that is not (G5.6, the include-capability default flip) is deliberately
+held as a release act.
+
+What this pass adds is not more implementation. It is the observation
+that **a completed programme's record decays in a way an incomplete
+one's does not** — nobody re-reads a register whose rows all say
+LANDED. Three of its statements were false when checked, one design
+document was orphaned entirely, and reconciling that document surfaced
+a defect in the canonical port that every gate in the repository agrees
+is fine.
+
+## Method, and its confidence
+
+Every claim below was re-derived by running **both** engines and
+diffing, at `aontu@0.53.0` / `go/v0.1.11` in-tree. No claim here rests
+on reading the register, and none rests on a filename: `ConstraintVal`
+existing says nothing about which syntax it answers to, which is
+exactly the mistake that made this pass necessary.
+
+The same caveat as the 2026-08-27 report applies and should be read as
+seriously: **this is written by the agent that did the work**, with no
+independent adversarial verifier. Judgements are one agent's;
+measurements carry their commands.
+
+## 1. The programme, re-checked
+
+| Gap | Capability | Phases | Status |
+|-----|-----------|--------|--------|
+| G1 | Constraint algebra | 7 | complete |
+| G2 | The validation verb | 6 | complete |
+| G3 | Subsumption, evolution | 7 | complete |
+| G4 | Identity, relations | 7 | complete |
+| G5 | Trust contract | 6 | 5 complete, **G5.6 held** for the next major |
+| G6 | Distribution | 5 | complete |
+| G7 | Machine access | 7 | complete |
+| G8 | Generation | 5 | complete |
+
+Two of those I checked rather than took:
+
+- **G1 is genuinely landed, atom by atom.** `min`, `max`, `above`,
+  `below`, `neq`, `re`, `length`, `unique`, `must` all answer in both
+  ports, byte-identically, including the refusals. String bounds work
+  (`string & min("m")` admits `"zebra"`, refuses `"apple"`).
+- **G7.7 is genuinely closed.** Piping `:load <file>` then
+  `:get $.b.c` into `aontu --jsonl` returns one JSON object per line in
+  both ports. The register's own prose still said the phase "stands
+  PARTIAL"; see §4.
+
+## 2. The orphaned constraint design
+
+`docs/design/AONTUCONSTRAINTS.0.md` was uploaded on 2026-08-27 in
+commit `8d892a4`, as that commit's only content. It is a serious
+document — a twelve-row empirical survey run through boru against **Go
+port v0.1.6**, cross-checked against real `cue export` rather than
+CUE's documentation — and until this pass nothing in the repository
+linked it.
+
+Re-running all twelve rows against the shipped engine: **five have
+changed.** The full disposition is in
+[g1-constraint-algebra.md](g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note);
+the shape of it:
+
+- **D1 and D2 — its two root-caused defects — were fixed the day
+  before it landed** (ADR-004, ADR-007). Its `D1-a` recommendation
+  (keep soft standalone `*x`) is what the engine does.
+- **N1 and N2 landed under different syntax.** It proposed CUE's
+  operators and budgeted a lexing break for them; G1 had already
+  chosen function atoms. Nothing broke because nothing was reused —
+  which is why bounds and regex shipped in a *minor* release.
+- **N3 (key-pattern constraints) is DEFERRED** — 2026-08-28, maintainer
+  decision. It is the substantial proposal still unbuilt, and the
+  deferral is a choice rather than a consequence: `re` supplies the
+  pattern machinery, `&:` spreads the scoping point, and neither is
+  missing. The sized-integer sugar is also unbuilt, and carries no such
+  decision.
+- **Its method is the part worth keeping.** Nothing in this repository
+  differentially tests against a pinned `cue` binary. If the
+  positioning argument in its §1 is real, that corpus belongs beside
+  `regex-corpus.tsv`.
+
+## 3. Two live defects
+
+**§45 — CUE-style operators lex as bare strings.** `port: >=1024`
+evaluates to `{"port":">=1024"}` and exits 0, in both ports. `>10`,
+`<5`, `!=0` and `=~"^ab"` likewise. The design note named this in its
+row 7 and called it "worse than unsupported, since it produces a
+well-formed wrong config"; choosing function syntax removed the *need*
+to reuse `>` without changing what `>` does, so **the capability landed
+and the defect that motivated it did not.** Critical by this project's
+own scale — silent wrong output from a document whose purpose is to
+reject wrong input — and pointed at the one language whose users are
+most likely to arrive holding that notation.
+
+**§44 — a `&:` element spread shifts the TypeScript port's list error
+paths.** `l: [&: integer, 10, 20, "bad"]` reports `$.l.3` in
+TypeScript and `$.l.2` in Go. Go is right, and TypeScript's own verbs
+say so: `aontu get $.l.2` returns the element in both ports, so the
+canonical port **rejects, through `get`, the path its own
+`vet --format json` emits**. On a one-element list the path points off
+the end. It is the §41 defect — right site, wrong path — in the
+container §41's fix did not reach.
+
+Both are in [`use-cases/BUGS.md`](../../use-cases/BUGS.md) with minimal
+repros under [`use-cases/repros/`](../../use-cases/repros/). Neither is
+fixed here: §45 is a language change and §44 is an evaluator change,
+and both want shared spec rows in the commit that makes them.
+
+### Why nothing caught §44
+
+This is the more useful half of the finding. Of the **7,679 `err` rows**
+in the shared suite, **15** include a `$.` path in their expectation;
+`errc`, the larger error mode, asserts the code alone. Both ports emit
+`no_scalar_unify` here, so *every gate in the repository agrees* while
+the two paths differ.
+
+The path is the field the machine surface hands to agents — the thing a
+repair loop reads from `.findings[].path` and feeds back to `get`. It
+is the least-asserted thing in the report. Fixing one index without
+pinning paths leaves the class open, and the class is exactly where
+ADR-001 has the least purchase.
+
+## 4. Corrections applied to the register
+
+Both were false against the tree, and both are now fixed in
+`progress.md`:
+
+- **Protocol rule 5's suite counts.** It claimed 86 `.tsv` files, 85
+  row-bearing, 3,099 rows in eighteen modes. The tree has **90, 89 and
+  3,478 in twenty** — `jsonschema` (54) and `reaches` (13) were missing
+  from the list entirely. The rule carries its own reproduction
+  commands precisely so a reader can falsify it in two lines; nobody
+  had. (`status-2026-08-27.md` had the right figures, so the register
+  was behind a document that defers to it.)
+- **G7's summary bullet contradicted itself** — opening "G7 is
+  complete" and closing "so the phase stands PARTIAL", a trailing
+  clause left behind when the phase closed on 2026-08-24. Re-verified
+  and rewritten.
+
+## 5. What is actually left
+
+1. **G5.6**, the include-capability default flip — held for the next
+   major, warning window already shipping. Unchanged.
+2. **BUGS §44 and §45**, above.
+3. **Error paths in the shared spec.** The gap §44 exposed; larger than
+   §44.
+4. **N3 key-pattern constraints — deferred**, by decision on
+   2026-08-28, not by any obstacle. Nothing it needs is missing, so
+   this stays available rather than open. The sized-integer sugar sits
+   beside it, unbuilt and undecided.
+5. **A differential corpus against real CUE**, if the positioning
+   claim is to be held to the same standard as everything else here.
+
+Items 3 and 5 are the two where this programme's own discipline —
+derive it or assert it — is not yet applied to itself.

--- a/docs/design/AONTUCONSTRAINTS.0.md
+++ b/docs/design/AONTUCONSTRAINTS.0.md
@@ -1,6 +1,18 @@
 # Aontu Constraint Machinery — Gap Analysis and Design
 
-**Status:** Discovery draft
+**Status:** Discovery draft — **superseded in part; the §2 baseline is
+stale.** Written against **Go port v0.1.6**. As of `aontu@0.53.0` /
+`go/v0.1.11`, D1 and D2 are FIXED (ADR-004 and ADR-007), and N1/N2
+landed as capabilities under *function* syntax — `min`, `max`, `above`,
+`below`, `neq`, `re` — not the CUE operators proposed here, which is why
+the §10 lexing break never happened. N3 is **deferred** (2026-08-28,
+maintainer decision — unblocked, simply not now); the sized-integer
+sugar is unbuilt; and row 7's defect is still live: `port: >=1024` still
+evaluates to `{"port":">=1024"}` and exits 0. Do not read §2 as current
+behaviour. The item-by-item reconciliation, re-run against both engines
+on 2026-08-28, is in
+[`docs/capability-review/g1-constraint-algebra.md`](../capability-review/g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note);
+row 7 is [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45.
 **Home:** this repository (TS canonical under `ts/`, Go port under `go/`)
 **Origin:** empirical survey run from boru, which consumes the Go port
 via its `boru:parselang` module (pinned at `go/` v0.1.6)
@@ -288,6 +300,14 @@ validation pattern.
 
 ## 8. N3 — key-pattern constraints (scoping extension)
 
+> **DEFERRED — 2026-08-28, maintainer decision.** Not built, and not
+> scheduled. The deferral is a choice, not a consequence: `re` landed in
+> G1 phase 2 and `&:` spreads already exist, so both ingredients this
+> section depends on are in the engine. `&"…"` is a parse error in both
+> ports today. The design below stands as written for whenever it is
+> picked up.
+
+
 `&:` already applies a constraint to *every* child (row 9) and is the
 right primitive. What is missing is CUE's ability to scope the
 constraint to keys matching a pattern (`[=~"^env_"]: string`). Rather
@@ -372,7 +392,7 @@ behavior change.
 | P0 | D1 + D2 (defect fixes, `disjunct.go` + error taxonomy) | outputs change; no syntax |
 | P1 | N1 bounds + sized-int sugar | lexing break for bare `>…` strings |
 | P2 | N2 regex (subset pinned first — N2-a is blocking) | additive |
-| P3 | N3 key patterns | additive; depends on P2 |
+| P3 | N3 key patterns — **DEFERRED 2026-08-28** | additive; depends on P2, which has landed |
 
 P0 is independently shippable and is the highest-value single change:
 it is the difference between "aontu has enums with defaults" and "aontu

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -1095,6 +1095,60 @@ in `test/spec/divergent.tsv`; at equal depth both ports agree, which is
 why `use-cases/10-data-model/money-wire.aon` declares its types at the
 top level.
 
+### 44. A list's `&:` element spread shifts every later index in the TypeScript port's error paths [major]
+The same defect as §41 — a right site under a wrong path — in the one
+container §41's fix did not reach. A `&:` element spread occupies an
+index slot in TypeScript's error paths and not in Go's, so every
+element written after the spread is reported one index too high:
+
+```
+$ cat l.aon                                   # l: [&: integer, 10, 20, "bad"]
+$ node ts/bin/aontu.js l.aon
+[aontu/no_scalar_unify]: Cannot unify values at path $.l.3
+$ go/aontu l.aon
+[aontu/no_scalar_unify]: Cannot unify values at path $.l.2
+```
+
+Go is right, and the TypeScript port's own verbs prove it rather than
+the Go port doing so. On the passing form `l: [&: integer, 10, 20, 30]`
+both ports generate `{"l":[10,20,30]}` and both answer `aontu get $.l.2`
+with `30` — the spread is not an element anywhere except in one port's
+error paths. So TypeScript **contradicts itself**, and the contradiction
+is on the machine surface:
+
+```
+$ node ts/bin/aontu.js vet l.aon l.aon --format json | jq -r '.findings[0].path'
+$.l.3
+$ node ts/bin/aontu.js get '$.l.3' l.aon
+$.l.3: no_path [reference]          # the port rejects the path it just emitted
+$ node ts/bin/aontu.js get '$.l.2' l.aon
+30
+```
+
+An agent doing the loop G7 exists to serve — read `.findings[].path`,
+`get` it, patch it — is handed a path that resolves to nothing. On a
+one-element list it points off the end entirely: `l: [&: integer, "bad"]`
+reports `$.l.1`.
+
+Two things bound it. Elements written **before** the spread are
+unaffected (`l: ["bad", &: integer]` is `$.l.0` in both ports), and the
+spread and the offending element must be in the **same list literal** —
+when the failure arrives from a separate document, which is the ordinary
+`vet` schema/data shape, both ports agree on `$.l.2`. That is why the
+`vet.tsv` rows did not catch it.
+
+Neither did anything else, and the reason is structural: of the 7,679
+`err` rows in the shared suite only 15 include a `$.` path in their
+expectation, and `errc` asserts the code alone. Both ports emit
+`no_scalar_unify` here, so every gate the suite has agrees while the two
+paths differ. **The suite pins error codes and message substrings; the
+path — the field the machine surface hands to agents — is very nearly
+unasserted.** Fixing this one index without also pinning paths leaves
+the class open.
+
+Not entered in `test/spec/divergent.tsv`: that register is for
+divergences which cannot be fixed from this repository, and this one can.
+
 ## relations — a graph one port can only partly see
 
 ### 42. Go's derived graph loses most of its edges on a two-view model [critical]
@@ -1181,6 +1235,58 @@ visible. Pinned by
 nil a different PATH (`$` and `$.&`) — a pre-existing engine
 disagreement that plain evaluation shows too, now recorded in
 `test/spec/divergent.tsv`.
+
+## constraint-syntax — the notation the constraint algebra did not claim
+
+### 45. CUE-style constraint operators lex as bare strings, so a schema written in them enforces nothing [critical, by design]
+`>10`, `>=10`, `<5`, `!=0` and `=~"^ab"` are all legal aontu — as
+**strings**. A schema written in them parses, evaluates, validates
+nothing and exits 0:
+
+```
+$ echo 'port: >=1024' | aontu
+{
+  "port": ">=1024"
+}
+$ echo $?
+0
+```
+
+Identical in both ports, so this is not a parity defect. It is by design
+in the narrow sense that bare strings are a documented scalar form
+(`reference-language.md`: `bare string | a:hello | "hello"`) — though
+the documentation nowhere says a `>` may lead one. It is kept here under
+this file's rule for by-design behaviour whose consequence is severe,
+and the consequence is the one the severity scale calls critical: silent
+wrong output from a document whose whole purpose is to reject wrong
+input.
+
+`docs/design/AONTUCONSTRAINTS.0.md` §6 named this in its row 7 and
+called it "worse than unsupported, since it produces a well-formed wrong
+config". G1 then landed the constraint algebra under **function** syntax
+— `min`, `max`, `above`, `below`, `neq`, `re` — which dissolved that
+design's headline compatibility risk (§10 had budgeted a lexing break
+for reusing `>`; nothing had to break, because nothing was reused). The
+capability landed and the defect that motivated it was never in a
+phase's scope. See the reconciliation in
+[`docs/capability-review/g1-constraint-algebra.md`](../docs/capability-review/g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note).
+
+The conjunct spelling does fail, but unhelpfully: `port: integer & >=1024`
+raises `no_scalar_unify`, "Literal scalar values of different kinds
+cannot unify" — which names neither the mistake nor `min(1024)`, the
+atom that fixes it.
+
+Why it matters more than an unfamiliar spelling would: the design note's
+own framing is that CUE is the **only** widely used language sharing
+aontu's commutative-unification core, which makes CUE notation the thing
+a new user most plausibly arrives holding. `min(1024)` is not
+discoverable from a document that silently accepted `>=1024`.
+
+A fix has a cheap form that needs no new syntax and breaks nothing that
+is not already broken: refuse a bare string whose first character is one
+of `> < = !` and name the atom to use. That is a language change with
+its own spec rows in both ports, so it is recorded here rather than
+taken as part of a documentation pass.
 
 ## Elsewhere in this review
 

--- a/use-cases/repros/constraint-syntax/cue-operators-lex-as-strings.aon
+++ b/use-cases/repros/constraint-syntax/cue-operators-lex-as-strings.aon
@@ -1,0 +1,31 @@
+# 45 (found by the 2026-08-28 constraint-design reconciliation): the
+# CUE-style constraint operators are not syntax errors — they are bare
+# strings, so a schema written in them produces a well-formed document
+# with no constraint in it and exit 0.
+#
+# docs/design/AONTUCONSTRAINTS.0.md §6 named exactly this in its row 7
+# and called it "worse than unsupported, since it produces a
+# well-formed wrong config". G1 then landed the whole constraint
+# algebra under FUNCTION syntax — min/max/above/below/neq/re — which
+# dissolved that design's headline compatibility risk (§10, "N1 is a
+# lexing break": nothing had to break, because nothing was reused).
+# The defect the row named was never in any phase's scope, and survives.
+#
+# The correct spelling of the line below is `port: integer & min(1024)`.
+#
+# Both ports agree, so this is not a parity defect. It is by design in
+# the narrow sense that bare strings are a documented scalar form
+# (reference-language.md, "bare string | a:hello | \"hello\""), and the
+# docs nowhere say `>` leads one. Kept here under BUGS.md's rule for
+# by-design behaviour whose practical consequence is severe: CUE is the
+# one language sharing aontu's core, so it is the notation a new user
+# most plausibly arrives holding.
+#
+# The conjunct form does fail — `port: integer & >=1024` raises
+# no_scalar_unify — but as "scalar values of different kinds", which
+# names neither the real mistake nor the atom that fixes it.
+#
+# expected: a refusal naming the operator, or the bound it should mean
+# actual:   {"port":">=1024"}, exit 0 — the same for >10, <5, !=0, =~"^ab"
+# run: node ../../ts/bin/aontu.js cue-operators-lex-as-strings.aon
+port: >=1024

--- a/use-cases/repros/diagnostics/list-spread-index-offset.aon
+++ b/use-cases/repros/diagnostics/list-spread-index-offset.aon
@@ -1,0 +1,29 @@
+# 44 (found by the 2026-08-28 constraint-design reconciliation): a `&:`
+# element spread occupies an index slot in the TypeScript port's error
+# paths but not in Go's, so every element written AFTER the spread is
+# reported one index too high by the canonical implementation.
+#
+# The generated output settles which side is right: `aontu` on the
+# passing form `l: [&: integer, 10, 20, 30]` prints {"l":[10,20,30]} in
+# BOTH ports, so "bad" below is element 2. Go names it; TypeScript does
+# not. Without the spread the two ports agree (`l: [10, 20, "bad"]`
+# against `l: [integer, integer, integer]` is `$.l.2` in both), and
+# elements written BEFORE the spread are unaffected
+# (`l: ["bad", &: integer]` is `$.l.0` in both).
+#
+# On a one-element list TypeScript's path points off the end:
+# `l: [&: integer, "bad"]` reports `$.l.1` in a list whose only element
+# is index 0. The path is the field the machine surface hands to agents
+# (`vet --format json` .findings[].path), which is what makes a
+# silently-wrong index worse than a missing one.
+#
+# NOT reproducible through `vet` with a separate data file: when the
+# failing element arrives from another document both ports agree on
+# `$.l.2`. The spread and the offending element must be written in the
+# SAME list literal.
+#
+# expected: both ports report path $.l.2 (the index the output uses)
+# actual:   TypeScript reports $.l.3; Go reports $.l.2
+# run: node ../../ts/bin/aontu.js list-spread-index-offset.aon
+#      (then the same file through go/aontu, and diff the paths)
+l: [&: integer, 10, 20, "bad"]


### PR DESCRIPTION
Documents only — no engine or spec change.

`docs/design/AONTUCONSTRAINTS.0.md` arrived on `main` in `8d892a4` as that commit's only content, and **nothing in the repository referenced it**. It is a serious document — a twelve-row empirical survey run through boru against **Go port v0.1.6**, cross-checked against real `cue export` rather than CUE's documentation. But it surveyed a tree predating most of G1's landing, so read as current it misleads in both directions: it reports as broken two things that are fixed, and names one defect that is still live and that no phase here ever claimed.

All twelve rows re-run against `aontu@0.53.0` and `go/v0.1.11`, both ports diffed. **Five have changed.**

## What the reconciliation found

- **D1 and D2 — its two root-caused defects — were fixed the day before it landed** (ADR-004, ADR-007). Its `D1-a` recommendation (keep soft standalone `*x`) is what the engine does.
- **N1 and N2 landed under different syntax.** It proposed CUE's operators and budgeted a lexing break for them (§10); G1 had already chosen function atoms — `min`, `max`, `above`, `below`, `neq`, `re`. Nothing broke because nothing was reused, which is why bounds and regex shipped in a *minor* release.
- Its `D6-a` string bounds are in — `string & min("m")` admits `"zebra"`, refuses `"apple"`.
- **N3 (key-pattern constraints) is marked DEFERRED** — not built, not scheduled, and a choice rather than a consequence: `re` and `&:` spreads are both in the engine, so nothing it depends on is missing. Marked at every point it appears, including its own section and the phasing table, so a later reader finds a decision rather than an oversight.

## Two live defects

Both in `use-cases/BUGS.md` with minimal repros. **Neither is fixed here** — §45 is a language change, §44 an evaluator change, and both want shared spec rows in the commit that makes them.

**§45 — CUE-style operators lex as bare strings.** `port: >=1024` evaluates to `{"port":">=1024"}` and exits 0, in both ports. The design note named this in its row 7 and called it "worse than unsupported, since it produces a well-formed wrong config". Choosing function syntax removed the *need* to reuse `>` without changing what `>` does — so **the capability landed and the defect that motivated it did not.**

**§44 — a `&:` element spread shifts the TypeScript port's list error paths.** `l: [&: integer, 10, 20, "bad"]` reports `$.l.3` in TypeScript, `$.l.2` in Go. Go is right and TypeScript's own verbs say so:

```
$ node ts/bin/aontu.js vet l.aon l.aon --format json | jq -r '.findings[0].path'
$.l.3
$ node ts/bin/aontu.js get '$.l.3' l.aon
$.l.3: no_path [reference]          # the port rejects the path it just emitted
$ node ts/bin/aontu.js get '$.l.2' l.aon
30
```

The §41 defect — right site, wrong path — in the container §41's fix did not reach. Not entered in `divergent.tsv`: that register is for divergences which cannot be fixed here, and this one can.

### Why nothing caught it

Of the **7,679 `err` rows** in the shared suite, **15** include a `$.` path in their expectation; `errc` asserts the code alone. Both ports emit `no_scalar_unify`, so *every gate in the repository agrees* while the paths differ. The path is the field the machine surface hands to agents — and the least-asserted thing in the report. Fixing one index without pinning paths leaves the class open.

## Two register corrections

Both were false against the tree:

- **Protocol rule 5's suite counts** said 86 `.tsv` files / 85 row-bearing / 3,099 rows in eighteen modes. The tree has **90 / 89 / 3,478 in twenty**, with `jsonschema` (54) and `reaches` (13) missing from the list entirely. The rule carries its own reproduction commands so a reader can falsify it in two lines; nobody had.
- **G7's summary bullet contradicted itself**, opening "G7 is complete" and closing "so the phase stands PARTIAL" — a clause left behind when the phase closed on 2026-08-24. Re-verified: piping `:load` and `:get` into `aontu --jsonl` answers one JSON object per line, byte-identical in both ports.

## Verification

- `node --test ts/dist-test/docs.test.js` — 2/2.
- 101 relative links across the changed files resolve on disk.
- Both repros re-checked against their own headers on the rebased tree.
- Register counts re-derived with the register's own two commands.

New status report: `docs/capability-review/status-2026-08-28.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6JJFKLqr2Ci1HwWTSK7iZ)_