### PR TITLE
Retract BUGS §45; drop import() for destructuring; adopt % as the alias sigil

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -755,11 +755,18 @@ The argument for adopting it is real and should be recorded rather than
 strawmanned. CUE is the only widely used configuration language sharing
 aontu's commutative-unification core, which makes CUE notation the thing
 a new user most plausibly arrives holding; and today that notation fails
-in the worst available way. `port: >=1024` is not a syntax error — it is
-the bare string `">=1024"`, so a schema written in CUE's operators
-parses, validates nothing, and exits 0. The note called this "worse than
-unsupported, since it produces a well-formed wrong config"
-([`use-cases/BUGS.md`](use-cases/BUGS.md) §45).
+differently from how a CUE user would read it. `port: >=1024` is not a
+syntax error — it is the bare string `">=1024"`, so a schema written in
+CUE's operators parses and imposes no constraint. The note called this
+"worse than unsupported, since it produces a well-formed wrong config".
+
+*That grading was withdrawn on the same day this entry was accepted, and
+the sentence is kept only because the argument below responds to it.*
+Those characters are not reserved, so the behaviour is the bare-string
+rule applying uniformly — `port: high` is `"high"` for the same reason —
+and calling it a wrong config assumes an intent the document never
+states. [`use-cases/BUGS.md`](use-cases/BUGS.md) §45 recorded it as a
+critical defect and is retracted.
 
 ### Decision
 
@@ -799,15 +806,18 @@ needs a new ADR.
   constraint layer, and the project should say so** rather than let a
   reader infer it from the shared core. The positioning claim in
   AONTUCONSTRAINTS.0.md §1 is about the *lattice*, not the notation.
-- **BUGS.md §45 is not closed by this decision, and is arguably
-  sharpened by it.** Declining the sugar settles what `>=1024` will
-  never mean; it does not settle what it should do *now*, which is
-  silently become a string. The remaining options are to refuse a bare
-  string whose first character is one of `> < = !` — naming the atom to
-  use, which closes the silent-wrong-config hole without adding a second
-  syntax and is the only option consistent with this entry — or to leave
-  it. That choice is **open**, and is a smaller break than the one
-  declined here: it removes a spelling rather than repurposing one.
+- **A bare value containing `> < = !` is ordinary text, and stays so.**
+  This follows directly, and is not an unfinished edge. Those characters
+  are not reserved, so `port: >=1024` produces `">=1024"` exactly as
+  `port: high` produces `"high"`. There is no silent failure to close:
+  reading one requires assuming the author meant a bound, which is an
+  assumption about intent that neither the document nor the engine can
+  make. An earlier draft of this entry proposed **refusing** such bare
+  strings; that is **withdrawn**, because carving `> < = !` out of the
+  bare-string rule to serve a guess about intent would make `a: >x` an
+  error while `a: ?x` stayed fine. What remains is discoverability — the
+  named atoms should be easy to find from where a CUE-trained reader
+  looks, which is what the reference and how-to now provide.
 - **The sized-integer sugar (`int8`, `uint16`) is untouched by this
   entry.** It is a name for a bounded `integer`, not an operator, so it
   is a *named* form and this decision does not bear on it. It remains
@@ -820,8 +830,7 @@ needs a new ADR.
 ### Enforcement
 
 Prose, and this entry. There is no test for a syntax that does not
-exist — a spec row can only pin what an engine does, and both engines
-today read `>10` as a string, which is BUGS.md §45 rather than a pin on
-this decision. Should §45 be closed by refusal, the refusal's own rows
-become the enforcement: a row asserting that `a: >10` is an error is
-also a row asserting it is not a bound.
+exist — a spec row can only pin what an engine does, and what both
+engines do with `>10` is read it as text, which pins the bare-string
+rule rather than this decision. The two are independent, and conflating
+them is what made the retracted §45 look like a defect.

--- a/docs/capability-review/g1-constraint-algebra.md
+++ b/docs/capability-review/g1-constraint-algebra.md
@@ -823,7 +823,8 @@ this section it was referenced by nothing in the repository.
 It is not a competing design. It surveyed a tree that predates most of
 G1's landing, and read as current it is misleading in both directions:
 it reports as broken two things that are now fixed, and it names one
-defect that is still live and that no phase here ever claimed.
+defect that no phase here ever claimed — and which, on inspection,
+turned out not to be a defect at all (row 7 below).
 
 **Its §2 baseline, re-run 2026-08-28 against `aontu@0.53.0` and
 `go/v0.1.11`, both ports byte-identical unless noted.** Five of the
@@ -835,8 +836,8 @@ twelve rows have changed since it was written:
 | **3** | **D1**: `*"i"\|"d"\|"w"` & `"nope"` → `{a:'nope'}`, no validation | `[aontu/\|:empty]` "Empty disjunction" | **fixed** before the note was written, by the preference admission gate (ADR-004) |
 | **4** | **D2**: defaultless disjunct reports a *conflict* | `[aontu/disjunct_no_gen]`, "supply a value that selects one alternative, or write a preference (\*)" | **fixed** by ADR-007 |
 | **5** | D1 again via explicit `&` | `[aontu/\|:empty]` | fixed with row 3 |
-| **7** | **N1**: `a: >10` lexes as the string `">10"` | *unchanged* — `{"a":">10"}`, exit 0 | **still live**; see below |
-| **8** | **N2**: `a: =~"^ab"` is a lex error | *changed, still wrong* — lexes as a bare string | still live, with row 7 |
+| **7** | **N1**: `a: >10` lexes as the string `">10"` | *unchanged* — `{"a":">10"}` | **not a defect**; see below |
+| **8** | **N2**: `a: =~"^ab"` is a lex error | *changed* — now a bare string | ordinary text, with row 7 |
 | 9, 10, 11 | `&:` spreads and optional keys exist | unchanged | — |
 | 12 | `a: $.a` correctly refused | now `path_cycle` | — |
 
@@ -899,18 +900,18 @@ admits `"zebra"` and refuses `"apple"`.
   `ts/test/docs.test.ts`. The idiom also exposes a trap a keyword would
   have hidden: bounds alone bound a *number*, so an alias must lead with
   `integer` or `1.5` satisfies it.
-- **Row 7's defect itself.** The atom vocabulary landed; the silent
-  mislex the note called "worse than unsupported, since it produces a
-  well-formed wrong config" was never in a phase's scope, because
-  choosing function syntax removed the *need* to reuse `>` without
-  removing what `>` currently does. `port: >=1024` still evaluates to
-  `{"port":">=1024"}` and exits 0. Recorded as
-  [`use-cases/BUGS.md` §45](../../use-cases/BUGS.md).
-  ADR-008 narrows this rather than closing it: it settles what `>=1024`
-  will never mean, leaving only whether to **refuse** such a bare string
-  and name the atom to use. That remains open, and it is the one repair
-  consistent with the ADR — it removes a spelling instead of
-  repurposing one.
+- **Row 7 — which turned out not to be a defect at all.** The note
+  called `a: >10` lexing as `">10"` "worse than unsupported, since it
+  produces a well-formed wrong config", and this document repeated that
+  grading. Both were wrong. `>`, `<`, `=` and `!` are not reserved, so a
+  bare value containing them is ordinary text, exactly as `port: high`
+  is `"high"`; reading a failure into it assumes the author meant a
+  bound. The grading made sense when bounds existed in no spelling and
+  CUE's operators were the live proposal — ADR-008 removes that premise,
+  and the grading should not outlive it.
+  [`use-cases/BUGS.md` §45](../../use-cases/BUGS.md) is **retracted**
+  and the refusal it proposed withdrawn. What is left is
+  discoverability, which the reference and how-to carry.
 
 **What this design has that the note does not.** The note scoped the gap
 to "exactly three things" — D1, D2, and bounds/regex plus key patterns.

--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -373,7 +373,8 @@ now declined outright** —
 [ADR-008](../../ADR.md#adr-008--constraints-are-named-not-spelled-with-operators),
 2026-08-28: constraints are named, not spelled with operators, and
 adopting them later needs a new ADR. That settles a question this
-register had left open, and narrows §45 (below) to one remaining repair.
+register had left open. It also removes the premise behind §45 (below),
+which is now retracted.
 **N3** key-pattern constraints
 (`&"^env_"` is a parse error in both ports) are **DEFERRED as of
 2026-08-28 by maintainer decision** — a choice, not a blockage: `re`
@@ -390,19 +391,22 @@ where it is used. Verified in both ports and pinned by
 `docs/how-to.md` "Name a reusable constraint", both executed by
 `ts/test/docs.test.ts`. This phase set never scoped either item.
 
-**One defect the note named is still live, and this register should not
-imply otherwise.** Its row 7 — `a: >10` lexing as the string `">10"`,
+**One defect the note named turned out not to be one, and this register
+should not imply otherwise.** Its row 7 — `a: >10` lexing as the string `">10"`,
 which it called "worse than unsupported, since it produces a
 well-formed wrong config" — is unchanged: `port: >=1024` evaluates to
 `{"port":">=1024"}` and exits 0, in both ports. Choosing function
 syntax removed the *need* to reuse `>` without changing what `>`
 currently does, so the capability landed while the defect that motivated
-it went unaddressed. [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45.
-ADR-008 does not close it: declining the sugar settles what `>=1024`
-will never mean, not what it does now. The one repair that ADR admits —
-refuse a bare string leading with `> < = !` and name the atom to use —
-is still an open choice, and a smaller break than the one declined,
-since it removes a spelling rather than repurposing one.
+it went unaddressed — **and on 2026-08-28 that framing was retracted as
+wrong.** `>`, `<`, `=` and `!` are not reserved, so a bare value
+containing them is ordinary text, exactly as `port: high` is `"high"`;
+calling the result a wrong config assumes an intent the document never
+states. The grading was inherited from a note written when bounds
+existed in no spelling at all, and ADR-008 removes its premise.
+[`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45 is retracted and the
+refusal it proposed withdrawn; what remains is discoverability, which
+the reference and how-to carry.
 
 **And one this review found while reconciling — now FIXED, 2026-08-28.**
 A `&:` element spread occupied an index slot in the TypeScript port's

--- a/docs/capability-review/status-2026-08-28.md
+++ b/docs/capability-review/status-2026-08-28.md
@@ -110,16 +110,16 @@ the shape of it:
 
 ## 3. Two defects — one fixed, one narrowed
 
-**§45 — CUE-style operators lex as bare strings.** `port: >=1024`
-evaluates to `{"port":">=1024"}` and exits 0, in both ports. `>10`,
-`<5`, `!=0` and `=~"^ab"` likewise. The design note named this in its
-row 7 and called it "worse than unsupported, since it produces a
-well-formed wrong config"; choosing function syntax removed the *need*
-to reuse `>` without changing what `>` does, so **the capability landed
-and the defect that motivated it did not.** Critical by this project's
-own scale — silent wrong output from a document whose purpose is to
-reject wrong input — and pointed at the one language whose users are
-most likely to arrive holding that notation.
+**§45 — retracted; it was never a defect.** `port: >=1024` evaluates to
+`{"port":">=1024"}` in both ports, and this report first graded that
+critical. Wrong: `>`, `<`, `=` and `!` are not reserved characters, so a
+bare value containing them is ordinary text — `port: high` is `"high"`
+for the same reason. Reading a failure into it requires assuming the
+author meant a bound, which is an assumption about intent that neither
+the document nor the engine can make. The grading came from
+`AONTUCONSTRAINTS.0.md` §6, written when bounds existed in no spelling
+and CUE's operators were the live proposal; ADR-008 declines that
+proposal and the grading should not have outlived its premise.
 
 **§44 — a `&:` element spread shifts the TypeScript port's list error
 paths.** `l: [&: integer, 10, 20, "bad"]` reports `$.l.3` in
@@ -141,14 +141,14 @@ one, in the grammar that introduces the exceptions.) Nine rows in
 both engines; reverting the fix fails exactly four of them, and
 pointedly not the code-only row. Both coverage gates stayed at 100%.
 
-**§45 is not fixed, but it is now narrowed.**
+**§45 needs no fix.**
 [ADR-008](../../ADR.md#adr-008--constraints-are-named-not-spelled-with-operators)
-(2026-08-28) declines CUE's operator spellings outright — constraints
-are named, not spelled with operators — which settles what `>=1024` will
-never mean and rules out closing §45 by making it work. What is left is
-the one repair the ADR admits: refuse a bare string leading with
-`> < = !` and name the atom to use. Still an open choice, and still a
-break, though a smaller one than the one declined.
+declines CUE's operator spellings outright, and with the proposal gone
+so is the reason to read `">=1024"` as anything but text. The refusal
+this report previously called "the one repair the ADR admits" is
+**withdrawn**: carving `> < = !` out of the bare-string rule to serve a
+guess about intent would make `a: >x` an error while `a: ?x` stayed
+fine. What is left is discoverability, not correctness.
 
 Both are in [`use-cases/BUGS.md`](../../use-cases/BUGS.md) with minimal
 repros under [`use-cases/repros/`](../../use-cases/repros/), along with
@@ -194,8 +194,8 @@ Both were false against the tree, and both are now fixed in
 
 1. **G5.6**, the include-capability default flip — held for the next
    major, warning window already shipping. Unchanged.
-2. **BUGS §45**, above — and **§46 and §47**, the two divergences found
-   while fixing §44. §44 itself is closed.
+2. **BUGS §46, §47 and §48** — three cross-port divergences, all
+   right-verdict/wrong-explanation. §44 is closed; §45 is retracted.
 3. **Error paths in the shared spec.** The gap §44 exposed; larger than
    §44.
 4. **N3 key-pattern constraints — deferred**, by decision on

--- a/docs/design/ALIASES.0.md
+++ b/docs/design/ALIASES.0.md
@@ -22,8 +22,12 @@ Three parts, as given:
 3. **`import(string, @<ref>, {...})`** takes the path (as a string) at
    which to place the import, the file to import, and an optional
    destructuring of the imported aliases so they can be used directly.
+   **Superseded — see §6.** Asked whether `import` was needed at all,
+   the answer is no: a destructuring left-hand side does the job with
+   no new builtin.
 4. **Shorthand.** `{ foo, bar }` stands for `{ foo: foo, bar: bar }`,
-   as in JavaScript.
+   as in JavaScript. This turns out to be **load-bearing** rather than a
+   nicety, once §6 drops `import`.
 
 The worked case is the one from
 [`docs/reference-language.md`](../reference-language.md#named-constraint-aliases):
@@ -79,13 +83,20 @@ All probed 2026-08-28, both ports byte-identical unless noted.
 | 4 | `a: b = 1` | **parse error**, `unexpected character(s): =` | spaced `=` in value position is FREE |
 | 5 | `foo = 1` (top level) | the list `["foo","=",1]` | spaced `=` at top level is TAKEN, but by nonsense |
 | 6 | `a: {foo, bar}` | **parse error**, `unexpected character(s): foo` | the `{foo,bar}` shorthand is FREE |
-| 7 | `copy(@"foo.aon")` | works | `@"…"` is legal in argument position — `import(…, @"f", …)` is expressible |
+| 7 | `copy(@"foo.aon")` | works | `@"…"` composes as a sub-expression — so it can sit on the right of `=` |
 | 8 | `a:1 b:$.a` canon | `{"a":1,"b":1}` | canon resolves references away |
 | 9 | `foo := 1` | parse error; `foo:=1` → `{"foo":"=1"}` | `:=` is WORSE than `=` — it silently collides |
 | 10 | `foo ~ 1` | the list `["foo","~",1]` | other sigils are no freer |
+| 11 | `{ u8: uint8 } = @"f.aon"` | the list `[{"u8":"uint8"},"=",{…}]` | a destructuring LHS sits in the SAME slot as row 5 |
+| 12 | `a: %x` / `~x` / `^x` / `!x` | all bare strings | free in the weak sense: text, no meaning |
+| 13 | `a: ?x` / `:x` / `&x` | parse errors | free outright, but structurally confusing |
+| 14 | `a: #x` / `.x` / `@x` | comment / path / include | genuinely taken |
 
 Row 6 is the happiest: the JavaScript shorthand costs nothing.
-Rows 2–5 are where the difficulty is, and §10 quantifies it.
+Row 11 matters for §6 — the destructuring form is the alias declaration
+generalised from a name to a pattern, not a new construct.
+Rows 12–14 matter for §4's A-4. Rows 2–5 are where the difficulty is,
+and §10 quantifies it.
 
 ## 4. Aliases
 
@@ -154,15 +165,76 @@ the two readings are both plausible to a human, and Aontu's habit is to
 refuse an ambiguity rather than resolve it by a rule the reader has to
 remember. Cheap to check, since both names are known after the pass.
 
-A related and worse case: a bare string that happens to match an alias
-name. `status: active` is the bare string `"active"` today; if a file
-declares `active = 1`, does `status` become `1`? **This is the
-substantive semantic risk in the whole proposal** — aliases and bare
-strings occupy the same syntactic position, so every alias name silently
-removes a bare string from the file's vocabulary. Options: require a
-sigil at the use site (which gives up the proposal's ergonomics), or
-accept it and rely on the shadowing error above only where an actual
-key collides. Not resolved here; see §9.
+### A-4: the capture hazard, and three ways out
+
+A bare string that happens to match an alias name is the worse case.
+`status: active` is the bare string `"active"` today; if a file declares
+`active = 1`, does `status` become `1`? Aliases and bare strings occupy
+the same syntactic position, so every alias name silently removes a bare
+string from the file's vocabulary — and adding an alias could change a
+line that does not mention it.
+
+**First, the part that is not a choice.** If aliases are referenced by a
+bare name, the capture is *inherent*, not incidental: a bare `X` in a
+file declaring `X = …` must mean the alias, or the alias is unusable.
+So "make the alias win only sometimes" is not on the table. The three
+real options are:
+
+**Option A — put a sigil in the alias's name.** Declared and used
+identically, so there is no question of which side carries it:
+
+```
+%uint8 = integer & min(0) & max(255)
+listen: %uint8
+```
+
+This ends the hazard outright — bare text stays bare text, and no
+declaration can reach a line that does not use the sigil. It also fixes
+the *other* problem the design has: §8's table has four name-like things
+and only three of them are distinguishable by sigil; this makes it four.
+CUE reaches for the same device with `#Foo` definitions.
+
+The cost is a reserved character, which is the same *class* of change as
+reserving `=` — so it deserves the same measurement, and gets it.
+Measured over the 309-file corpus with comments stripped, bare tokens
+led by each candidate:
+
+| Candidate | Files in corpus | Spec rows | Note |
+|---|---|---|---|
+| `%` | 0 | 0 | reads as substitution — the best semantic fit |
+| `~` | 0 | 0 | free |
+| `^` | 0 | 0 | free |
+| `!` | 0 | 0 | free, but reads as negation |
+
+All four are unused. `?`, `:` and `&` are free *outright* (parse errors
+today) but are structurally confusing; `#`, `.` and `@` are genuinely
+taken. **`%` is the recommendation**, and the choice among `% ~ ^` is
+free on this evidence.
+
+**Option B — refuse a declaration that would capture.** Keep the bare
+spelling, and at the whole-file pass the design already requires for
+order-independence, check whether the bare token `X` appears in value
+position anywhere in the file. If it does, refuse `X = …` and name both
+sites. The author quotes the string or renames the alias.
+
+This is decidable and non-circular — the check runs at the *declaration*
+against existing bare uses, so it never refuses the alias's own use
+sites — and it converts a silent change into a parse-time refusal, which
+is the opposite of the A-4 harm. It costs no character. Its residual
+weakness is that it fixes the *silent change* without fixing the
+*legibility*: a reader still cannot tell a bare `uint8` from a bare
+string without checking the declarations.
+
+**Option C — accept and document it.** Cheapest, and what most languages
+with bare identifiers do. It leaves the property that adding a line can
+change an unrelated line, which is the thing the rest of Aontu does not
+do.
+
+**Recommendation: A**, because it is the only one that also answers §8,
+and the measurement puts its cost at the same near-zero as `=`. **B is
+the fallback** if the sigil is judged to cost more than it looks —
+it preserves the `listen: uint8` reading exactly. A and B compose, but
+A alone makes B unnecessary.
 
 ## 5. `export`
 
@@ -186,66 +258,80 @@ Open shape questions:
   importing a name that is not exported must be an error naming the
   name — not a silent nothing.
 
-## 6. `import`
+## 6. Crossing the file boundary — and why `import` is not needed
 
-`import("path.to.place", @"other.aon", { uint8, port })`
+The proposal gave `import` three arguments. Taken one at a time, two of
+them duplicate machinery the language already has, and the third is the
+only thing actually missing.
 
-Three arguments, each doing something different, and the middle one is
-the only one that resembles what the language already does.
+| Argument | What it does | Already expressible? |
+|---|---|---|
+| `"path.to.place"` | place the file's **values** at a path | yes — `svc: @"other.aon"` |
+| `@"other.aon"` | read the file | yes — that *is* `@"…"` |
+| `{ uint8, port }` | bring its **aliases** into scope | **no** — the only gap |
 
-### Argument 1 — the placement path, as a string
+`@"…"` already crosses the file boundary for values. What it cannot
+carry is aliases, because an alias is erased before a value exists. So
+the missing feature is not an import verb; it is a way to bind names.
 
-This is the unusual one. Nothing in Aontu today takes a **string that
-is interpreted as a write location**. `move(p)` does take a path — but a real path *expression* (`move($.m)`),
-resolved and checked like any reference, and it reads rather than
-writes. A string path argument would introduce a second way to say
-"where": unchecked by the parser, invisible to the path machinery, and
-not something `why` or `get` could follow.
+**A destructuring left-hand side does exactly that**, and row 11 shows it
+occupies the same syntactic slot as the alias declaration — it is
+`KEY = value` with the key generalised from a name to a pattern:
 
-**Decision point I-1.** Alternatives worth weighing before accepting a
-string: (a) place the import where the call is written, as `@"…"` does,
-and let the author nest it — `svc: import(@"other.aon", {…})`; (b) take
-a real path value rather than a string. Option (a) is strictly simpler,
-loses nothing obvious, and keeps one answer to "where does this land".
-The string form's advantage — placing at a computed or deep path from
-the top level — should be shown to be needed before it is bought.
+```
+{ uint8, port }   = @"types.aon"     # bind two exported aliases
+{ u8: uint8 }     = @"types.aon"     # …and rename while binding
+svc: @"types.aon"                    # values, if also wanted — unchanged
+```
 
-### Argument 2 — the file
+One form, `<pattern> = <value>`, where the pattern is a name or a map of
+names. No new builtin, and the two concerns separate cleanly: **values
+cross via `@"…"`, names cross via a pattern on the left of `=`.**
 
-Row 7 confirms `@"…"` already works in argument position, so this is
-expressible today. It must resolve through **the same resolver chain
-and the same confinement** as `@"…"`: in-memory, filesystem, then
-package resolution, under the trust profile.
+### What dropping `import` buys
 
-**This is not optional.** [`docs/trust.md`](../trust.md) clause 1 states
-that an evaluation's output is a pure function of four inputs, the
-second being "the resolved `@"…"` include closure". An `import` that
-read files by any other route would add a fifth input and silently
-falsify the hermeticity claim in both ports. It must also appear in the
-include manifest, or `aontu mod verify` stops seeing the whole file set.
+- **Decision I-1 disappears.** There is no placement argument, so there
+  is no question of a string path as a write location — the thing
+  nothing else in the language does. `move(p)` takes a real path
+  expression and reads; a string path would have been unchecked by the
+  parser and unfollowable by `why` or `get`.
+- **Decision I-2 disappears.** The destructuring list *is* the import,
+  so "exported but not destructured" has no meaning.
+- **The trust question dissolves.** The earlier draft argued at length
+  that `import` must ride the same resolver and confinement as `@"…"`,
+  or it adds a fifth input to hermeticity's four and falsifies
+  [`docs/trust.md`](../trust.md) clause 1 in both ports. With the
+  right-hand side being a plain `@"…"`, **there is no new file-reading
+  route to govern** — confinement, the resolver chain and the include
+  manifest all apply unchanged, because it is the same include.
+- **The module question dissolves too.** A module-shaped `@"…"` works on
+  the right-hand side with no new machinery, so this adds no
+  distribution surface at all — which §6 of the earlier draft named as
+  the outcome to aim for and could only hope for.
+- **The shorthand becomes load-bearing.** `{ uint8, port }` is now the
+  import syntax rather than a convenience, which also answers **S-1**:
+  it is confined to *pattern* position, a principled boundary rather
+  than an arbitrary one, and never collides with bare strings in
+  ordinary maps.
 
-### Argument 3 — the destructuring
+### The one question it opens
 
-`{ uint8, port }` brings the named aliases into the importing file's
-alias namespace directly. With the row-6 shorthand this reads well, and
-`{ u8: uint8 }` gives renaming for free.
+`@"other.aon"` evaluates to the file's **value**. So `{ port, host } =
+@"config.aon"` has two readings: bind to the file's exported *aliases*,
+or bind to the *keys* of the map it evaluates to.
 
-**Decision point I-2: what happens to aliases that are exported but not
-destructured?** Either they are unavailable (recommended — the
-destructuring list is then the file's declared surface, and an unused
-import is visible), or they are reachable through some qualified form,
-which needs a syntax the proposal does not yet have.
+**Decision point E-1.** The second reading is arguably more natural, and
+it would make `export` unnecessary — the public surface would just be
+the file's keys. But it also dissolves §2's locality argument, which is
+the whole case for aliases crossing a boundary at all. The first reading
+keeps `export` meaningful and keeps "this name is mine" expressible.
+They could coexist (aliases when the name is exported, keys otherwise),
+but a rule that silently falls back from one namespace to another is the
+A-4 mistake in a new place, so: pick one.
 
-### Relationship to modules
-
-Aontu already has a distribution layer (G6): `@"corp.example/pkg@1"`,
-`mod.aon`, a canonical-form lockfile, vendoring, and `aontu mod
-verify`. **`import` must not become a second, competing module system.**
-The safe framing is that `import` is about *names within a file set*
-and modules are about *artifacts and their provenance* — `import`
-should be able to take a module-shaped `@"…"` and get all of G6's
-machinery unchanged. If that is true, this note adds no distribution
-surface at all, which is the outcome to aim for.
+Recommend the **alias** reading, with `export` retained — and note that
+under Option A of §4 the two are visibly different anyway, since an
+exported alias is written `%uint8` and a key is not.
 
 ## 7. The `{ foo, bar }` shorthand
 
@@ -277,10 +363,12 @@ has to tell them apart at a glance:
 | `foo` (alias) | the **file** | file | **yes** |
 | `foo:` (key) | it *is* the document | document | no |
 
-Three of the four are already distinguishable by sigil; the alias is
-the one that is not. That is the ergonomic win and the readability cost
-in the same sentence, and §4's bare-string hazard is its sharpest
-consequence.
+Under the bare spelling, three of the four are distinguishable by sigil
+and the alias is the one that is not — the ergonomic win and the
+readability cost in one sentence, with §4's capture hazard as its
+sharpest consequence. **Option A of §4 makes it four out of four**,
+which is the second reason to prefer it: this table is an argument for
+a sigil quite apart from A-4.
 
 ## 9. Decision points, gathered
 
@@ -291,11 +379,16 @@ Nothing should be built before these are answered.
 | **A-1** | What site does a finding name when the value came via an alias? | Both, as a `why` contribution |
 | **A-2** | May an alias reference another alias? | Yes, with a cycle check |
 | **A-3** | Alias name colliding with a key | Refuse |
-| **A-4** | **Alias name colliding with a bare string** | **Unresolved — the main risk** |
-| **I-1** | Placement: string path, or place-where-written? | Place where written |
-| **I-2** | Exported but not destructured | Unavailable |
-| **S-1** | Is `{foo, bar}` general or confined to export/import? | Confined |
+| **A-4** | **Alias name colliding with a bare string** | **Option A — a sigil in the name (`%uint8`)**; B as fallback. §4 |
+| **E-1** | Does a destructure bind exported *aliases* or the value's *keys*? | Aliases, `export` retained. §6 |
+| **S-1** | Is `{foo, bar}` general or confined? | **Answered** by §6 — confined to pattern position |
 | **X-1** | Is `=` the right spelling at all? | See §10 |
+
+**Dissolved, not decided.** `I-1` (placement as a string path) and `I-2`
+(exported but not destructured) were questions about `import`, and §6
+removes the builtin that raised them; `S-1` is answered by the same
+change. A-4 moved from unresolved to a recommendation with a
+measurement behind it. **Two open questions replace four.**
 
 ## 10. Compatibility, measured
 
@@ -374,13 +467,15 @@ Sketch only, since §9 is open:
   erased from canon *and* from the hash — a document with aliases and its
   expanded twin must produce the identical `aon1-…` string, which is the
   sharpest single row in this list.
-- **Export/import:** exported name importable; unexported name refused
-  by name; destructure and rename; a not-exported destructure refused;
-  import through the module-shaped path resolving as G6 already does.
-- **Trust:** an `import` under `--trust none` and under `--trust root:`
-  behaving exactly as `@"…"` does, and appearing in the include
-  manifest. A row per confinement mode, mirroring the existing include
-  rows.
+- **Export and destructuring:** exported name bindable; unexported name
+  refused *by name*; destructure and rename; a module-shaped `@"…"` on
+  the right-hand side resolving as it already does; and whichever way
+  E-1 lands, a row pinning that a non-exported key is not silently
+  reachable.
+- **Trust:** nothing new to pin. The right-hand side is a plain `@"…"`,
+  so the existing include rows already cover every confinement mode and
+  the include manifest. That absence is itself the argument for §6 —
+  the earlier `import` design would have needed a row per mode.
 - **Shorthand:** `{foo}` ≡ `{foo: foo}` in canon; refusal wherever S-1
   lands it out of scope.
 - **Negatives paired with positives** throughout, per the house rule.
@@ -389,17 +484,21 @@ Sketch only, since §9 is open:
 
 | Phase | Content | Gate |
 |-------|---------|------|
-| P0 | Settle §9, X-1 and A-4 first | no code |
+| P0 | Settle X-1, A-4 and E-1 first | no code |
 | P1 | Aliases, file-local, with canon erasure and the cycle/shadow refusals | the hash row |
-| P2 | `export` + `import` without destructuring | trust rows |
-| P3 | Destructuring and the `{foo, bar}` shorthand | canon expansion |
+| P2 | `export`, and `{…} = @"…"` destructuring | canon expansion |
 
 P1 is independently useful and independently shippable: file-local
 aliases with nothing crossing a file boundary is the whole of §2's
 argument, and it can be judged before any of §5–6 is built.
 
-**A-4 is the one that could sink the design as spelled** — if an alias
-name silently captures a bare string, then adding an alias to a file can
-change the meaning of a line that does not mention it. That is the
-opposite of what the rest of the language does, and it should be
-answered before P1, not during it.
+**A-4 must be answered before P1, not during it** — if an alias name
+silently captures a bare string, adding an alias to a file can change
+the meaning of a line that does not mention it, which is the opposite of
+what the rest of the language does. It is no longer the open risk it
+was: §4 gives three ways out, a recommendation, and a corpus
+measurement putting the recommended one at the same cost as `=`. But it
+determines the spelling, so it cannot be deferred into implementation.
+
+The old P2/P3 split is gone with `import`: `export` and destructuring
+are one phase now, because destructuring *is* the import.

--- a/docs/design/ALIASES.0.md
+++ b/docs/design/ALIASES.0.md
@@ -1,8 +1,10 @@
 # Aliases, export and import — design note
 
-**Status:** Discovery draft. **Nothing here is implemented**, and this
-note does not propose that it should be until the decision points in
-§9 are settled.
+**Status:** Discovery draft. **Nothing here is implemented.**
+**Revised 2026-08-28: `%` is adopted as the alias sigil** (A-4 Option A),
+and it carries through the declaration, the use site, `export`, the
+destructuring form and the shorthand. That decision closes A-4, dissolves
+A-3, and reopens X-1 in a better place — see §10.
 **Origin:** Richard Rodger, 2026-08-28, as the general form behind the
 sized-integer question that [ADR-008](../../ADR.md#adr-008--constraints-are-named-not-spelled-with-operators)
 left standing.
@@ -15,19 +17,24 @@ such.
 
 Three parts, as given:
 
-1. **Alias declaration.** `foo = 1` means that `foo`, appearing in a
-   value expression, denotes `1`. Grammar: `KEY = <aontu value>`.
-   Aliases are **local to the file that declares them**.
-2. **`export({...})`** declares which aliases a file publishes.
+1. **Alias declaration.** `%foo = 1` means that `%foo`, appearing in a
+   value expression, denotes `1`. Grammar: `%NAME = <aontu value>`.
+   Aliases are **local to the file that declares them**. *(The proposal
+   was written without the sigil; §4 adopts it, and §10 notes that with
+   `%` reserved the `=` may not be needed either.)*
+2. **`export({ %uint8, %port })`** declares which aliases a file
+   publishes — the sigil marks each one as an alias rather than a key.
 3. **`import(string, @<ref>, {...})`** takes the path (as a string) at
    which to place the import, the file to import, and an optional
    destructuring of the imported aliases so they can be used directly.
    **Superseded — see §6.** Asked whether `import` was needed at all,
    the answer is no: a destructuring left-hand side does the job with
    no new builtin.
-4. **Shorthand.** `{ foo, bar }` stands for `{ foo: foo, bar: bar }`,
-   as in JavaScript. This turns out to be **load-bearing** rather than a
-   nicety, once §6 drops `import`.
+4. **Shorthand.** `{ %foo, %bar }` stands for `{ foo: %foo, bar: %bar }`
+   — the JavaScript idea, **gated on the sigil**. `{ foo, bar }` without
+   sigils stays a parse error, so the sugar can never be confused with
+   bare strings. It is **load-bearing** rather than a nicety, once §6
+   drops `import`.
 
 The worked case is the one from
 [`docs/reference-language.md`](../reference-language.md#named-constraint-aliases):
@@ -40,8 +47,8 @@ listen: $.type.uint8
 listen: 200
 
 # proposed
-uint8 = integer & min(0) & max(255)
-listen: uint8
+%uint8 = integer & min(0) & max(255)
+listen: %uint8
 listen: 200
 ```
 
@@ -91,12 +98,17 @@ All probed 2026-08-28, both ports byte-identical unless noted.
 | 12 | `a: %x` / `~x` / `^x` / `!x` | all bare strings | free in the weak sense: text, no meaning |
 | 13 | `a: ?x` / `:x` / `&x` | parse errors | free outright, but structurally confusing |
 | 14 | `a: #x` / `.x` / `@x` | comment / path / include | genuinely taken |
+| 15 | `%uint8: 1` | `{"%uint8":1}` — an ordinary key | **a sigil name is already a legal key** |
+| 16 | `a: { %foo, %bar }` | parse error | the sigil-gated shorthand is FREE |
+| 17 | `%`-led bare tokens, 309 files | **0**, and 0 in the spec | reserving `%` costs nothing measurable |
 
 Row 6 is the happiest: the JavaScript shorthand costs nothing.
 Row 11 matters for §6 — the destructuring form is the alias declaration
 generalised from a name to a pattern, not a new construct.
-Rows 12–14 matter for §4's A-4. Rows 2–5 are where the difficulty is,
-and §10 quantifies it.
+Rows 12–14 matter for §4's A-4, and rows 15–17 for the sigil that
+answers it. **Row 15 is the surprise**: `%name:` already parses as a
+key, so a sigil declaration needs no new operator — see §10. Rows 2–5
+are where the difficulty was, and §10 now questions whether it remains.
 
 ## 4. Aliases
 
@@ -116,7 +128,7 @@ already resolving references away, so the machinery is the right shape.
 
 ### Substitution, not assignment
 
-`uint8 = integer & min(0) & max(255)` followed by `listen: uint8`
+`%uint8 = integer & min(0) & max(255)` followed by `listen: %uint8`
 must mean exactly what `listen: integer & min(0) & max(255)` means —
 including at the *site* level, since a conflict reports the site that
 wrote the value. **Decision point A-1: what does a finding point at
@@ -133,8 +145,8 @@ Aontu is commutative — that is the language's central claim. So an
 alias must be usable **before its declaration**:
 
 ```
-listen: uint8
-uint8 = integer & min(0) & max(255)
+listen: %uint8
+%uint8 = integer & min(0) & max(255)
 ```
 
 must mean what the reverse order means. Anything else introduces a
@@ -156,16 +168,19 @@ cannot threaten [`docs/trust.md`](../trust.md) clause 2 (termination).
 it (`u8 = integer & bounds`, `bounds = min(0) & max(255)`) is the
 useful case and costs only the cycle check above. Recommend yes.
 
-### Shadowing
+### Shadowing — dissolved by the sigil
 
-**Decision point A-3.** If a file declares `uint8 = …` and also has a
-key `uint8:`, what does a bare `uint8` in value position mean? Three
-options: alias wins, key wins, or it is an error. Recommend **error** —
-the two readings are both plausible to a human, and Aontu's habit is to
-refuse an ambiguity rather than resolve it by a rule the reader has to
-remember. Cheap to check, since both names are known after the pass.
+**A-3 asked** what a bare `uint8` means when a file declares both an
+alias `uint8` and a key `uint8:`. **With `%` adopted the question does
+not arise**: `%uint8` and `uint8:` are different namespaces, and no
+spelling is ambiguous between them. The recommendation was to refuse the
+collision; there is now no collision to refuse.
 
-### A-4: the capture hazard, and three ways out
+This is the second decision the sigil removes rather than answers, and
+it is worth noticing that both were ambiguity questions. A namespace
+that is visibly distinct has no ambiguities to adjudicate.
+
+### A-4: the capture hazard — DECIDED, Option A
 
 A bare string that happens to match an alias name is the worse case.
 `status: active` is the bare string `"active"` today; if a file declares
@@ -180,8 +195,10 @@ file declaring `X = …` must mean the alias, or the alias is unusable.
 So "make the alias win only sometimes" is not on the table. The three
 real options are:
 
-**Option A — put a sigil in the alias's name.** Declared and used
-identically, so there is no question of which side carries it:
+**Option A — put a sigil in the alias's name. ADOPTED 2026-08-28.**
+Declared and used identically, so there is no question of which side
+carries it, and the sigil goes everywhere a name goes: the declaration,
+the use site, `export`, the destructuring pattern and the shorthand.
 
 ```
 %uint8 = integer & min(0) & max(255)
@@ -208,8 +225,9 @@ led by each candidate:
 
 All four are unused. `?`, `:` and `&` are free *outright* (parse errors
 today) but are structurally confusing; `#`, `.` and `@` are genuinely
-taken. **`%` is the recommendation**, and the choice among `% ~ ^` is
-free on this evidence.
+taken. **`%` is adopted** — it reads as substitution, which is what an
+alias does, and row 17 re-confirms zero `%`-led bare tokens in the
+corpus and none in the spec.
 
 **Option B — refuse a declaration that would capture.** Keep the bare
 spelling, and at the whole-file pass the design already requires for
@@ -230,16 +248,31 @@ with bare identifiers do. It leaves the property that adding a line can
 change an unrelated line, which is the thing the rest of Aontu does not
 do.
 
-**Recommendation: A**, because it is the only one that also answers §8,
-and the measurement puts its cost at the same near-zero as `=`. **B is
-the fallback** if the sigil is judged to cost more than it looks —
-it preserves the `listen: uint8` reading exactly. A and B compose, but
-A alone makes B unnecessary.
+**A is adopted.** It was the only option that also answered §8, and the
+measurement puts its cost at zero rather than merely near-zero. B and C
+are recorded above because the reasoning is worth keeping, not because
+either remains open.
+
+What adopting it settles, beyond A-4 itself:
+
+- **A-3 dissolves** — an alias and a key can no longer collide.
+- **§8 becomes four sigils out of four**, so every name-like thing in
+  the language is legible at a glance.
+- **The shorthand can be general** rather than confined, because
+  `{ %foo }` is unambiguous wherever it appears (§7). That is a better
+  answer to S-1 than the one this note gave.
+- **X-1 reopens in a better place.** Row 15 shows `%uint8:` is already a
+  legal key, so the `=` operator — the proposal's only break — may be
+  unnecessary. See §10.
 
 ## 5. `export`
 
-`export({ uint8, port })` — using the row-6 shorthand — declares which
-of the file's aliases are published. Everything else stays private.
+`export({ %uint8, %port })` — using the sigil-gated shorthand of §7 —
+declares which of the file's aliases are published. Everything else
+stays private. The sigils are not decoration: they are what makes the
+argument a list of *aliases* rather than a map of keys, so
+`export({ uint8 })` is not a shorter spelling of the same thing but a
+different — and refused — one.
 
 Open shape questions:
 
@@ -268,7 +301,7 @@ only thing actually missing.
 |---|---|---|
 | `"path.to.place"` | place the file's **values** at a path | yes — `svc: @"other.aon"` |
 | `@"other.aon"` | read the file | yes — that *is* `@"…"` |
-| `{ uint8, port }` | bring its **aliases** into scope | **no** — the only gap |
+| `{ %uint8, %port }` | bring its **aliases** into scope | **no** — the only gap |
 
 `@"…"` already crosses the file boundary for values. What it cannot
 carry is aliases, because an alias is erased before a value exists. So
@@ -279,8 +312,8 @@ occupies the same syntactic slot as the alias declaration — it is
 `KEY = value` with the key generalised from a name to a pattern:
 
 ```
-{ uint8, port }   = @"types.aon"     # bind two exported aliases
-{ u8: uint8 }     = @"types.aon"     # …and rename while binding
+{ %uint8, %port }  = @"types.aon"    # bind two exported aliases
+{ %u8: %uint8 }    = @"types.aon"    # …and rename while binding
 svc: @"types.aon"                    # values, if also wanted — unchanged
 ```
 
@@ -308,17 +341,18 @@ cross via `@"…"`, names cross via a pattern on the left of `=`.**
   the right-hand side with no new machinery, so this adds no
   distribution surface at all — which §6 of the earlier draft named as
   the outcome to aim for and could only hope for.
-- **The shorthand becomes load-bearing.** `{ uint8, port }` is now the
-  import syntax rather than a convenience, which also answers **S-1**:
-  it is confined to *pattern* position, a principled boundary rather
-  than an arbitrary one, and never collides with bare strings in
-  ordinary maps.
+- **The shorthand becomes load-bearing.** `{ %uint8, %port }` is now the
+  import syntax rather than a convenience — and with the sigil adopted
+  it needs no confinement to be unambiguous, which is a better answer to
+  **S-1** than this note first gave (§7).
 
 ### The one question it opens
 
-`@"other.aon"` evaluates to the file's **value**. So `{ port, host } =
-@"config.aon"` has two readings: bind to the file's exported *aliases*,
-or bind to the *keys* of the map it evaluates to.
+`@"other.aon"` evaluates to the file's **value**. So `{ %port, %host } =
+@"config.aon"` still has two readings: bind to the file's exported
+*aliases*, or bind to the *keys* of the map it evaluates to. The sigil
+marks the left-hand names as aliases; it says nothing about what they
+are bound *from*.
 
 **Decision point E-1.** The second reading is arguably more natural, and
 it would make `export` unnecessary — the public surface would just be
@@ -329,27 +363,39 @@ They could coexist (aliases when the name is exported, keys otherwise),
 but a rule that silently falls back from one namespace to another is the
 A-4 mistake in a new place, so: pick one.
 
-Recommend the **alias** reading, with `export` retained — and note that
-under Option A of §4 the two are visibly different anyway, since an
-exported alias is written `%uint8` and a key is not.
+Recommend the **alias** reading, with `export` retained. The sigil helps
+but does not decide this: it makes the *binding* unambiguous, while E-1
+is about the *source*. Under the alias reading `{ %port } = @"c.aon"`
+requires `c.aon` to have written `export({ %port })`; under the key
+reading it would bind from `port:`. Pick one.
 
-## 7. The `{ foo, bar }` shorthand
+## 7. The `{ %foo, %bar }` shorthand
 
-Row 6 shows this is free syntax. Two notes:
+`{ %foo, %bar }` stands for `{ foo: %foo, bar: %bar }`: the key is the
+alias's name without the sigil, the value is the alias reference. That
+is the JavaScript reading, and it is what makes `export({ %uint8 })`
+say "publish the alias named uint8" rather than "publish a key called
+`%uint8`".
 
-- It should be **general**, not special to `export`/`import`. If
-  `{foo, bar}` means `{foo: foo, bar: bar}` in one place and is a parse
-  error in another, that is a second grammar to remember. But general
-  means it also applies to ordinary maps, where `foo` in value position
-  is a bare string today — so `{name, port}` would mean
-  `{name: "name", port: "port"}` in a file with no such aliases, which
-  is almost certainly not what anyone means.
-  **Decision point S-1**: general (and therefore interacting with the
-  bare-string hazard of §4) versus confined to the two builtins
-  (and therefore a local rule). This note leans **confined**, on the
-  grounds that the shorthand's whole value is in an alias context.
-- Canon must expand it. `{foo}` and `{foo: foo}` are the same document
-  and must hash identically.
+**The sigil settles the scope question this note could not.** Written
+`{ foo, bar }`, the shorthand had to be confined to pattern position,
+because in an ordinary map `foo` in value position is a bare string —
+so `{name, port}` would have meant `{name: "name", port: "port"}`, which
+nobody intends. Written `{ %foo, %bar }` there is no such collision:
+row 16 shows the sigil form is a parse error today, so it can be given
+one meaning everywhere without displacing anything.
+
+So the shorthand can be **general**, and S-1's confinement is
+unnecessary. The rule is not "this form works in export and
+destructuring" but "this form works for sigil aliases" — a rule about
+what the entries *are*, which is why it needs no positional exception.
+
+`{ foo, bar }` without sigils stays exactly what it is today: a parse
+error. That is the guard, and it costs nothing to keep.
+
+Canon must still expand the sugar. `{ %foo }` and `{ foo: %foo }` are
+the same document and must hash identically — and since aliases are
+erased before canon (§4), both reduce to whatever `%foo` denotes.
 
 ## 8. Interactions to keep straight
 
@@ -363,12 +409,11 @@ has to tell them apart at a glance:
 | `foo` (alias) | the **file** | file | **yes** |
 | `foo:` (key) | it *is* the document | document | no |
 
-Under the bare spelling, three of the four are distinguishable by sigil
-and the alias is the one that is not — the ergonomic win and the
-readability cost in one sentence, with §4's capture hazard as its
-sharpest consequence. **Option A of §4 makes it four out of four**,
-which is the second reason to prefer it: this table is an argument for
-a sigil quite apart from A-4.
+With `%` adopted this is **four sigils out of four**: every name-like
+thing in the language is legible at a glance, and none can be mistaken
+for a bare string. That property was the second argument for the sigil,
+independent of A-4 — and it is the one that will still matter in a year,
+when nobody remembers what A-4 was.
 
 ## 9. Decision points, gathered
 
@@ -378,17 +423,23 @@ Nothing should be built before these are answered.
 |---|----------|------------------|
 | **A-1** | What site does a finding name when the value came via an alias? | Both, as a `why` contribution |
 | **A-2** | May an alias reference another alias? | Yes, with a cycle check |
-| **A-3** | Alias name colliding with a key | Refuse |
-| **A-4** | **Alias name colliding with a bare string** | **Option A — a sigil in the name (`%uint8`)**; B as fallback. §4 |
+| **A-3** | Alias name colliding with a key | **Dissolved** by the sigil — different namespaces. §4 |
+| **A-4** | Alias name colliding with a bare string | **DECIDED: `%` sigil in the name.** §4 |
 | **E-1** | Does a destructure bind exported *aliases* or the value's *keys*? | Aliases, `export` retained. §6 |
-| **S-1** | Is `{foo, bar}` general or confined? | **Answered** by §6 — confined to pattern position |
-| **X-1** | Is `=` the right spelling at all? | See §10 |
+| **S-1** | Is `{%foo, %bar}` general or confined? | **Answered: general**, because the sigil disambiguates. §7 |
+| **X-1** | Is `=` the right spelling at all? | **Reopened, better placed** — row 15. §10 |
 
-**Dissolved, not decided.** `I-1` (placement as a string path) and `I-2`
-(exported but not destructured) were questions about `import`, and §6
-removes the builtin that raised them; `S-1` is answered by the same
-change. A-4 moved from unresolved to a recommendation with a
-measurement behind it. **Two open questions replace four.**
+**Three of the original eight are now dissolved rather than decided,
+and that is the pattern worth noticing.** `I-1` and `I-2` were questions
+about `import`, which §6 removes. `A-3` was an ambiguity between an
+alias and a key, which the sigil makes unrepresentable. In each case the
+question disappeared with the construct that raised it, which is a
+better outcome than answering it — an answered question is a rule
+someone has to remember.
+
+**Open: A-1, A-2, E-1, X-1.** A-1 (which site a finding names) and A-2
+(alias-of-alias, lean yes) are unchanged. E-1 is new with §6. X-1 is
+the live one, and the sigil has improved its odds — see §10.
 
 ## 10. Compatibility, measured
 
@@ -432,17 +483,33 @@ worth noticing that **this proposal is already two-thirds named**:
 `export` and `import` are builtins in the house style, and `=` is the
 one operator among them.
 
-**X-1** is therefore a real fork, not a formality:
+**X-1 is therefore a real fork — and adopting the sigil has changed
+what is on it.** Row 15 is the reason: `%uint8: 1` *already* parses, as
+an ordinary key named `%uint8`. So a third option exists that did not
+before:
 
-- `foo = 1` — best ergonomics, the break above, whitespace becomes
-  significant in one place.
-- `alias(foo, 1)` — no break at all, consistent with ADR-008 and with
-  the proposal's own other two parts, worse to read at the density
-  where aliases pay off.
+- `%foo = 1` — the proposal as written. Needs the `=` break above.
+- `alias(%foo, 1)` — no break, consistent with ADR-008's named style,
+  worse to read at the density where aliases pay off.
+- **`%foo: integer & min(0)`** — declare an alias with the ordinary
+  key syntax, in the namespace the sigil already creates. **No new
+  operator, no lexing break, nothing to measure.** The whole of §10's
+  compatibility argument becomes moot, because there is nothing to
+  break.
 
-This note does not resolve it. It records that the syntax is the
-expensive part of the proposal and the semantics are the valuable part,
-and that the two can be decided separately.
+The third looks strictly better and it should be tested properly before
+being believed: it means a declaration and a key are spelled alike and
+told apart only by the sigil, which is either the point (one syntax,
+one namespace marker) or a confusion (two things that look the same).
+It also needs an answer for the destructuring form, which is the one
+place `=` is doing work a key cannot: `{ %a, %b } = @"f.aon"` binds
+several names at once, and `%…:` has no obvious multi-binding spelling
+(`%{ a, b }: @"f.aon"` is a parse error today, so it is available but
+would be a new construct).
+
+**Recommendation: settle X-1 before P1, and start from the third
+option.** The syntax was the expensive part of this proposal; the sigil
+may have made it free.
 
 ## 11. Non-goals
 
@@ -463,8 +530,10 @@ Per ADR-001 nothing lands without shared rows probed in both engines.
 Sketch only, since §9 is open:
 
 - **Aliases:** substitution in every value position; use-before-declare
-  (order independence); alias-of-alias; cycle refused; shadowing refused;
-  erased from canon *and* from the hash — a document with aliases and its
+  (order independence); alias-of-alias; cycle refused; a bare `foo` and
+  an alias `%foo` in one file staying independent (the A-4 guard, which
+  can only be written now the sigil exists); erased from canon *and*
+  from the hash — a document with aliases and its
   expanded twin must produce the identical `aon1-…` string, which is the
   sharpest single row in this list.
 - **Export and destructuring:** exported name bindable; unexported name
@@ -476,15 +545,16 @@ Sketch only, since §9 is open:
   so the existing include rows already cover every confinement mode and
   the include manifest. That absence is itself the argument for §6 —
   the earlier `import` design would have needed a row per mode.
-- **Shorthand:** `{foo}` ≡ `{foo: foo}` in canon; refusal wherever S-1
-  lands it out of scope.
+- **Shorthand:** `{%foo}` ≡ `{foo: %foo}` in canon, in every position
+  since S-1 lands general; and `{foo}` without a sigil still a parse
+  error — the guard that keeps the sugar unambiguous.
 - **Negatives paired with positives** throughout, per the house rule.
 
 ## 13. Phasing
 
 | Phase | Content | Gate |
 |-------|---------|------|
-| P0 | Settle X-1, A-4 and E-1 first | no code |
+| P0 | Settle X-1 and E-1 first — A-4 is decided | no code |
 | P1 | Aliases, file-local, with canon erasure and the cycle/shadow refusals | the hash row |
 | P2 | `export`, and `{…} = @"…"` destructuring | canon expansion |
 
@@ -492,13 +562,16 @@ P1 is independently useful and independently shippable: file-local
 aliases with nothing crossing a file boundary is the whole of §2's
 argument, and it can be judged before any of §5–6 is built.
 
-**A-4 must be answered before P1, not during it** — if an alias name
-silently captures a bare string, adding an alias to a file can change
-the meaning of a line that does not mention it, which is the opposite of
-what the rest of the language does. It is no longer the open risk it
-was: §4 gives three ways out, a recommendation, and a corpus
-measurement putting the recommended one at the same cost as `=`. But it
-determines the spelling, so it cannot be deferred into implementation.
+**A-4 is decided and no longer gates P1.** The `%` sigil ends the
+capture hazard outright: bare text stays bare text, and no declaration
+can reach a line that does not carry the sigil.
+
+**What gates P1 now is X-1** — whether a declaration is `%foo = …` or
+simply `%foo: …` — because that is the difference between a proposal
+carrying a lexing break and one carrying none, and it cannot be deferred
+into implementation. §10's third option would make the whole
+compatibility section moot; it deserves a proper look before P1 rather
+than a guess during it.
 
 The old P2/P3 split is gone with `import`: `export` and destructuring
 are one phase now, because destructuring *is* the import.

--- a/docs/design/AONTUCONSTRAINTS.0.md
+++ b/docs/design/AONTUCONSTRAINTS.0.md
@@ -11,12 +11,15 @@ proposes are **declined outright** — [ADR-008](../../ADR.md#adr-008--constrain
 adopting `>=10` later needs a new ADR. N3 is **deferred** (2026-08-28,
 maintainer decision — unblocked, simply not now); the sized-integer
 sugar is **not needed**, since named aliases express it in user space
-(§6); and row 7's defect is still live: `port: >=1024` still
-evaluates to `{"port":">=1024"}` and exits 0. Do not read §2 as current
-behaviour. The item-by-item reconciliation, re-run against both engines
-on 2026-08-28, is in
+(§6); and **row 7 was not a defect** — `port: >=1024` still evaluates to
+`{"port":">=1024"}`, because `>` is not a reserved character and a bare
+value containing one is ordinary text, exactly as `port: high` is
+`"high"`. This note grades that "worse than unsupported"; the grading
+was **retracted** on 2026-08-28, since it assumes an intent the document
+never states. Do not read §2 as current behaviour. The item-by-item
+reconciliation, re-run against both engines on 2026-08-28, is in
 [`docs/capability-review/g1-constraint-algebra.md`](../capability-review/g1-constraint-algebra.md#reconciliation-with-the-2026-08-27-constraint-design-note);
-row 7 is [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45.
+row 7's disposition is [`use-cases/BUGS.md`](../../use-cases/BUGS.md) §45.
 **Home:** this repository (TS canonical under `ts/`, Go port under `go/`)
 **Origin:** empirical survey run from boru, which consumes the Go port
 via its `boru:parselang` module (pinned at `go/` v0.1.6)
@@ -229,8 +232,18 @@ well-formed wrong config.
 > named atoms — `min`, `max`, `above`, `below`, `neq` — so
 > `port: integer & min(1024) & max(65535)` is the spelling of the
 > example below. One spelling per concept; adopting the operators later
-> needs a new ADR. What remains open is only what `>=1024` should do
-> TODAY, where it is silently the string `">=1024"` (BUGS.md §45).
+> needs a new ADR. And what `>=1024` does today is settled too: it stays
+> the string `">=1024"`, because `>` is not a reserved character and a
+> bare value containing one is ordinary text — `port: high` is `"high"`
+> for the same reason.
+>
+> **The paragraph immediately below grades that "worse than unsupported,
+> since it produces a well-formed wrong config". That grading is
+> retracted** (2026-08-28; BUGS.md §45, itself retracted). It was
+> reasonable when written — bounds existed in no spelling, so a reader
+> writing `>10` could only have meant one thing — but it assumes an
+> intent the document never states, and ADR-008 removes its premise.
+> Nothing here needs fixing; the original text is kept as written.
 
 Unary comparison prefixes in value position: `>10`, `>=10`, `<5`,
 `<=5`, `!=0`. Composition needs no new syntax — `&` already exists:
@@ -398,7 +411,7 @@ doing — every aontu program terminates:
   arrived as named atoms, so nothing had to be reused, and the break
   would now buy only a synonym. The analysis above stands as the reason
   a *refusal* of those bare strings would still be a break, if BUGS.md
-  §45 is closed that way.
+  §45 was retracted rather than closed.
 - **N2/N3 are pure additions** (both currently lex errors).
 - boru sees nothing until `lang/go/go.mod` bumps the pin; the boru-side
   test rows below make the bump's behavior change visible in one diff.

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -1331,16 +1331,41 @@ disagreement that plain evaluation shows too, now recorded in
 
 ## constraint-syntax — the notation the constraint algebra did not claim
 
-### 45. CUE-style constraint operators lex as bare strings, so a schema written in them enforces nothing [critical, by design]
-**Status: NARROWED 2026-08-28, not fixed.**
+### 45. CUE-style constraint operators lex as bare strings [RETRACTED — not a defect]
+**Status: RETRACTED 2026-08-28. This entry was wrong, and is kept
+because the numbering is cited elsewhere.**
+
+`>`, `<`, `=` and `!` are not reserved characters. A bare value
+containing them is **undifferentiated text content**, for exactly the
+reason `port: high` is the string `"high"` — the language never assigned
+those characters a meaning, and
 [ADR-008](../ADR.md#adr-008--constraints-are-named-not-spelled-with-operators)
-declines CUE's operator spellings outright: constraints are named, not
-spelled with operators. That removes one of the two ways this could have
-been closed — making `>=1024` *mean* `min(1024)` — and leaves the other:
-**refuse** a bare string whose first character is one of `> < = !` and
-name the atom to use. That refusal is the only repair consistent with
-the ADR, and it is still an open choice. Until it is taken, everything
-below remains true of the shipped engine.
+settled that it never will. `port: >=1024` producing `">=1024"` is
+therefore not a silent failure; it is the bare-string rule applying
+uniformly.
+
+**What the entry got wrong** is that it graded the behaviour against an
+*intent* rather than against the language. Calling the output "a
+well-formed wrong config" assumes the author meant a bound — but nothing
+in the document says so, and an engine cannot read that. By the same
+argument `timeout: fast` would be a critical defect, which nobody would
+claim. The severity was inherited uncritically from
+`AONTUCONSTRAINTS.0.md` §6, which wrote it when bounds did not exist in
+any spelling and CUE's operators were the proposal on the table; once
+ADR-008 declines that proposal, the premise is gone and the sentence
+should not have outlived it.
+
+There is consequently **nothing to fix and no repair outstanding**. The
+earlier suggestion — refuse a bare string leading with `> < = !` — is
+withdrawn: it would carve an arbitrary hole in the bare-string rule to
+serve a guess about intent, and make `a: >x` an error while `a: ?x`
+stayed fine.
+
+What survives is a *documentation* point, not a defect: a reader arriving
+from CUE may expect those characters to mean something, and the
+reference should make the named atoms easy to find from where they would
+look. `docs/reference-language.md` "Named constraint aliases" and
+`docs/how-to.md` "Name a reusable constraint" are that surface.
 
 `>10`, `>=10`, `<5`, `!=0` and `=~"^ab"` are all legal aontu — as
 **strings**. A schema written in them parses, evaluates, validates
@@ -1355,14 +1380,9 @@ $ echo $?
 0
 ```
 
-Identical in both ports, so this is not a parity defect. It is by design
-in the narrow sense that bare strings are a documented scalar form
-(`reference-language.md`: `bare string | a:hello | "hello"`) — though
-the documentation nowhere says a `>` may lead one. It is kept here under
-this file's rule for by-design behaviour whose consequence is severe,
-and the consequence is the one the severity scale calls critical: silent
-wrong output from a document whose whole purpose is to reject wrong
-input.
+Identical in both ports. Bare strings are a documented scalar form
+(`reference-language.md`: `bare string | a:hello | "hello"`), and a
+leading `>` does not except a value from that rule.
 
 `docs/design/AONTUCONSTRAINTS.0.md` §6 named this in its row 7 and
 called it "worse than unsupported, since it produces a well-formed wrong
@@ -1385,14 +1405,8 @@ aontu's commutative-unification core, which makes CUE notation the thing
 a new user most plausibly arrives holding. `min(1024)` is not
 discoverable from a document that silently accepted `>=1024`.
 
-A fix has a cheap form that needs no new syntax and breaks nothing that
-is not already broken: refuse a bare string whose first character is one
-of `> < = !` and name the atom to use. That is a language change with
-its own spec rows in both ports, so it is recorded here rather than
-taken as part of a documentation pass. It is also, after ADR-008, the
-only form left — and note it is still a *break*, just a smaller one: a
-document today holding `a: ">10"` unquoted would start failing. Quoted
-strings are unaffected.
+*(The original entry proposed refusing such bare strings. Withdrawn —
+see the Status note above.)*
 
 ## Elsewhere in this review
 


### PR DESCRIPTION
Documents only — no engine or spec change. Two corrections from review, and two design simplifications.

---

## 1 — `108cc31` §45 retracted; `import()` dropped

**§45 was never a defect.** `>`, `<`, `=` and `!` are not reserved characters, so a bare value containing them is undifferentiated text — for exactly the reason `port: high` is `"high"`. The entry graded the behaviour against an assumed **intent**: calling `{"port":">=1024"}` a *well-formed wrong config* assumes the author meant a bound, which nothing states and no engine can read. By the same argument `timeout: fast` would be critical.

The grading was inherited from `AONTUCONSTRAINTS.0.md` §6, written when bounds existed in **no** spelling. ADR-008 declines that proposal, and the grading should not have outlived its premise. **The proposed refusal is withdrawn** — it would carve a hole in the bare-string rule to serve a guess, making `a: >x` an error while `a: ?x` stayed fine. Corrected in six places; the original prose in the constraints note is kept and marked, not rewritten.

**`import()` is not needed.** Two of its three arguments duplicate existing machinery — placement is `svc: @"other.aon"`, and reading the file *is* `@"…"`. The only gap is binding aliases, and a destructuring left-hand side closes it while sitting in the **same syntactic slot** as the alias declaration.

Dropping it **dissolves I-1 and I-2**, and **removes the trust argument entirely** — with a plain `@"…"` on the right there is no new file-reading route, so confinement and the include manifest apply unchanged. The earlier design needed a spec row per confinement mode; this needs none.

## 2 — `0dfab20` `%` adopted as the alias sigil

A-4 is decided. The sigil is part of the alias's **name**, so declaration and use are spelled identically, and it carries through every place a name appears:

```
%uint8 = integer & min(0) & max(255)
listen: %uint8
export({ %uint8, %port })
{ %uint8, %port } = @"types.aon"
{ %u8: %uint8 }   = @"types.aon"
```

The shorthand is gated on the sigil: `{ %foo, %bar }` → `{ foo: %foo, bar: %bar }`, while `{ foo, bar }` stays the parse error it is today.

**What it settles beyond A-4:**

- **A-3 dissolves.** `%uint8` and `uint8:` are different namespaces, so the collision the note proposed to refuse cannot be written. Both questions the sigil removes were *ambiguity* questions — a visibly distinct namespace has none to adjudicate.
- **S-1 gets a better answer.** Written bare, the shorthand had to be confined to pattern position (`{name, port}` would have meant `{name:"name", port:"port"}`). Written with sigils there is no collision, so it can be **general** — a rule about what the entries *are*, not a positional exception.
- **§8 becomes four sigils out of four**, so every name-like thing is legible at a glance. That argument stands independent of A-4, and outlasts it.

### X-1 reopens, better placed — and now gates P1

Probing for the sigil turned up the surprise: **`%uint8: 1` already parses**, as an ordinary key named `%uint8`. So a third option exists that did not before:

```
%uint8: integer & min(0) & max(255)
```

Declare an alias with the ordinary key syntax, in the namespace the sigil creates. **No new operator, no lexing break, nothing to measure** — the whole compatibility section becomes moot.

It needs testing before it is believed: a declaration and a key would be spelled alike and told apart only by the sigil, which is either the point or a confusion. And it needs an answer for the destructuring form — the one place `=` does work a key cannot. `%{ a, b }: @"f.aon"` is a parse error today, so that spelling is available but would be a new construct.

**Three of the original eight decision points are now dissolved rather than decided** (I-1, I-2 with `import`; A-3 with the sigil) — the better outcome, since an answered question is a rule someone has to remember. Open: A-1, A-2, E-1, X-1.

## Verification

- `node --test ts/dist-test/docs.test.js` — 2/2.
- Links and ADR anchors resolve.
- Baseline table grew from 10 rows to **17**, every row probed against `aontu@0.53.0` and `go/v0.1.11`. New: `%uint8: 1` is a legal key; `{ %foo, %bar }` is a parse error; `%`-led bare tokens number **zero** across the 309-file corpus and zero in the spec sources.