### PR TITLE
G9: code generation from the model — the plan for declarative transformation, and six defects found on the way

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,8 @@ record them.
 
 Forward-looking design work lives in
 [`docs/capability-review/`](docs/capability-review/index.md): eight gap
-documents (G1–G8), each ending in a numbered implementation plan.
+documents (G1–G9), each ending in a numbered implementation plan
+(G9 was opened 2026-08-30, after the original eight had landed).
 **When a phase of one of those plans lands, its row in
 [`docs/capability-review/progress.md`](docs/capability-review/progress.md)
 changes in the same commit** — the register is the single record of what

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Quick reference:
   `ts/test/docs.test.ts` enforces it — every tagged snippet tested or
   skipped with a reason.
 - Forward-looking work is the capability review in
-  `docs/capability-review/` (G1–G8, design) plus
+  `docs/capability-review/` (G1–G9, design) plus
   `docs/capability-review/progress.md` (the register of what has
   landed). **A phase's row in the register changes in the same commit
   that changes its status** — see AGENTS.md, "The capability-review

--- a/docs/capability-review/g9-transformation.md
+++ b/docs/capability-review/g9-transformation.md
@@ -1,0 +1,2070 @@
+# G9: Declarative transformation — one model, many generated artifacts
+
+*Status: design proposal. Part of the
+[capability review](index.md), opened August 2026 after G1–G8 landed.
+This document expands a gap the original eight did not name: turning
+an evaluated Aontu model into OUTPUT CODE — TypeScript, Go, SQL,
+YAML, OpenAPI — in three forms that must all feel native to the
+language. Form (a) is a host program consuming the model; form (b) is
+driving [jostraca](https://github.com/jostraca/jostraca) as a library;
+form (c) is DECLARATIVE TRANSFORMATION, designed with XSLT as the
+inspiration. The owner has settled the open questions as decisions D1
+through D7 (see [Design space](#design-space)); this document
+specifies them rather than relitigating them. Per-phase status will be
+in the [progress register](progress.md), which is authoritative for
+status; this document is authoritative for design. Every claim marked
+VERIFIED was run against the built CLIs at 0.53.0 — `node
+ts/bin/aontu.js` and a fresh `go build ./cmd/aontu` — during the
+drafting of this document.*
+
+## Problem
+
+A model that is ground truth for a system, and cannot produce the
+system's code, is ground truth for nothing that ships. Every one of
+the fourteen use cases under [`use-cases/`](../../use-cases/) exists
+to be *derived from*: `10-data-model/domain.aon` describes four record
+types a Go server, a TypeScript client and a SQL schema all have to
+agree about; `03-api-contract/` describes an API whose clients,
+servers and tests all derive from it; `01-service-catalog/` describes
+eight services whose Kubernetes manifests are the point. Today none of
+those derivations exists, and the reason is one missing capability,
+not fourteen.
+
+**First failing example, from a real document.**
+[`use-cases/10-data-model/domain.aon`](../../use-cases/10-data-model/domain.aon)
+already carries every fact a TypeScript emitter needs:
+
+```aon
+schema: {
+  Customer: type(close({
+    id: string & re("^cust-[0-9]{4}$")
+    ledgerId: integer & min(1) | biginteger & min(1)
+    name: string & length(min(1) & max(120))
+    country: string & re("^[A-Z]{2}$")
+    currency: string & re("^[A-Z]{3}$") & neq("XXX", "XTS")
+    email?: string & re("^[^@ ]+@[^@ ]+[.][a-z][a-z]+$")
+    creditLimitCents?: integer & min(0) & max(100000000000)
+  }))
+  ...
+}
+```
+
+The wanted artifact is fifteen lines of TypeScript. Aontu cannot
+produce a byte of it. `generate()` returns JSON and nothing else; a
+document evaluates to a value, and there is no verb, no library
+function and no vocabulary that turns a value into target-language
+source. So the `Customer` interface gets written by hand, in three
+languages, and then the model and the three copies drift — which is
+exactly the disease [G8](g8-generation.md) diagnosed *inside* a
+document, reappearing *between* the document and everything derived
+from it. G8 removed the copy-paste within the model; nothing removed
+it at the boundary.
+
+**Second failing example, and this one is not a missing feature but a
+missing shape.** The obvious repair is to build the text in the model.
+Aontu can already hold a code template as a value — VERIFIED,
+backtick strings are multi-line and process escapes in both ports:
+
+```
+$ printf 'a: `x\\ty\\nz`\n' | aontu -    ->  {"a":"x\ty\nz"}
+```
+
+and `+` concatenates and even coerces — VERIFIED, both ports:
+`"port: " + 8080` is `"port: 8080"`, `"x" + true` is `"xtrue"`. So a
+model can compute one line of output per field. What it cannot do is
+assemble those lines into a body:
+
+```
+$ printf 'n: [a, b]\nj: join($.n, ",")\n' | aontu -
+[aontu/unknown_function]: Cannot resolve value at path $.j
+$ printf 'n: [a, b]\nj: sum($.n)\n' | aontu -
+[aontu/invalid-arg]: Cannot sum value at path $.j
+```
+
+There is no `join`, no `indent`, no `replace`, no case conversion
+beyond whole-string `upper()`/`lower()`, and `sum()` is numeric only.
+`sum` : `add` :: `join` : `+` — the fold over `+` is the exact
+missing sibling of a fold the language already has.
+
+**Third, the natural map is a meet.** `each()` looks like the
+element-wise mapper every author reaches for and is not one —
+VERIFIED, both ports:
+
+```
+$ printf 'n: [a, b]\nup: each($.n, upper(_))\n' | aontu -
+[aontu/scalar_value]: Cannot unify values at path $.up.0
+```
+
+`each` MEETS the template into each child
+(ts/src/val/EachFuncVal.ts, the `unite(elctx, el, ...)` call), so
+`each($.ports, integer)` is a schema statement and a lattice citizen,
+and `each($.names, upper(_))` is a contradiction. `pack()` maps, but
+only into a map, and only over string-keyed data: VERIFIED,
+`pack([{n: id},{n: name}], {x:1})` is `[aontu/pack_key]`, so a list of
+records — the central shape of any code-generation model — cannot be
+packed at all.
+
+**Fourth, and this is the one that decides the architecture.** Nothing
+checks the derivation. If a host program walks the model and prints
+text, the text is checked by the target compiler, hours later, in
+someone else's repository. XSLT's answer to this is its defining
+trick: a stylesheet is itself an instance of its own output vocabulary
+(XML), with instructions distinguished by namespace, so literal result
+elements pass through and can be validated against the output schema.
+Aontu has no analogue, and without one, the "transformation layer"
+would be a text templating engine with a lattice bolted to the front —
+the failure mode every prior art below shares.
+
+For the agent mission these four are one disease. An agent asked to
+"add a field to Customer" must today edit the model, the TypeScript,
+the Go, the SQL and the OpenAPI, infer the pattern from examples in
+four languages, and hope. Every one of those edits is a place where an
+agent can make the system disagree with itself, and no conflict is
+detected anywhere.
+
+## Current state
+
+What exists is more than it looks like, and most of it is reusable.
+
+- **A model can already be read by a model.** VERIFIED, and this was
+  not previously recorded: `pack()` enumerates the keys of a
+  `type(close({...}))` record, even though such a record generates
+  as `{}`. So a transform CAN introspect a schema. The mechanism is
+  that `PackFuncVal`'s key walk reads the bag's keys while the
+  `type()` mark only affects `gen` (ts/src/val/BagVal.ts).
+- **`match()` discriminates Aontu kinds by trial meet.** VERIFIED:
+  `match(_, integer, "int", string, "string", boolean, "bool", [],
+  "list", {}, "map", "any")` classifies correctly, because `match`
+  selects by unifiability (ts/src/val/MatchFuncVal.ts) and the four
+  numeric leaves are mutually disjoint. One thing it cannot do:
+  bare `number` unifies with every leaf, so a field declared `number`
+  classifies as whichever leaf is tried first and no re-ordering
+  fixes it. `domain.aon` lines 36–41 already argue, on its own
+  terms, that bare `number` is the wrong spelling for a
+  codegen-facing field.
+- **`pick(pack(d, {f: t}), f)` is an element-wise map, and it
+  composes.** VERIFIED byte-identically in BOTH ports, nested inside
+  another `pack` template, over the real `domain.aon` across an
+  `@"./domain.aon"` include. A complete transform is therefore
+  expressible today, with no new grammar and no new builtin. The
+  worked example is [below](#worked-example-1).
+- **A source record's own fields are reachable through the
+  placeholder.** The obvious spelling fails —
+  VERIFIED `pack($.m, {got: _.n})` is `[aontu/no_path]` — but a
+  hidden capture works, VERIFIED byte-identically in both ports:
+
+  ```aon
+  m: {a: {n: "one", t: "T"}, b: {n: "two", t: "U"}}
+  v: pack($.m, {src: hide(_), d: `x` + .src.n + .src.t})
+  # -> {"a":{"d":"xoneT"},"b":{"d":"xtwoU"}}
+  ```
+
+  This matters: a transform can read any number of fields of the
+  record it is transforming, today. It also demonstrates why a
+  REPLACING combinator is needed — under `each` the source keys `n`
+  and `t` survive the meet into the produced element.
+- **`funcMap` is the blessed extension point.** ts/src/lang.ts:530
+  maps names to Val classes; the G1 atoms and the G8 combinators
+  landed there "with zero grammar change". Adding `join` is a class
+  plus registry entries, not a parser change.
+- **Marker-delimited regeneration already exists.** `agentsMdSplice`
+  (ts/src/agentsmd.ts) rewrites between markers and leaves
+  surrounding hand-written text alone — the mechanism a generator
+  needs for protected regions, already written once.
+- **The loss-report contract exists.** `SchemaLoss`/`SchemaReport`
+  (ts/src/jsonschema.ts:41-67) is the established shape for "the
+  artifact ships, and what could not be carried is reported": a
+  `{path, construct, reason}` triple, a three-valued verdict, and
+  `--strict` turning the report into a refusal. A code emitter has
+  strictly more loss than a JSON Schema emitter and must not invent
+  a second shape.
+- **`anchorAt` gives every verb a slice.** `--at <path>` already
+  exists on `vet`, `jsonschema`, `diff` and `breaking`, and
+  `aontu get $.db -c` already yields a stable canon fragment for a
+  slice. D5's "every output declares the slice it consumes" needs no
+  new selection mechanism.
+- **`std/system` is the bundling precedent.** ts/src/std.ts:16-66 and
+  go/std.go carry the same bytes, resolved from the engine itself
+  under every include capability except `none`, pinned by
+  test/spec/std-system.tsv's canon and hash rows. A shipped
+  vocabulary costs no new machinery.
+- **Jostraca is real, is the same author's, and is at parity.**
+  `/home/user/jostraca/jostraca` at 0.33.1, module path
+  `github.com/jostraca/jostraca/go`, tags `v0.33.1` and
+  `go/v0.33.1`, 38 parity scenarios under `go/testdata/parity/`. It
+  owns atomic write-then-rename, the `existing.txt` policy matrix
+  (`write|preserve|present|diff|merge`), three-way merge with the
+  previous generate as ancestor, `JOSTRACA_PROTECT`, `Inject`
+  markers, `Fragment`/`Slot`, exclusion and dry-run.
+
+What structurally blocks the capability:
+
+- **There is no output vocabulary.** Nothing says what a transform
+  result IS, so nothing can check one.
+- **There is no fold to a string** (`join`), so per-item strings
+  cannot become a body. This is the single missing primitive.
+- **There is no order-preserving element-wise map.** `pick(pack(...))`
+  goes through a map, and map keys are code-point sorted in both
+  ports (ts/src/keyorder.ts). VERIFIED on a real document: the
+  service catalog's source order is `payments, ledger, risk` and the
+  generated order is `ledger, payments, risk`. For a struct's fields
+  or a SQL DDL's columns that is valid but surprising output that
+  changes silently when a field is renamed.
+- **Four facts are invisible to any in-language transform.**
+  VERIFIED: optionality (`email?:` packs with no marker), source key
+  order, closedness, and disjunction arm membership
+  (`ledgerId: integer & min(1) | biginteger & min(1)` collapses to
+  one arm under `match`). All four are things generated code needs.
+- **Hidden and unfilled-optional children flow into every bag.**
+  VERIFIED identically in both ports:
+  `m: {a: 1, b?: 2, c: hide(3)}` gives `each($.m)` = `[1,2,3]` while
+  the map generates `{"a":1,"b":2}`. For an aggregate over numbers
+  this was invisible; for a primitive whose output is bytes written
+  to a file it is a disclosure hazard.
+- **Three engine defects sit directly on this path**, none of them
+  recorded in [`use-cases/BUGS.md`](../../use-cases/BUGS.md),
+  [`DIVERGENCE.md`](../../DIVERGENCE.md) or
+  [`test/spec/divergent.tsv`](../../test/spec/divergent.tsv) — which
+  today has **zero** rows. They are enumerated in
+  [Phase 0](#phase-0--the-four-gating-defects-s) and are gating.
+
+## Prior art
+
+Every system that generates code from a model chooses one of four
+shapes, and the failure modes are consistent enough to be predictive.
+
+**XSLT** is the direct inspiration and the direct warning. Its
+defining property is that a stylesheet is an instance of its own
+output vocabulary — XML — with `xsl:` as the escape, so literal result
+elements pass through and can be validated against the output schema.
+Nothing else in the field has that. Its failures are equally
+instructive, and all four are avoidable here. (1) *Whitespace is
+unowned*: whitespace-only text nodes are stripped but a node with any
+non-whitespace is preserved whole *including its source indentation*,
+and `xsl:output indent` applies only to the `xml` and `html` methods —
+so the community's answer for text output was DTD entities expanding
+to `xsl:text`. (2) *Conflict resolution is by accident*: XSLT 1.0's
+four-valued default priority is resolved, when it ties, by
+"choosing the template rule that occurs last", and XSLT 3.0 retracted
+both that and import precedence. (3) *The built-in rule is unsafe for
+text*: unhandled nodes have their string value copied into the result,
+which for source code means model data silently landing in the middle
+of a file. (4) *Action at a distance*: no local reading of a template
+tells you what it emits. This document takes XSLT's one great idea and
+refuses all four failures explicitly.
+
+**Acceleo** (Eclipse/OMG MTL) is the closest working analogue: an OCL
+query language over an EMF model, `[template]` blocks, and — the part
+worth stealing — *protected regions* with markers that survive
+regeneration. Its cost is a whole model layer (Ecore) before anything
+can be transformed, and a template language that grew until it
+was a programming language with an XML-adjacent syntax.
+
+**StringTemplate** (Parr) contributes the strongest *negative*
+theorem in the field: it deliberately enforces strict model–view
+separation — no side effects, no assignment, no iteration counters, no
+general expressions — on the argument that a template language which
+can compute becomes an untestable second program. Its ADT-driven
+`<attr:{x|...}>` maps are the discipline. It is also the proof that
+"the template owns layout" is survivable *only* if the template
+language cannot compute.
+
+**TypeSpec** (Microsoft) and **Smithy** (AWS) are the two mature
+"one model, many emitters" systems, and they agree on the two things
+that matter here. Both have a *neutral IR* the emitters consume rather
+than each emitter walking the source AST. Both have discovered that
+the hard part is not the IR but **symbols**: Smithy's `SymbolProvider`
+plus `$T` formatting exists so generation logic never writes an
+identifier by hand and imports are derived from references, and
+TypeSpec's Alloy has `refkey`s for the same reason. Smithy also
+contributes the escape design: a typed property bag on `Symbol` rather
+than a per-language dialect of the IR.
+
+**protoc plugins** contribute the process shape: the compiler
+produces a `CodeGeneratorRequest` — a serialised, complete,
+language-neutral description — and every plugin is a program that
+reads it on stdin and writes files on stdout. The lesson is that the
+IR being *serialisable data* is what made twenty independent language
+backends possible. The counter-lesson is **OpenAPI Generator**, whose
+mustache-template-per-language design has 5,000+ open issues and
+per-language template forks: an escape hatch with no cost attached
+swallows the core.
+
+**Pkl** (Apple) is the nearest neighbour in the configuration-language
+family and made the opposite choice to D2 deliberately: its renderers
+(`PcfRenderer`, `YamlRenderer`, ...) live in the *tooling*, and the
+language stays value-valued. Its `@go.Package`/`@go.Name` annotations
+are Smithy's property bag by another name.
+
+**Jostraca** is the fourth form and the reason D3 is a dependency
+rather than a design: it already owns file writing, folder structure,
+three-way merge over hand-edited code, `Slot`/`Inject`, protected
+regions and exclusion, in TypeScript and Go, by the same author, under
+the same parity discipline. Reimplementing any of it here would be
+building a second, worse copy of a solved problem one layer down.
+
+## Design space
+
+**A. A host program per target (form (a) alone).** Document
+`generate()` and let each consumer walk the JSON. Near-zero cost, and
+it is what people will do anyway. Rejected as the *end state* for
+three reasons: `generate()` has already deleted optionality,
+closedness, defaults, constraints and kinds by the time the host sees
+it; a Go host cannot walk the Val tree at all (go/val.go exports
+`Canon`/`Gen`/`Unify`/`Dc`/`Nil` and nothing else, and `MapVal`'s
+fields are unexported), so form (a) is a TypeScript-only capability
+today; and nothing checks the derivation. Kept as a supported form,
+not as the mechanism.
+
+**B. A template language in the document.** Backtick strings plus
+interpolation plus a loop construct: the Acceleo/mustache shape.
+Rejected: it puts layout in the template, which is XSLT's whitespace
+failure and mustache's fork-per-language failure, and it needs the
+comprehension keywords [G8](g8-generation.md) refused on grammar-size
+grounds. The G8 boundary holds here.
+
+**C. A second evaluator — an XSLT-shaped rule engine with its own
+semantics.** A stylesheet document, its own pattern language, its own
+priority scheme, its own conflict resolution. Rejected: it is a second
+language to specify, teach and keep in TS/Go parity, and Aontu already
+has a pattern language whose patterns are values and whose match test
+is unification. Reinventing that is surface-area creep of exactly the
+kind [index.md](index.md) names.
+
+**D. Emit JSON Schema (or OpenAPI) and generate from that.** Zero new
+Aontu surface; hand off to the mature ecosystem. Rejected on evidence
+this repository already has: `aontu jsonschema` exists and its whole
+`SchemaLoss` machinery exists *because* JSON Schema cannot carry what
+the model says. Routing code generation through a strictly weaker
+vocabulary discards the constraints, the identity, the relations and
+the closedness dial — which is most of what makes the model worth
+generating from.
+
+**E. A neutral output vocabulary, expressed as an Aontu schema, that a
+transform written in ordinary Aontu produces, that the unifier vets,
+that a tooling renderer turns into bytes, and that Jostraca writes.**
+The costs are real and stated: the transform reads a schema through
+`pack`/`match` rather than through a reflection API; four facts are
+invisible until a reflection sidecar lands; and the renderer will
+never produce byte-for-byte what `gofmt` would.
+
+**Recommendation: E.** It is the only option that keeps the XSLT
+property — the result is an instance of the output vocabulary, and the
+output vocabulary is an Aontu schema, so the result is checked by the
+same unifier that produced it — while refusing all four of XSLT's
+failures and reusing rather than reimplementing Jostraca.
+
+### The owner's decisions
+
+The following are settled. They are recorded here with their reasons
+so that a later reader does not re-derive them.
+
+**D1 — the transform is Aontu; the result is shaped like the target
+language.** "The XSLT analogue exists in the output target language,
+yet is syntax neutral" describes the RESULT TREE, not the transform
+file. The result is a document of declarations, types, fields,
+functions and comments, which a renderer turns into bytes. It is
+syntax-neutral because the output vocabulary is neutral. And because
+the output vocabulary is itself an Aontu schema, a transform result
+can be VETTED by unification against the vocabulary it claims to
+speak — the analogue of XSLT validating literal result elements
+against the output schema, and better, because it is the same
+mechanism the language already uses for everything else.
+
+This works today. VERIFIED, both ports, on the transform document
+of [worked example 1](#worked-example-1):
+
+```
+$ aontu vet std-code.aon xf-domain.aon        -> verdict: valid
+$ go run ./cmd/aontu vet std-code.aon xf-domain.aon  -> verdict: valid
+```
+
+and with one `prim: "int"` corrupted to `prim: "nope"`:
+
+```
+verdict: invalid
+$.code.units.0.decls.0: empty [conflict]
+  data:   xf-domain.aon:3:32 ({"fields":[...{"prim":"nope"}...],"k":"record","name":"Customer"})
+  schema: std-code.aon:9:8  ({"doc"?:string,"fields":[&:$.%Field],...}|{"k":"text",...})
+```
+
+**D2 — text output lives in the tooling, not the engine.** The unifier
+stays JSON-valued. A new CLI verb plus a library — the precedent is
+ts/src/jsonschema.ts and ts/src/agentsmd.ts, engine functions with CLI
+verbs and MCP tools over them — walks the evaluated model and renders
+bytes. Aontu documents never evaluate to a file; they evaluate to a
+MODEL OF the output, and the tooling renders it.
+
+**D3 — Aontu drives Jostraca as a library**, in both ports (`jostraca`
+on npm, `github.com/jostraca/jostraca/go`). Jostraca owns file
+writing, folder structure, three-way merge, `Slot`/`Inject` and
+protected regions; Aontu reimplements none of it.
+
+**D4 — four clauses of the [G8 boundary](g8-generation.md#boundary-what-we-will-not-do)
+are opened**, and only these four: (i) a fold over strings —
+`join(list, sep)` and family; (ii) string interpolation syntax,
+previously refused outright; (iii) an engine-driven recursive walk —
+an apply-templates analogue whose descent lives in the engine so that
+no USER recursion exists; (iv) a general map combinator over lists.
+Everything else in the G8 boundary stands.
+
+**D5 — one model, many outputs, each over part of the model.** A
+single model is the source of several artifacts in several target
+languages at once, and each consumes only part of the model. This is
+the normal case, not an extension.
+
+**D6 — a transform is not confined to its slice.** The slice an output
+declares is DOCUMENTATION — a statement of intent for readers and for
+the coverage report — not a capability boundary. Nothing enforces
+confinement, and there is therefore no sound per-output staleness
+answer.
+
+**D7 — one manifest, one run, N files.** The user invokes the
+manifest; every output is produced in one pass over one evaluated
+model; Jostraca receives ONE Project containing all N outputs, so its
+merge, exclusion and protected-region logic sees the whole tree at
+once and one consistent snapshot backs every file.
+
+### Two specialist disagreements, resolved
+
+Two designs were drafted in parallel and they disagree. Papering over
+either would leave an implementer without an answer, so both are
+resolved here.
+
+**Resolution 1 — the IR is at DECLARATION level, not at TEXT level.**
+One draft proposed a high-level vocabulary of units, declarations,
+types and fields; another proposed a Jostraca-shaped plan of
+project/folder/file/content nodes. They cannot both be the output
+vocabulary. **The declaration vocabulary wins**, and the plan is
+demoted to a data structure the *bridge* builds in the host from the
+render report — never something a transform writes. Three reasons.
+(i) At text level, and with no `join`, one output line is one plan
+node: a forty-line Go struct is forty nodes carrying `kind`/`src`,
+which is strictly worse to write and review than the fifty-line host
+program it replaces. (ii) At text level the vocabulary can assert
+almost nothing — "this is a string" — so D1's vetting claim
+evaporates, which is the whole prize. (iii) At text level the layout
+is baked into the leaf at construction time and a renderer can never
+re-indent, which is XSLT's whitespace failure imported wholesale.
+
+This resolution has a large consequence downstream: **`join` is not on
+the critical path.** The renderer owns lines and indentation, so
+`join` is needed only for leaf strings — a struct tag, a SQL column
+list, a generic parameter list. It is still built (D4 i), and first,
+because it is cheap and because those leaves are real; but no phase
+blocks on it.
+
+It also removes a claimed blocking requirement on the other
+repository: because the bridge builds the Project tree in the host
+from a render report, Jostraca needs no data-driven `Tree(nodedef)`
+component. That was named as blocking; it is not.
+
+**Resolution 2 — `_.field` is not unspellable, and the risk built on
+that claim is withdrawn.** One draft recorded, correctly, that
+`pack($.m, {got: _.n})` fails `[aontu/no_path]`, and concluded that a
+transform cannot read a field of the record it is transforming. The
+conclusion does not follow: the hidden-capture idiom in
+[Current state](#current-state) reads any number of fields, VERIFIED
+byte-identically in both ports. The phase that existed to decide
+whether `_.field` was blocking is therefore not needed, and
+`fillPlace` is not being taught to fill the head of a relative
+reference in this design.
+
+## Proposed design
+
+Five parts. Each is separable, and the ordering below is the
+dependency order.
+
+```
+  model.aon
+    -- a transform, written in ORDINARY AONTU (pack/match/pick/join) -->
+  a %Code instance         <-- VETTED against @"std/code" (D1)
+    -- render(), a pure fold with a language PROFILE -->
+  text units + a loss report
+    -- the jostraca bridge (D3) -->
+  one Project, one generate(), N files on disk (D7)
+```
+
+### 1. The output vocabulary — `@"std/code"`
+
+A bundled Aontu schema, served from the engine as `std/system` already
+is (ts/src/std.ts, go/std.go, same bytes, pinned by a canon and a hash
+row). It is ONE vocabulary, not a family: variation is carried by
+`x?: {}`, an open map on every node keyed by backend name, which is
+the language's own open/closed dial doing the job Smithy needs a typed
+property bag for. A family would multiply the parity surface by the
+number of dialects and would make "which vocabulary does this result
+speak" a new failure mode.
+
+Three properties carry the design, and each was reached by refusing an
+earlier draft.
+
+**It is anchored under a key, and `type()`-marked.** A root-anchored
+vocabulary is *vacuous* and *polluting*, both VERIFIED. Vacuous:
+with `units: [&: %Unit]` at the root, `aontu vet vocab.aon
+<anything>` answers `valid` — a document containing only `other: 1`
+passes, and so does one that typo'd the top-level key to `unit:`,
+because a spread generates `[]` and a root cannot be closed.
+Polluting: a document that includes such a vocabulary generates
+`{"myconfig":{"a":1},"units":[]}`. The fix is the `std/system`
+arrangement — namespace under one key, mark it — and it costs nothing:
+VERIFIED, an includer of the marked vocabulary generates `{"my":1}`,
+and vetting needs no `--at`.
+
+Avoiding `--at` matters for a second reason. VERIFIED, a two-line
+reproducer of an **unrecorded ADR-001 break**:
+
+```aon
+# p7.aon
+%F: close({ n: string })
+code: { fs: [&: %F] }
+# p7d.aon
+fs: [ {n:"x"} ]
+```
+```
+$ aontu vet --at code p7.aon p7d.aon          -> verdict: valid    (exit 0)
+$ go run ./cmd/aontu vet --at code p7.aon p7d.aon
+verdict: invalid                                                   (exit 1)
+$.code.fs.0: no_path [reference]   schema: p7.aon:2:17 ($.%F)
+```
+
+The cause is not what an earlier draft diagnosed (root-level aliases
+becoming unreachable after re-rooting): a non-spread alias under `--at`
+resolves fine in Go — VERIFIED, `code: { f: %F }` with `f: {n:"x"}`
+is `valid` in both ports. It is the LIST SPREAD re-resolving its alias
+after re-rooting. Both the failing and the passing case go into
+[`use-cases/BUGS.md`](../../use-cases/BUGS.md) so the fixer can bisect
+immediately.
+
+**Container types take only LEAF types.** A recursive `%Type` —
+`list.of: %Type` — is quadratic-to-exponential and, past a threshold,
+non-terminating. VERIFIED, an eight-arm recursive `%Type` vetted
+against a nested list type:
+
+| nesting depth | TypeScript | Go |
+|---|---|---|
+| 4 | 0.18 s | 0.01 s |
+| 6 | 0.28 s | 0.04 s |
+| 7 | 0.49 s | 0.13 s |
+| 8 | 1.14 s | 0.35 s |
+| 9 | 2.27 s | 1.17 s |
+
+and, worse, VERIFIED: a nine-arm recursive vocabulary INCLUDED BY BOTH
+the schema and the data document does not terminate in **either** port
+(both killed at 60 s). At five arms only TypeScript hangs and Go
+answers in under a second — so the same construct is a G5 termination
+failure at one size and an ADR-001 divergence at another. Making
+`list.of`, `map.of`, `map.key` and `opt.of` accept only
+`{k:"prim"|"ref"|"text"}` removes the blow-up entirely, and it matches
+what every target language does anyway: you name the intermediate
+type. VERIFIED with the capped vocabulary: the same double-include
+evaluates in 0.17 s (TS) and 0.01 s (Go), the hash is byte-identical
+in both ports, and — the unexpected bonus — **diagnostics stop
+degrading with depth**. A bad node three levels down reports
+`$.code.units.0.decls.0` with both a data site and a schema site,
+where the recursive vocabulary reported `|:trial-nil [internal]` with
+no sites at all.
+
+**Two escapes, and only two, both counted.** `{k:"text", lang, text}`
+carries verbatim target syntax at type, body or declaration position,
+guarded by a check that `lang` matches its unit's `lang` — without
+that guard a Go snippet silently lands in a `.ts` file. `x?: {}` is
+the per-backend rider. Every `{k:"text"}` node and every check a
+backend cannot enforce appears in the render report's `lossy[]`, and
+`--strict` refuses when any exists. That counting is the only
+mechanical pressure keeping the core from decaying into decoration —
+the OpenAPI Generator failure mode.
+
+The vocabulary, complete. It contains no backtick and no backslash,
+because ts/src/std.ts holds it in a template literal and go/std.go in
+a raw string that has no escape (ts/src/std.ts:13-14 states the rule).
+
+```aon
+# std/code --- THE OUTPUT VOCABULARY (G9).
+#
+# An Aontu transform evaluates to an instance of this schema; the
+# `render` verb turns the instance into bytes. Because it is an
+# ordinary schema, a transform result is CHECKED by unification.
+# `vet` takes FILE PATHS, not include expressions, so the vocabulary
+# is reached through a one-line wrapper (VERIFIED against std/system,
+# which is bundled the same way):
+#
+#   $ echo '@"std/code"' > code.aon
+#   $ aontu vet code.aon result.aon
+#
+# `aontu vet @"std/code" result.aon` is NOT a command -- it fails with
+# ENOENT on a file literally named `@"std/code"`.
+#
+# TWO ESCAPES. {k:"text", lang, text} carries verbatim target syntax;
+# `x` is an open per-backend rider. A render report counts both.
+#
+# CONTAINER TYPES TAKE LEAVES ONLY. Anything deeper is a named alias
+# declaration plus a {k:"ref"} -- which is what every target language
+# makes you write anyway, and which keeps this schema's meet linear.
+#
+# IMPORTS ARE DERIVABLE: a renderer computes them from {k:"ref"}
+# nodes; %Unit.imports is a manual supplement, merged, not a
+# replacement.
+#
+# EXPERIMENTAL until the distribution layer can version it by
+# canon-hash (the std/system marking, for the same reason).
+
+%Name: string & re("^[A-Za-z_][A-Za-z0-9_]*$") & length(min(1) & max(255))
+
+%Text: close({ k: "text", lang: string & length(min(1)), text: string })
+
+%Doc: close({
+  text: string
+  deprecated?: close({ msg?: string, use?: string, since?: string })
+})
+
+%Check:
+  close({ c: "min",    n: number, exclusive: *false | boolean })
+| close({ c: "max",    n: number, exclusive: *false | boolean })
+| close({ c: "re",     p: string })
+| close({ c: "len",    min?: integer & min(0), max?: integer & min(0) })
+| close({ c: "unique", key?: %Name })
+| close({ c: "ne",     of: [&: string | number | boolean] })
+| close({ c: "must",   note: string })
+
+%Prim: close({ k: "prim",
+  prim: "string"|"int"|"bigint"|"float"|"decimal"|"bool"|"null"|"any" })
+%Ref:  close({ k: "ref", name: %Name, unit?: string })
+%Leaf: %Prim | %Ref | %Text
+
+%Type: %Leaf
+| close({ k: "list", of: %Leaf })
+| close({ k: "map",  key: %Leaf, of: %Leaf })
+| close({ k: "opt",  of: %Leaf })
+| close({ k: "union", of: [&: %Leaf] })
+| close({ k: "lit",  of: [&: string | number | boolean | null] })
+
+%Field: close({
+  name: %Name
+  type: %Type
+  optional: *false | boolean
+  doc?: %Doc
+  default?: string | number | boolean | null
+  check?: [&: %Check]
+  rel?: close({ to: string, name?: string })
+  x?: {}
+})
+
+%Member: close({ name: %Name, value?: string | number, doc?: %Doc, x?: {} })
+%Param:  close({ name: %Name, type: %Type,
+                 default?: string|number|boolean|null, x?: {} })
+%Body:   %Text | close({ k: "abstract" })
+
+%Record: close({ k: "record", name: %Name, doc?: %Doc, open: *false | boolean,
+                 fields: [&: %Field], entity?: string,
+                 check?: [&: %Check], x?: {} })
+%Enum:   close({ k: "enum", name: %Name, doc?: %Doc,
+                 members: [&: %Member], x?: {} })
+%Alias:  close({ k: "alias", name: %Name, doc?: %Doc, type: %Type,
+                 check?: [&: %Check], x?: {} })
+%Const:  close({ k: "const", name: %Name, doc?: %Doc, type?: %Type,
+                 value: string|number|boolean|null, x?: {} })
+%Func:   close({ k: "func", name: %Name, doc?: %Doc, params: [&: %Param],
+                 returns?: %Type, body: %Body, x?: {} })
+
+%Decl: %Record | %Enum | %Alias | %Const | %Func | %Text
+
+%Import: close({ from: string & length(min(1)), names?: [&: %Name],
+                 alias?: %Name, x?: {} })
+
+%Unit: close({
+  path: string & length(min(1))
+  lang: string & length(min(1))
+  pkg?: string
+  doc?: %Doc
+  imports?: [&: %Import]
+  decls: [&: %Decl]
+  x?: {}
+})
+
+%Source: close({ path?: string, hash?: string & re("^aon1-[A-Za-z0-9_-]+$") })
+
+code: type(close({ source?: %Source, units: [&: %Unit] }))
+```
+
+`%Source.hash` carries the `aon1-` pin of the model the result was
+generated from — which
+[`docs/design/ONTOLOGY.0.md`](../design/ONTOLOGY.0.md) already asks
+every generated artifact to carry — and because it is a node of the
+vocabulary it is *vetted*, not a renderer flag.
+
+#### Five spelling rules the vocabulary imposes, each found by probe
+
+These are the traps an author hits in the first hour. Each was
+VERIFIED, and each is a spec row rather than a paragraph of advice.
+
+1. **An atom kind in an IR value must be QUOTED.** `prim: string` is a
+   `ScalarKindVal`, not the string `"string"`, and the whole document
+   refuses at generation — VERIFIED,
+   `t: {k: "prim", prim: string}` is `[aontu/mapval_no_gen]` at
+   `$.t.prim`, while `prim: "string"` generates cleanly. The
+   vocabulary's `%Prim` closes `prim` over eight string literals
+   precisely so this is a *vet* error at the node rather than a
+   generation failure at the root. One `ir-vet.tsv` row pins the
+   refusal so the trap is caught once rather than rediscovered.
+2. **`default?: _` is NOT part of the sanctioned idiom.** It looks
+   irresistible — VERIFIED, it does recover `8080` from
+   `*8080 | integer` and vanishes when there is no default, exploiting
+   `BagVal.gen`'s rule that an optional key whose value is not
+   generable is dropped. But it leaves an unsettled CONSTRAINT
+   standing in the unified tree, which only `generate()` discards, so
+   the transform document no longer vets: VERIFIED, adding it to
+   worked example 1 turns `verdict: valid` into `empty [conflict]`
+   with `"default"?:re("^[A-Z]{2}$")` visible in the data site. A
+   default arrives through the reflection sidecar (Phase 5), which
+   reports it as a settled scalar. Trading D1's in-place check for one
+   recovered field is a bad trade, and the rule is stated here so
+   nobody makes it twice.
+3. **A `&:` spread carries the template's own scaffolding keys into
+   every generated node.** VERIFIED: spreading
+   `{ kind: "content", src: ... }` over `{n: "id"}` produces
+   `{"kind":"content","n":"id","src":"..."}` — `n` is an unknown key
+   on a closed node. The vocabulary does catch it: VERIFIED, a
+   spread-generated bad node is refused `invalid` in both ports, and
+   with the depth-capped vocabulary the finding carries both sites.
+   But an author who reaches for `&:` to build declarations will fight
+   `close()` on every node. `pick(pack(d, {f: t}), f)` — and, after
+   Phase 3, `form` — produces clean nodes and is the idiom the
+   worked examples use. The how-to says so with this example.
+4. **`*[] | [&: %X]` is not the way to spell an empty-by-default
+   list.** VERIFIED in both ports, it raises `pref_not_instance
+   [compat]`: the empty list is not an instance of a one-or-more list
+   spread (ADR-004). The vocabulary writes `imports?: [&: %Import]`
+   instead — an optional key already means "absent is fine" — and the
+   note goes in docs/reference-language.md, because every schema
+   author reaching for the obvious spelling will hit it.
+5. **`code:` is a CONVENTION of the vocabulary, not a magic key.**
+   [ADR-010](../../ADR.md#adr-010--no-magic-keys-or-paths-the-tree-at-all-levels-is-user-space)
+   is unconditional — "a plain, spellable key name never carries
+   engine- or verb-assigned meaning, at any depth, the root
+   included" — and its one grandfathered exception, `relations:`, was
+   discharged the day before this document was drafted. So `render`
+   defaults `--at` to `$`, not to `$.code`. The `code:` key means
+   something only because `@"std/code"` declares it, in user space,
+   opted into by inclusion — which is exactly the carve-out ADR-010
+   makes for libraries. A document that nests its result elsewhere
+   passes `--at` explicitly.
+
+Killed from the vocabulary, with reasons. **`module`**: a unit IS the
+compilation unit and grouping is `pkg` plus the directory implied by
+`path`; a `module` node would duplicate the folder structure Jostraca
+owns, which is the reimplementation D3 forbids. **A `comment` node
+kind**: docs are a `doc?` rider on every named node, never a
+positional node — the parser lexes `#` comments and discards them
+(ts/src/lang.ts:245-255) and ts/src/patch.ts names the absent CST as
+the blocker for format preservation, so doc text can only ever be
+model data; and a positional comment node forces every renderer to
+answer "does this attach to the next declaration or the previous
+one", which is what makes every AST-printer's comment handling a bug
+farm. **`statement`/`expression`/`block`**: the LCD trap in its purest
+form; a function body is `{k:"text"}` or `{k:"abstract"}`, because a
+transform cannot compute a body anyway — the only thing an Aontu
+document produces is data, so a body is always a string the transform
+assembled, and modelling it as an expression tree buys nothing and
+costs a per-target expression printer in two ports.
+
+### 2. The rule layer — apply-templates, in the engine
+
+D4(iii) sanctions an engine-driven recursive walk. Three things
+already exist that make it small:
+
+- `match()` IS the rule table: alternating pattern/result arguments,
+  first match in argument order wins, patterns matched by
+  unifiability only, no fallthrough, and a located error naming the
+  patterns tried when nothing matches and there is no default. That
+  is XSLT's template list with all four of its failures already
+  designed out, shipped in G8 phase 2 and pinned by
+  test/spec/gen-match.tsv. **This design adds no second rule engine
+  and no second pattern language.**
+- `filter()` selects by "already satisfies" — the same question
+  `subsume` asks, answered locally.
+- `pick(pack(d, {f: t}), f)` is the element-wise map, VERIFIED
+  working in both ports.
+
+What is missing is the DESCENT. `walk(data, tmpl)` produces a list of
+`tmpl` instantiated once per node of `data` in pre-order, `data`
+itself included, with `_` bound to the node. Then
+
+```aon
+join(walk($.model, match(_, <pattern>, <emit>, ..., <default>)), "\n")
+```
+
+is apply-templates, with the recursion in the engine and none in user
+space, which is exactly what D4(iii) requires.
+
+**The totality argument, and it must be real.** ts/src/walk.ts
+describes its seen-set as "a termination guard, not an optimisation",
+so the evaluated value graph does admit cycles. Reading it and its
+neighbours, the reachable set is not a tree for four distinct reasons
+and only one of them is a true cycle:
+
+1. **Sharing.** `mergeEntities` (ts/src/unify.ts) installs ONE
+   representative object at every position carrying the same `id()`.
+   A visit-once walk over this terminates and is correct: it is a
+   DAG, not a cycle.
+2. **Off-peg back-edges.** ts/src/walk.ts deliberately follows
+   `spread.cj`, `superpeg`, `musts[].v`, `primary` and `secondary`.
+   `superpeg` is a preference's derived yardstick;
+   `primary`/`secondary` are a failure's operands, which are values
+   from elsewhere in the tree. These are DIAGNOSTIC edges, not
+   structure. **`walk()` follows none of them**; it descends map and
+   list `peg` only, which is what `walkBagVals` (ts/src/utility.ts)
+   already does.
+3. **Links are not edges.** ts/src/val/ReferFuncVal.ts is explicit —
+   "the field's own value stays the address string: a LINK, not an
+   embedding" — so `refer`/`rel` create no structural edge. The
+   entity graph they induce is explicitly permitted to be cyclic
+   (ts/src/reach.ts) and acyclicity is a report-layer verdict. A walk
+   that dereferenced links would be a graph traversal needing a
+   visited set and a declared visit order; a walk that descends
+   children is a fold over a finite tree. They must stay separate,
+   and `walk()` does not dereference.
+4. **A true cycle in `peg`**, and it is the only one:
+   `a: id(x) & { b: id(x) & { c: 1 } }` makes `res.peg.a.peg.b ===
+   res.peg.a`. VERIFIED, both ports die:
+
+   ```
+   TS: Aontu: unexpected error: Maximum call stack size exceeded
+   GO: runtime: goroutine stack exceeds 1000000000-byte limit
+       fatal error: stack overflow          (unrecoverable)
+   ```
+
+   This is a [G5](g5-trust-contract.md) violation on its own terms —
+   "my budget ran out", "your model is cyclic" and "your model is
+   incomplete" are distinct located codes, and a host stack overflow
+   is none of them — and an ADR-001 hazard, a throw in one port and
+   an uncatchable fatal in the other. It is fixed **at the merge**,
+   as `id_ancestor` (class `conflict`), in [Phase 0](#phase-0--the-four-gating-defects-s).
+
+With (4) closed and (2)/(3) refused by construction, the totality
+argument is one sentence: *the structure `walk` descends is a finite
+DAG, and a visit-once pre-order descent over a finite DAG halts.* A
+`walk_budget` counter charged against `trust.budget.depth` is a
+backstop, not the argument.
+
+If (4) is ever reachable again, `walk` must **REFUSE on revisit**
+(`walk_cycle`, class `conflict`), never skip: a silently truncated
+document is worse for a code generator than a crash.
+
+**`onNoMatch` is `fail`.** XSLT's built-in rule copies the string
+value of unhandled nodes into the result, which for code output means
+model data landing silently in the middle of a source file. That is
+the single worst default in the prior art and it is refused.
+
+**Provenance is a first-class output.** The render report records
+(node path, rule index) for every emitted declaration. That one map
+gives rule coverage (D5 vi: which parts of the model no output
+consumed — dead model; which output consumed a part no rule matched —
+a silent hole), a shadowing report, an explain-this-line command, and
+source maps from generated code back to the model. It is what turns
+XSLT's most durable criticism, action at a distance, into a feature,
+and retrofitting it is what XSLT never managed. Build it from the
+start.
+
+**But a trace is not the whole answer, and saying so matters.** A
+trace tells you what a particular run emitted; XSLT's criticism is
+that you cannot read a rule set and know what it emits, which is a
+READING problem. The static half is available here and is not
+available in XSLT: because each rule's `emit` is a value and the
+output vocabulary is a schema, **every rule's result is checked
+against the vocabulary node it claims to produce BEFORE any input is
+walked.** A rule that can never emit a well-formed declaration is a
+finding at the rule, not a surprise on the third file of a run, and a
+rule no input can reach is reported as unreachable in the same pass.
+That is the static check XSLT has no way to express, it costs nothing
+beyond a `vet` of each rule's arm, and it is a named deliverable of
+Phase 6 rather than a property claimed for the trace.
+
+**Modes (D5 iii).** Several outputs traverse one model independently,
+which is exactly what XSLT modes are for. A mode here needs no new
+mechanism: it is one more argument to `walk` naming which rule table
+to apply, and the rule tables are ordinary `match` calls held under
+distinct keys. Cheap, and it is the difference between "one giant
+match with a `target` discriminator in every pattern" and N readable
+tables.
+
+### 3. The renderer and the language profiles
+
+`render(value, profile) -> RenderReport` is a **pure, total fold from
+`generate()` output plus a data profile to a byte string.** It never
+touches the Val tree, never reads or writes a file, never shells out,
+never sorts, and never iterates a map.
+
+**The fold is total by inspection, and needs no counter of its own.**
+`generate()` has already produced a finite JSON-shaped tree by the time
+the renderer runs — the id() cycle of [§2](#2-the-rule-layer--apply-templates-in-the-engine)
+cannot survive it, because generation is where it dies today. So there
+is no `render_depth` error code and no render-side budget: registering
+a code whose branch no input can reach would break ADR-002's set
+equality between `errcodes.tsv` and both engines' tables, and a knob
+one port's options struct cannot express would break ADR-001 at the
+interface before a line was written. The cycle is refused upstream, at
+the merge, where it belongs.
+
+**It consumes `generate()` output, not the Val tree.** This is the
+decision that makes ADR-001 tractable: Go's embedding surface cannot
+read a single child of a `MapVal` — the exported `Val` interface is
+`Canon`/`Gen`/`Unify`/`Dc`/`Nil`, and `MapVal`/`ListVal`/`ScalarVal`
+have no exported fields — so a Val-tree renderer would be
+TypeScript-only on the day it landed, in the exact layer the code
+generation story depends on. The cost is stated: `generate()` destroys
+provenance, so a render finding carries a `$.dotted.path` into the IR
+rather than a source site. That is the addressing every other report
+in the repository uses.
+
+**Indentation is STRUCTURAL. The renderer owns the prefix.** Templates
+never carry leading whitespace that means indentation. This is the one
+XSLT failure it would be easiest to repeat and the algorithm is small:
+
+- `nest(body)` renders `body` at `depth + 1` and produces no bytes.
+- `line(body)` concatenates its inline pieces into `s`, and appends
+  `pad + s` right-trimmed of space and tab, where `pad` is
+  `indent.unit` repeated `indent.width x depth`.
+- A blank line is zero bytes plus its terminator — never padding.
+- **An inline piece may not contain U+000A, U+000D, U+2028 or
+  U+2029.** This single rule is what makes the fold total and the
+  output stable: a line is a line, and the check is local.
+- A block-level `raw` node is the only node that may carry a line
+  terminator. Its components each get the depth prefix and keep
+  their own interior shape, so a multi-line escape nested three
+  levels deep gets the depth-3 prefix on every line with its own
+  relative indentation preserved on top. `reindent: false` emits at
+  column 0 verbatim, for text where column 0 is contractual — a
+  heredoc body, a C preprocessor directive, a fenced block inside a
+  doc comment.
+- **The renderer does not strip a raw's common leading indentation.**
+  Guessing which of a template's leading whitespace is structural is
+  precisely the XSLT mistake, and no rule is right for both a Python
+  block and a Markdown fence.
+
+**A profile is data, and only data.** The test, stated in the profile
+document's own header so a reviewer can point at a rule: *a field
+belongs in the profile only if the renderer applies it WITHOUT LOOKING
+AT THE SHAPE OF ANY NODE.* Anything else is a lowering and lives in
+the transform. This is the line that stops a profile accumulating
+`if_optional_prefix` and `interface_embed_style` until it is a
+badly-typed programming language, which is how OpenAPI Generator's
+mustache templates got where they are.
+
+A profile declares: `indent` (unit and width, width bounded 0..16 so
+no port can differ on a repeat count); comment forms (line, block,
+doc, each `{open?, prefix?, close?}`); string quoting and an escape
+table **keyed by decimal code point** — a literal control character
+cannot be an Aontu key (`aontu/unprintable`), and a character-keyed
+table would make replacement ORDER significant, where a per-code-point
+lookup has no order at all; identifier character classes drawn from a
+closed named set (no regular expressions: docs/trust.md already names
+pattern matching as the one subsystem with a stated RE2-vs-RegExp
+complexity divergence, and putting a regex on the hot path of every
+emitted identifier would import that divergence into the renderer's
+core); a reserved-word list matched by exact case-sensitive equality
+(Go's `Type` is not reserved even though `type` is); a per-role naming
+convention; an acronym set; and a primitive type map with
+`open`/`close` per container form plus `prec`/`child_prec` for
+parenthesisation.
+
+**Case conversion is ASCII-only and does not call `upper()`/`lower()`.**
+Those builtins are full Unicode — `String.prototype.toUpperCase` in
+TypeScript, `cases.Upper(language.Und)` from `golang.org/x/text` in
+Go. They agree today, but they are two independently versioned Unicode
+tables, and an identifier's spelling must not depend on which minor
+release of `x/text` a consumer pinned. Any code point at or above
+U+0080 is carried into the current word verbatim, never split, never
+case-converted. That rule is the parity guard.
+
+**The acronym set is per-profile, and the reason is a real bug this
+design hit.** With one shared acronym list, `ledgerId` renders as
+`ledgerID` in TypeScript — correct for a Go field, wrong for a
+TypeScript one. Go uppercases trailing acronyms; TypeScript does not.
+The set is a profile field, empty for TypeScript and SQL.
+
+**`prec`/`child_prec` are needed, and TypeScript proves it.** Atoms
+have `prec: 9`; a form renders `open + inner + close`, wrapping
+`inner` in parens when the inner expression's `prec` is strictly less
+than this form's `child_prec`. TypeScript's `opt` is `" | null"` at
+`prec: 1` and its `list` has `child_prec: 2`, so a list of nullable
+strings renders `(string | null)[]` and not the wrong
+`string | null[]`. Go needs no parens in a type expression, which is
+why every Go `child_prec` is 0.
+
+**The renderer NEVER invokes a formatter.** Not optionally, not behind
+a flag, not "if available". Four reasons, each sufficient. (i) G5
+hermeticity: a shelled-out formatter makes output depend on `PATH` and
+a third-party version — `gofmt`'s output has changed between Go
+releases — and it would make an `aon1`-stamped artifact a lie. (ii)
+ADR-001: the TypeScript suite would need a Go toolchain to render a Go
+target. (iii) ADR-002: "formatter absent", "exited non-zero",
+"rewrote into something that no longer round-trips" and "timed out"
+are four uncoverable branches per port. (iv) The shared suite cannot
+express a dependency on a binary being on the runner's PATH.
+
+**What that costs, plainly.** The renderer will not column-align
+consecutive struct field types the way `gofmt` does, will not align
+trailing comments, will not sort or group imports, and **has no
+line-width concept at all**. That last is a decision: a
+Wadler/Prettier `group`/`softline` document IR is refused, because
+every group decision is a place two implementations can differ with no
+cheap way to pin the difference, and because it makes a spec row's
+expected bytes depend on a width setting three levels up. Line
+breaking is the model's job, expressed as `line` and `nest`. The
+hand-off is a pipeline step the user runs deliberately:
+
+```
+aontu render --profile go --stdout model.aon | gofmt
+aontu render --profile go --out ./gen model.aon && gofmt -w ./gen
+```
+
+and the CI story is `aontu render --check`, which compares rendered
+bytes against what is on disk and exits 1 on drift. One non-gating
+exception, outside the contract: a per-port test may run `gofmt -l`
+over a `.go` fixture golden when a toolchain is present and skip
+otherwise — a canary, never an assertion.
+
+**Everywhere the two ports could disagree, and the pin for each:**
+
+| site | mechanism | pin |
+|---|---|---|
+| map iteration | **forbidden**; lookups only. `generate()` gives TypeScript code-point-sorted keys and Go a deliberately randomised range order, so a single `range` over a map is a guaranteed divergence. Every ordered thing is a LIST. | code review plus `grep -n 'range ' go/render.go` showing slices only |
+| string escaping | one pass, per code point, table keyed by decimal code point | render rows: tab, quote, backslash, control, non-ASCII, astral, lone surrogate |
+| numbers | delegated to `exactJSON` / `encoding/json`; **no second number formatter** | already pinned by every `gens` row in the suite |
+| line endings | LF only. There is no `eol` profile field. | render rows; and a TSV cell cannot hold a carriage return at all |
+| case conversion | ASCII-only, own tables | 6 rows including two non-ASCII pass-through |
+| reserved words | exact case-sensitive equality on the converted name | 2 rows (`type` -> `type_`, `Type` -> `Type`) |
+| sorting | **the renderer sorts nothing** — not imports, not fields, not keys. Import order is the transform's job. | removes the whole "is the sort stable the same way in both ports" question |
+| profile values | one bundled source text, both ports | a `hash` row per profile |
+
+### 4. The language additions (D4)
+
+**`join(coll, sep?)` — the fold. BUILD.** Arity `[1,2]`; the default
+separator is `""`, so `join(coll)` is concatenation and no `concat` is
+needed, and `join(coll, "\n")` is lines so no `lines` is needed.
+`split`/`words` is the inverse — an input-parsing operation with no
+generation use — and is refused. **One builtin, not a family.**
+
+It folds with `+` seeded with `""`, exactly as `sum` folds with `add`
+seeded with `0`, so it inherits `+`'s number-to-text rule for free and
+the language keeps exactly one answer to "how does a number become
+text". Members are validated BEFORE folding, because `+` with a string
+left residuates rather than refuses on a container or a null —
+VERIFIED, `"" + {b:1}` and `"x" + null` both reach generation as
+`mapval_no_gen` — so folding blindly would turn a bad member into a
+useless late error. A settled non-text member is `join_member`, class
+`conflict`. An UNSETTLED member — an unresolved kind, a stable
+residue — is not a join failure at all: the call stays residual and
+`mapval_no_gen` (class `incomplete`) fires at generation, exactly as
+docs/trust.md requires ("a stable residue ... is ordinary
+incompleteness"). Order is source order for a list and
+`cmpCodePoint`-sorted key order for a map. Empty is `""` —
+concatenation's identity, the exact parallel of `sum([]) == 0`.
+
+**`form(data, tmpl)` — the map. BUILD.** One element per child of
+`data`, being `tmpl` cloned per destination with `_` bound to the
+source child. It REPLACES; it does not meet.
+
+`each` is not a mistake and is not renamed. `each($.ports, integer)`
+is a schema statement and is monotone — more information about the
+template narrows the children — so it is a lattice citizen, and a
+constructor is not. The language already draws this line twice:
+`min`/`max` (bounds) versus `least`/`greatest` (aggregates), and
+`filter` (select by unifiability) versus `match` (choose a result).
+`each` is the bound; `form` is the construction. `each` also carries
+the source child's identity (its clone keeps the entity), where
+`form`'s element IS the template.
+
+`form` earns its place on **order**, not on expressiveness.
+`pick(pack(d, {f: t}), f)` already maps, VERIFIED in both ports — but
+it goes through a map, so it re-sorts to code-point order, and it
+refuses a list of records outright (`pack_key`). VERIFIED on a real
+document, [`use-cases/01-service-catalog/catalog.aon`](../../use-cases/01-service-catalog/catalog.aon)
+declares `payments, ledger, risk` and the generated units come out
+`ledger, payments, risk`. For a struct's fields, a SQL DDL's columns
+or a file's imports, silently alphabetising is wrong output.
+
+`form` reuses `each`'s exported ordering helper, so the two can never
+disagree about order. It joins `boundArgStart` in both ports —
+ts/src/val/PlaceVal.ts:86 and go/place.go — and **forgetting that is
+the silent failure mode**: every existing test passes and the new
+combinator captures an outer generator's hole, which is
+[BUGS.md](../../use-cases/BUGS.md) §34 exactly. The nesting rows are
+therefore not optional.
+
+**Hidden and unfilled-optional children are SKIPPED by `join` and
+`form`, and by `each` and `pick` too.** VERIFIED that today they are
+not: `m: {a: 1, b?: 2, c: hide(3)}` gives `each($.m)` = `[1,2,3]` in
+both ports while the map generates `{"a":1,"b":2}`. A hidden value
+reaching generated source text is a disclosure, and an unfilled
+optional is not a value. Changing it is observable behaviour on
+existing verbs and therefore lands in Phase 0 with rows pinning the
+new behaviour on all four.
+
+**String interpolation — `${...}` inside BACKTICK strings only.
+BUILD, in the last phase, and the cost is not small.** D4(ii)
+sanctions it and this document designs it rather than arguing it down;
+what follows is the design, with the costs on the record.
+
+- **Backticks only.** Single and double quotes stay inert. VERIFIED
+  today, every candidate delimiter is live text in every quote
+  style: `"cost $x and {y}"` is `"cost $x and {y}"` and
+  `` `t ${a}` `` is `"t ${a}"`. Restricting to backticks halves the
+  blast radius and gives authors a deliberate opt-in quote.
+  `$$...$$` is refused: it is Jostraca's fragment macro, and two
+  systems in one pipeline sharing a delimiter is a debugging trap.
+- **`$${` escapes a literal `${`**, XSLT's `{{` doubling precedent,
+  and non-recursive: braces are not re-scanned inside an
+  interpolation.
+- **It is PARSE-TIME SUGAR and reaches no Val.** `` `a${$.b}c` ``
+  desugars to `"a" + $.b + "c"`. The precedent is decisive and
+  already in the repository: `|>` is "pure parse-time sugar that
+  never reaches a Val" (G8 phase 4). No new Val kind, no dispatch
+  arm, no canon spelling.
+- **Canon prints the CONCATENATION**, `"a" + $.b + "c"`. This is
+  forced, not chosen: canon must round-trip and converge, the `+`
+  form already round-trips, and re-emitting `${...}` would require
+  canon to decide which of `+`'s operands were originally
+  interpolated — information the tree does not carry, because there
+  is no CST. **The hash form and `hcanon` therefore see no change
+  whatsoever**, which is the best property of this design.
+- **The costs, stated.** (1) It is the FIRST change to string lexing
+  in either port: ts/src/lang.ts calls `jsonic.options(...)` five
+  times and sets comment, number, text and hint — never `string`;
+  go/lang.go sets ErrMsg, Comment, List, Text, Number, Value, Map —
+  no String key. Both inherit backtick multi-line and escape
+  handling from @tabnas defaults unchanged, which is the one place a
+  @tabnas bump in one port can silently diverge from the other.
+  AGENTS.md already warns that the spread and optional-key rules
+  depend on parser internals. (2) It is a **breaking change**: a
+  document with a literal `${` in a backtick string changes meaning.
+  It ships behind a language-version gate for one minor line, with
+  `vet` reporting a `compat`-class finding at every backtick string
+  containing `${`, then flips. (3) It **regresses `patch`**: the only
+  port-neutral implementation sub-parses each `${...}` at parse time,
+  and the Vals that come back carry synthetic sites, so
+  `spanHolds` (ts/src/patch.ts) — which verifies recorded source
+  text before writing a byte — must learn to REFUSE an interpolated
+  span explicitly rather than silently degrading to
+  append-with-a-warning. That refusal is a named deliverable of the
+  phase, not a discovered surprise.
+
+Because backticks are already multi-line and already process escapes
+in both ports, and because only two spec rows anywhere touch backticks
+and both are single-line, **multi-line backtick `gens`/`canon` rows go
+into the shared suite in Phase 0**, whatever happens to interpolation.
+They cost a handful of rows and they protect a feature this whole
+capability already depends on.
+
+### 5. The Jostraca seam (D3, D7)
+
+**The dependency is exact-pinned in both ports.** `"jostraca":
+"0.34.0"` in ts/package.json and `github.com/jostraca/jostraca/go
+v0.34.0` in go/go.mod. Exact, no range operator, for the reason
+AGENTS.md already gives for the `@tabnas` pins: the spec suite will
+assert *through* Jostraca's public API — the `existing.txt` policy
+defaults, the `Inject` marker pair, the merge conflict marker text,
+the `.jostraca/generated/` baseline layout — and none of that is
+versioned API. `^0.34.0` would let a Jostraca patch turn an Aontu spec
+row red with no Aontu commit.
+
+**A pin-equality guard lands with it, and covers `@tabnas` too.**
+Nothing today checks that the two ports' shared pins agree. They
+mostly do, by discipline — but VERIFIED they do not entirely:
+`@tabnas/json` is `v0.5.2` in go/go.mod and resolves to `0.5.7` in the
+TypeScript lockfile, and `@tabnas/debug` has no Go counterpart. The
+test therefore asserts equality over an explicit SHARED-PIN SET plus a
+declared exclusion list, and asserts the exclusion list is exhaustive
+so a new one-sided dependency fails it. One copy in each port so
+neither can be deleted quietly.
+
+**The bridge is the only Jostraca importer, and it is isolated.** In
+TypeScript the `require('jostraca')` happens inside the function body,
+not at module top level, so `require('aontu')` does not pull the
+generator. In Go the bridge is its own package —
+`github.com/aontu-lang/aontu/go/emit` — so a consumer embedding Aontu
+for unification alone never links Jostraca. **The LSP may never reach
+it**, asserted mechanically by walking the require graph of
+`dist/lsp-server.js` and by `go list -deps` on go/lsp: an editor
+plugin must never be able to write files.
+
+**Install weight is a blocking cross-repository item.** Jostraca's own
+runtime dependencies are zero, but it imports `memfs` unconditionally
+at module load for a capability used only when `mem: true`. VERIFIED
+by `du`: that closure is 15 MB (`@jsonjoy.com` alone is 14 MB) against
+1.4 MB for Aontu's entire `@tabnas` parser stack. That is an 11x
+install growth for a capability a normal render never uses, and it is
+also a parity absurdity — Jostraca's Go port ships its own `MemFS`
+backed by a string-keyed map and needs no dependency at all. Lazy
+loading it, and moving `shape` from `peerDependencies` (where it is
+today, while four modules import it unconditionally) into
+`dependencies`, are the two blocking asks on the other repository.
+
+**What the bridge does, and what it does not.** It receives the render
+report — N units, each a path and a byte string — and builds ONE
+Jostraca `Project` containing all N as folders and files, then makes
+ONE `generate()` call. Aontu contributes no file writing, no diff, no
+merge, no protected-region format. `agentsMdSplice` stays what it is —
+a 20-line marker replacement for Aontu's own AGENTS.md stanza —
+and is explicitly NOT generalised into a second protected-region
+mechanism that would put Aontu and Jostraca in competition over the
+same file. `Inject` is the sanctioned spelling.
+
+`Content` templates unconditionally in Jostraca, so a `$$path$$`
+sequence appearing in Aontu-generated bytes would be silently
+substituted. The bridge therefore passes `raw: true` (a small addition
+on the Jostraca side); until it exists, the bridge passes an empty
+model. Without this, "Aontu owns the bytes" is not true — Jostraca
+gets the last edit, invisibly.
+
+**Dry run needs no new Jostraca feature.** `mem: true` plus
+`result.vol()` runs the same write path a real run does, which a
+bespoke dry-run reporter would not.
+
+### 6. The manifest (D5 iv, D7)
+
+One document names the N outputs, and it is an Aontu document, so it
+is vettable like anything else:
+
+```aon
+@"std/code"
+@"./model.aon"
+
+outputs: [
+  { target: "typescript", at: "$.schema",  transform: $.xf.ts,   out: "ts/domain.ts" }
+  { target: "go",         at: "$.schema",  transform: $.xf.go,   out: "go/domain.go", profile: {pkg: "domain"} }
+  { target: "sql",        at: "$.schema",  transform: $.xf.sql,  out: "sql/schema.sql" }
+  { target: "openapi",    at: "$.api",     transform: $.xf.oas,  out: "openapi.yaml" }
+]
+```
+
+`at` is DOCUMENTATION (D6): it is what the coverage report measures
+intent against, and nothing refuses a read outside it.
+
+**Pinning (D5 ii): `hash --at` is not needed and will not be built.**
+`aontu hash` hashes the whole document, so a docs-only edit moves the
+pin even when a slice's canon is byte-identical. Under D7 that is the
+right answer, not a defect: one run regenerates every output from one
+model, so every generated file carries the SAME whole-model pin, and
+drift is exactly "some file's pin is not the current model hash" — one
+comparison, no per-slice bookkeeping.
+
+**Incremental regeneration is refused (D5 v).** Everything regenerates
+on every run. There is no dependency graph, no per-slice hash, no
+staleness cache — and under D6 there could not be a sound one anyway,
+because a transform may read anything. The cost at scale is one full
+model evaluation plus N transform folds per run; the model is
+evaluated ONCE and shared by every transform (D7), so the cost that
+grows with N is the fold, which is linear in output size. For the
+sizes in `use-cases/` this is milliseconds. If a model ever reaches
+the point where a full run is intolerable, the honest fix is a faster
+evaluator, not a cache that D6 makes unsound.
+
+**Coverage cuts both ways (D5 vi), and it is free from provenance.**
+The report names (a) model paths no output consumed — dead model —
+and (b) output declarations produced by no rule — a silent hole. Both
+fall out of the (node path, rule index) trace with no extra
+machinery.
+
+**One slice may feed several targets and one target may draw on
+several slices (D5 vii).** Nothing in the manifest assumes a
+partition, and the coverage report is computed as a set union over all
+outputs, not per-output.
+
+**Partial failure: the whole run is abandoned, and nothing is
+written.** VERDICT and reason. Jostraca receives one `Project` and one
+`generate()` call (D7), so there is no half-written tree to reason
+about — but that is a mechanism, not a justification. The
+justification is that the N outputs are N views of ONE model and are
+only meaningful together: a Go server written from the model and a
+TypeScript client left at the previous revision is precisely the drift
+this whole capability exists to remove, and it is worse than no output
+because it looks like success. So: render every output, collect every
+finding, report all of them, and write nothing unless all N rendered.
+One exit code, one report. This also makes `--check` meaningful — a
+run either agrees with the tree on disk or does not.
+
+---
+
+## Worked examples
+
+All four are real: the transforms run against real documents under
+[`use-cases/`](../../use-cases/), the IR was produced by both CLIs and
+diffed, and the bytes below came out of a reference renderer
+implementing the algorithm in [§3](#3-the-renderer-and-the-language-profiles).
+
+### Worked example 1
+
+**One transform, over the real
+[`use-cases/10-data-model/domain.aon`](../../use-cases/10-data-model/domain.aon),
+read across an `@include`, to TypeScript.** This is nine lines of
+actual transform, and every construct in it exists today.
+
+```aon
+# xf-domain.aon
+@"./domain.aon"
+
+step: hide(pack($.schema, { d: {
+  k: "record"
+  name: key(2)
+  fields: pick(pack(_, { f: {
+    name: key(2)
+    type: match(_,
+      integer,    { k: "prim", prim: "int" },
+      biginteger, { k: "prim", prim: "bigint" },
+      string,     { k: "prim", prim: "string" },
+      boolean,    { k: "prim", prim: "bool" },
+      [],         { k: "list", of: { k: "prim", prim: "any" } },
+      { k: "prim", prim: "any" })
+  }}), f)
+}}))
+
+code: { units: [ { path: "domain.ts", lang: "typescript", decls: pick($.step, d) } ] }
+```
+
+VERIFIED, the IR is byte-identical from both engines:
+
+```
+$ diff <(node ts/bin/aontu.js get '$.code' xf-domain.aon -c) \
+       <(go run ./cmd/aontu   get '$.code' xf-domain.aon -c)
+   (no output)
+```
+
+and VERIFIED, the transform document itself vets against the
+vocabulary — D1's payoff, in place, in both ports:
+
+```
+$ aontu vet std-code.aon xf-domain.aon        -> verdict: valid
+```
+
+The rendered bytes, exactly (535 bytes, LF, final newline):
+
+```typescript
+export interface Customer {
+  country: string;
+  creditLimitCents: number;
+  currency: string;
+  email: string;
+  id: string;
+  ledgerId: number;
+  name: string;
+}
+
+export interface Invoice {
+  currency: string;
+  grossCents: number;
+  id: string;
+  netCents: number;
+  orderId: string;
+  taxCents: number;
+}
+
+export interface Order {
+  customerId: string;
+  id: string;
+  lines: unknown[];
+  placed: string;
+  status: string;
+}
+
+export interface OrderLine {
+  amountCents: number;
+  qty: number;
+  sku: string;
+  unitCents: number;
+}
+```
+
+**Read the losses, because they are the honest state of the art.**
+`email` should be `email?`, and is not, because optionality is
+invisible to `pack` (Current state). `ledgerId` should be
+`number | bigint`, and is `number`, because `match` selects one arm of
+`integer & min(1) | biginteger & min(1)` and there is no `members()`.
+`lines` should be `OrderLine[]` and is `unknown[]`. Field order is
+alphabetical, not authored. Every `re()`, `min()`, `max()` and
+`length()` in the source is gone. Each of those is a specific,
+addressable gap and each is closed by a specific, named thing below —
+none of them by "more transform".
+
+### Worked example 2
+
+**The same model, three targets, one run (D5, D7).** The transform
+gains the two facts the record schema cannot state — stated once, as
+data, which is what an author does before the reflection sidecar
+lands — and names three units.
+
+```aon
+# xf-order.aon --- ONE model, THREE outputs, each over part of the model.
+@"./domain.aon"
+
+rec: hide(pack($.schema, { d: {
+  k: "record"
+  name: key(2)
+  fields: pick(pack(_, { f: {
+    name: key(2)
+    optional: match(key(2), "email", true, "creditLimitCents", true, false)
+    type: match(_,
+      integer,    { k: "prim", prim: "int" },
+      biginteger, { k: "prim", prim: "bigint" },
+      string,     { k: "prim", prim: "string" },
+      boolean,    { k: "prim", prim: "bool" },
+      [],         { k: "list", of: { k: "ref", name: "OrderLine" } },
+      { k: "prim", prim: "any" })
+  }}), f)
+}}))
+
+decls: hide(pick($.rec, d))
+
+code: { units: [
+  { path: "ts/domain.ts",   lang: "typescript", decls: $.decls }
+  { path: "go/domain.go",   lang: "go", pkg: "domain", decls: $.decls }
+  { path: "sql/schema.sql", lang: "sql", decls: $.decls }
+]}
+```
+
+VERIFIED byte-identical from both engines. The three rendered units,
+exactly. `ts/domain.ts` (`Customer` only, the rest as above):
+
+```typescript
+export interface Customer {
+  country: string;
+  creditLimitCents?: number;
+  currency: string;
+  email?: string;
+  id: string;
+  ledgerId: number;
+  name: string;
+}
+```
+
+`go/domain.go`:
+
+```go
+package domain
+
+type Customer struct {
+	Country string `json:"country"`
+	CreditLimitCents *int64 `json:"creditLimitCents,omitempty"`
+	Currency string `json:"currency"`
+	Email *string `json:"email,omitempty"`
+	ID string `json:"id"`
+	LedgerID int64 `json:"ledgerId"`
+	Name string `json:"name"`
+}
+```
+
+Three things to read off it. `Email` is `*string` with `omitempty`
+while TypeScript got `email?` — presence and nullability are the same
+fact here and would be two different facts if the model said
+`email: string | null`, which is why the vocabulary keeps
+`%Field.optional` and `{k:"opt"}` separate. `ID` and `LedgerID`
+carry the acronym override where TypeScript's `ledgerId` does not,
+because the acronym set is per-profile. And **the types are not
+column-aligned**: `gofmt` would align them, this renderer does not,
+and that is the stated cost of refusing a formatter subprocess.
+
+`sql/schema.sql` (667 bytes), and this one found a real defect:
+
+```sql
+CREATE TABLE customer (
+  country TEXT NOT NULL,
+  credit_limit_cents BIGINT,
+  currency TEXT NOT NULL,
+  email TEXT,
+  id TEXT NOT NULL,
+  ledger_id BIGINT NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE "order" (
+  customer_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  lines order_line[] NOT NULL,
+  placed TEXT NOT NULL,
+  status TEXT NOT NULL
+);
+```
+
+The first render of this emitted `CREATE TABLE order (` — a syntax
+error in every SQL dialect, produced silently, from a valid model, by
+a correct-looking transform. `Order` is a record in the model and
+`order` is a reserved word in the target. **This is the whole
+argument for `ir_name` and for the reserved-word list being profile
+data**, and the corrected line above is what the rule produces. It
+also produces a loss entry, because the rename is a real loss —
+hand-written consumer code referring to `order` will not compile
+against `"order"`:
+
+```
+lossy: $.code.units.2.decls.2  ir_name: "Order" is reserved in sql; quoted as "order"
+lossy: $.code.units.2.decls.2.fields.2  union-unsupported: SQL has no list-of-record type
+```
+
+The second entry is the other honest loss: `lines order_line[]` is
+not what any real schema wants. SQL falls off the core here, and the
+report says so rather than the renderer inventing a join table.
+
+### Worked example 3
+
+**A different real document, a different shape: one output FILE PER
+ENTITY, from
+[`use-cases/01-service-catalog/`](../../use-cases/01-service-catalog/).**
+
+```aon
+# xf-k8s.aon
+@"./system.aon"
+
+svc: hide(pack($.catalog.domains.payments.services, { u: {
+  path:  `k8s/` + key(2) + `.yaml`
+  lang:  "yaml"
+  decls: [ { k: "record", name: key(4), open: false, fields: [
+    { name: "tier",  type: {k:"prim", prim:"int"} }
+    { name: "owner", type: {k:"prim", prim:"string"} }
+  ]} ]
+}}))
+
+code: { units: pick($.svc, u) }
+```
+
+VERIFIED byte-identical from both engines, and it produces three
+units:
+
+```
+k8s/ledger.yaml    ledger
+k8s/payments.yaml  payments
+k8s/risk.yaml      risk
+```
+
+**Two findings, both from this one small transform.** First, the
+order: `catalog.aon` declares `payments` (line 11), `ledger` (17),
+`risk` (22), and the generated units come out `ledger, payments,
+risk`. That is the code-point sort, on a real document, changing the
+order of generated files. Second, and worse, the FIRST version of
+this transform wrote `name: key(2)` inside the `decls` list, and every
+unit came out with `name: "decls"` — silently, with no error, in both
+ports. `key(n)` counts UP: `key(0)` is the node's own key, and inside
+a template nested one map deeper the source key has moved. It is
+documented (docs/reference-language.md:1306) and it is still the
+single easiest thing to get wrong when writing a transform. Both go in
+the risk table; the first is what `form` fixes.
+
+### Worked example 4
+
+**What the vocabulary refuses, and where.** This is D1 doing its job,
+in place, on the transform of worked example 1 with a single character
+changed (`prim: "int"` to `prim: "nope"`):
+
+```
+$ aontu vet std-code.aon xf-domain-bad.aon
+verdict: invalid
+
+$.code.units.0.decls.0: empty [conflict]
+  [aontu/empty]: Cannot unify values at path $.code.units.0.decls.0
+  data:   xf-domain-bad.aon:3:32 ({"fields":[{"name":"country","type":{"k":"prim",
+          "prim":"string"}},{"name":"creditLimitCents","type":{"k":"prim","prim":
+          "nope"}},...],"k":"record","name":"Customer"})
+  schema: std-code.aon:9:8 ({"doc"?:string,"fields":[&:$.%Field],"k":"record",
+          "name":re("^[A-Za-z_][A-Za-z0-9_]*$"),"open":*false|boolean}|
+          {"k":"text","lang":string,"text":string})
+$.code.units.0.decls.1: empty [conflict]
+  ...
+```
+
+Exit 1, both ports, with a site in the transform's own source. XSLT
+could only validate the result against the output *schema*, after the
+fact; here the same unification engine that built the result checks
+it, at the node.
+
+**And what it does NOT do well, stated because it will be the first
+complaint.** When *every* arm of `%Decl` fails, the finding is one
+`empty [conflict]` whose `schema:` field prints all six arms. When one
+arm survives — the `k` matched and something inside it is wrong —
+diagnostics are precise and path-anchored. Three mitigations, in
+order: the RENDERER is the primary gate and refuses with a precise
+`ir_*` code at the node; the per-kind aliases are public so an author
+debugging one node vets it against `%Record` alone; and an
+engine-level improvement is proposed in
+[Open questions](#open-questions) — when all arms of a disjunction of
+closed maps fail and exactly one arm's discriminator key matched,
+report inside that arm. That last is diagnostics-only, changes no
+semantics, and would improve every discriminated-union schema in the
+language.
+
+---
+
+## Boundary: what we will not do
+
+The [G8 boundary](g8-generation.md#boundary-what-we-will-not-do)
+stands except where D4 opens it. Restated with what this document
+adds:
+
+- **No user-defined functions (`def()`)** — unchanged from G8. A
+  transform is a template plus combinators; recursion in user space
+  is what D4(iii) puts in the engine precisely so that it stays out
+  of user space.
+- **No comprehension keywords (`for`/`if`/`in`)** — unchanged.
+- **No computed-key syntax** — unchanged; `pack` is that job.
+- **No new operator tokens** — `-` `*` `/` `%` stay reserved.
+- **No lazy-evaluation redesign** — unchanged.
+- **No second rule engine, no second pattern language.** `match()`
+  IS the rule table and unification IS the match test. A stylesheet
+  with its own priority scheme, its own conflict resolution and its
+  own patterns is the thing XSLT 3.0 retracted; it will not be
+  imported.
+- **No priority numbers and no import precedence.** Ordered
+  first-match-wins, which is `match`'s existing, spec-pinned rule.
+- **`onNoMatch` is never `copy`.** XSLT's built-in text-copy rule is
+  refused: silently emitting model data into a source file is the
+  worst available default.
+- **No line-width concept, and no Wadler/Prettier document IR.** Line
+  breaking is the model's job. Every `group`/`softline` decision is a
+  TS/Go divergence site with no cheap pin, and it makes a spec row's
+  bytes depend on a width three levels up. If it is ever wanted it
+  needs its own phase and its own spec file; it must not arrive
+  incrementally.
+- **No formatter subprocess.** Not behind a flag, not "if available".
+  Hermeticity (G5), parity (ADR-001) and coverage (ADR-002) each
+  refuse it independently.
+- **No heuristic quoting.** The IR node says which quoting form it
+  wants; asking for a raw form on a string that cannot take one is a
+  refusal, never a silent fallback. Heuristics are nondeterminism
+  dressed as convenience.
+- **No host-registered render extensions** — no handler table, no
+  callback. A TypeScript handler has no Go twin (ADR-001), a host
+  callback is neither deterministic nor hermetic (G5), and a handler
+  that runs during rendering is a branch the shared suite cannot
+  reach and ADR-002 cannot cover. The escape is `{k:"text"}` or a new
+  vocabulary node landed in both ports with rows.
+- **No map iteration in the renderer, and no sorting.** Ordered
+  things are lists. Import ordering is the transform's job.
+- **No re-implementation of anything Jostraca owns** — no file
+  writer, no diff, no three-way merge, no protected-region format.
+  `agentsMdSplice` is not generalised.
+- **No incremental regeneration, no per-slice hash, no staleness
+  cache, and no `hash --at`** (D5 v, D5 ii).
+- **No slice confinement** (D6). A transform may read anything; the
+  declared slice is documentation and a coverage input.
+- **No partial writes.** Output 3 of 5 failing abandons the run.
+- **No `drive`-style write tool over MCP.** The trust profile governs
+  `@"..."` READS (ts/src/type.ts) and there is no write clause; a
+  tool whose purpose is writing files cannot be confined by it, and
+  ts/src/mcp.ts is explicit that a tool must never choose its own
+  confinement. The plan half is served; the writing half is not.
+- **No LLM anywhere in the pipeline.** Deterministic, mechanical
+  derivation is the entire pitch.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| The four invisible facts (optionality, source order, closedness, disjunction arms) make every sidecar-free transform quietly lossy — VERIFIED on `domain.aon`: `email` lost its `?`, `ledgerId` lost an arm, fields came out alphabetical | High | High | Named as losses in the docs and in every worked example, not hidden; the reflection sidecar (Phase 5) closes all four with zero language change, via the `$name` host-variable mechanism both ports already have; until then the model states them as data, as worked example 2 does |
+| Go has NO public Val reflection (`go/val.go` exports five methods; `MapVal` fields are unexported), so form (a) is TypeScript-only today | High | High | Sized as its own phase, not "mostly not my area": exported Go accessors mirroring what `ts/src/val/MapVal` already exposes, with shared rows, land BEFORE the `$model` injection so the injection is a thin re-expression of one API rather than two new surfaces |
+| The recursive-alias vocabulary does not terminate — VERIFIED, nine arms double-included is killed at 60 s in BOTH ports; five arms hangs TypeScript while Go answers, so the same construct is a G5 failure at one size and an ADR-001 divergence at another | High | High | The vocabulary is depth-capped by construction (containers take leaves only): VERIFIED 0.17 s / 0.01 s on the same document, byte-identical hash, and diagnostics stop degrading with depth. A `divergent.tsv` row and a BUGS.md entry regardless, because the engine defect outlives this vocabulary |
+| `id()` naming a node and its own descendant stack-overflows both ports — VERIFIED, uncatchable `fatal error` in Go | Medium | High | Phase 0 refuses it at the merge as `id_ancestor`; the walk's totality argument depends on it and says so |
+| `pick` orders a map's children differently in the two ports — VERIFIED, `["B","A"]` in TS and `["A","B"]` in Go with an astral key | Medium | High | Phase 0, one word: `ts/src/val/AggFuncVal.ts` uses a bare `.sort()` where Go uses `sort.Strings` and where `each` correctly uses `cmpCodePoint`. `join` inherits the same helper, so it must land first or the new builtin ships broken |
+| `pick(each(d, {computing template}), k)` resolves in TypeScript and fails `mapval_no_gen` in Go — VERIFIED — and the INLINE spelling fails in BOTH | Medium | High | Phase 0 fixes Go's staged snapshot to defer as TypeScript's `argsnap` does, and pins BOTH spellings in both ports; the design does not depend on either, because `pick(pack(...))` nested is VERIFIED working in both |
+| Hidden and unfilled-optional children flow into every bag — VERIFIED, `each({a:1,b?:2,c:hide(3)})` is `[1,2,3]` in both ports | Medium | High | Phase 0 makes `each`/`pick`/`join`/`form` skip both, with rows pinning the CHANGED behaviour on the two existing verbs; a hidden value reaching generated source is a disclosure, and this is the one place this design changes shipped semantics |
+| `{k:"text"}` and `x` swallow the core, the OpenAPI Generator failure mode (5,000+ open issues, per-language template forks) | Medium | High | Every escape and every unenforceable check is an entry in `lossy[]` with its path; `--strict` refuses; `{k:"text"}` is opaque to `diff`/`subsume`/`breaking` and cannot render to more than one target, where a `ref` can. "How much of this generator is escapes" is a number, not a feeling |
+| The union diagnostic is coarse when EVERY arm fails — VERIFIED, one `empty [conflict]` printing all six `%Decl` arms | High | Medium | The renderer is the primary gate with precise `ir_*` codes; per-kind aliases are public for narrowing; an engine diagnostics-only improvement is proposed in Open questions |
+| `vet --at` loses `%alias` references through a LIST SPREAD in the Go port — VERIFIED, 2-line reproducer; `--at` is shared by `vet`, `jsonschema`, `diff` and `breaking` | Medium | Medium | The vocabulary is anchored under a key so no `--at` is needed; the defect lands in BUGS.md and `divergent.tsv` with the corrected diagnosis and the passing counter-case, so the fixer can bisect |
+| An alias-bearing disjunction that crosses an `@include` reports different message text and a different SITE in the two ports — VERIFIED, TS `($.%A&{"k":"c"})\|($.%B&{"k":"c"})` against `top` at the schema file, Go the expanded form against the data at the include line, same code and class; docs/trust.md puts message text in parity | Low | Medium | Recorded in `divergent.tsv`; `vet` AGREES on the same input, so the divergence is in the plain evaluation path only and the design's own checks are unaffected |
+| `gofmt` visibly disagrees with rendered Go — VERIFIED in worked example 2: struct field types are not column-aligned | High | Medium | The two-step pipeline is in `--help` and in the reference page with the reasoning; a non-gating `gofmt -l` canary in `go/render_test.go` tells the repository when its own goldens are not gofmt-clean |
+| `key(n)` depth is miscounted and produces silently wrong output — VERIFIED on the service catalog: every unit came out named `"decls"`, no error, both ports | High | Medium | `form` removes the commonest nesting; the trap is documented in the how-to with this exact example; a spec row pins it |
+| String interpolation destabilises @tabnas string lexing — it would be the FIRST such change in either port, in a component neither port configures, guarded by two single-line backtick rows | Medium | High | Phase 8 lands it alone, behind a version gate, with `patch`'s `spanHolds` refusal as a named deliverable; multi-line backtick `gens`/`canon` rows go into the suite in Phase 0 regardless, so a @tabnas bump cannot move the behaviour this design already depends on |
+| Golden churn: the Jostraca fixture goldens are valid only for the pinned version | High | Medium | Goldens are small and vary OPTIONS rather than content; a scheduled non-blocking `jostraca-latest` CI job gives warning without letting another repository's cadence break `main` |
+| The cross-repository dependency does not land: `memfs` lazy-loading and `shape` are blocking asks on jostraca | Medium | High | Phases 1–5 have no Jostraca dependency at all; `render --out` writes files directly and is a complete product without the bridge. The bridge is Phase 7 precisely so it cannot block the language work |
+| ADR-002's 100 % floor on a hand-written checker with per-kind, per-key arms, times two ports | High | Medium | The vocabulary IS the checker for shape (unification does it), so the renderer's checker validates only what unification cannot see — `ref` resolution, `lang` agreement, duplicate names, reserved words. Fault injection through the render profile reaches every arm |
+| Adoption: a transform reads worse than a fifty-line host program | Medium | Medium | Stated plainly rather than denied: what the layer buys over a host program is a vetted result, TS/Go byte parity, `--check`, a mandatory provenance pin and rule coverage. A single-host consumer with none of those needs should write the host program, and the docs say so |
+
+## Implementation plan
+
+Spec-rows-first throughout: every behaviour lands as `test/spec/*.tsv`
+rows agreed before code; TypeScript (canonical) implements; the Go
+port follows to green on the identical rows, with no skip list. At
+every phase nothing may regress: the full shared suite (97 files,
+3755 rows at drafting — re-derive with
+[protocol rule 5](progress.md#the-update-protocol)), canon
+convergence, and the ADR-002 floor in both ports.
+
+Baseline for the register: `ls test/spec/*.tsv | wc -l` = **97**,
+`awk -F'\t' 'NF>2 && $0 !~ /^#/' test/spec/*.tsv | wc -l` = **3755**.
+
+### Phase 0 — the four gating defects (S)
+
+None is recorded anywhere;
+[`test/spec/divergent.tsv`](../../test/spec/divergent.tsv) has zero
+rows today, so these would be its first entries, and per that file's
+own rules a divergence fixable from this repository gets FIXED rather
+than recorded — so three of the four are fixes and only the fourth is
+a row.
+
+1. **`pick` map ordering.** `ts/src/val/AggFuncVal.ts` sorts with a
+   bare `Object.keys(...).sort()` (UTF-16 code-unit order) where
+   `go/constraint.go`'s `bagChildren` uses `sort.Strings` (code-point
+   order) and where `ts/src/val/EachFuncVal.ts` correctly uses
+   `cmpCodePoint`. One import and one argument. `join` inherits the
+   same helper, so this is genuinely blocking.
+2. **The staged pipeline.** Go's snapshot of a staged producer with a
+   computing template is taken before the template resolves;
+   TypeScript's `argsnap` deferral (`ts/src/val/FuncBaseVal.ts`)
+   waits. Fix in `go/func.go`/`go/generate.go`. Pin BOTH the
+   two-statement and the inline spelling, in both ports.
+3. **`id_ancestor`.** `mergeEntities` (ts/src/unify.ts,
+   go/identity.go) refuses an `id()` whose named node is an ancestor
+   or descendant of another position bearing the same name — a
+   located `conflict` where today both ports die of stack overflow.
+4. **Bag membership.** `each`, `pick`, `join` and `form` skip
+   `hide`-marked children and unfilled optional keys. This is
+   observable behaviour on two shipped verbs and is the one place
+   this design changes existing semantics; it lands with rows
+   pinning the change and a CHANGELOG note.
+
+Also here, because they are cheap and protect what follows:
+multi-line backtick `gens`/`canon` rows (the only backtick rows in the
+suite today are single-line), and the `vet --at` list-spread alias
+break recorded in BUGS.md and `divergent.tsv` with its corrected
+diagnosis and its passing counter-case.
+
+*Files:* ts/src/val/AggFuncVal.ts, ts/src/val/EachFuncVal.ts,
+ts/src/unify.ts; go/agg.go, go/constraint.go, go/func.go,
+go/generate.go, go/identity.go.
+*Spec:* `agg.tsv` +6, `gen-each.tsv` +4, `id.tsv` +3,
+`errcodes.tsv` +1 (`id_ancestor`, conflict), `edge.tsv` +4,
+`divergent.tsv` +1.
+**Acceptance:** the astral-key `pick`, both `pick(each(...))`
+spellings, the `id()` ancestor document and the hide/optional bag all
+answer identically in both ports; the full suite is green.
+
+### Phase 1 — the vocabulary, as a bundled schema (S)
+
+The `@"std/code"` text of [§1](#1-the-output-vocabulary--stdcode)
+added to `ts/src/std.ts` (a `STD_CODE` constant plus two
+`STD_SOURCES` entries) and `go/std.go` (the same bytes), containing no
+backtick and no backslash. Nothing else in either engine changes: no
+builtin, no grammar, no LSP list, no error code. VERIFIED already
+working from a file in both ports, including the byte-identical hash.
+
+*Files:* ts/src/std.ts, go/std.go, docs/reference-api.md.
+*Spec:* new `std-code.tsv` (2 rows: canon, hash — mirroring
+`std-system.tsv`); new `ir-vet.tsv`, ~40 rows in the EXISTING five-column
+`vet` mode — one valid instance per node kind, plus a negative per
+kind (unknown `k`, unknown `c`, unknown `prim`, a bad `%Name`, a key
+`close()` refuses, and a missing required key asserting the
+`incomplete` verdict rather than `invalid`). **No new spec mode and no
+runner edit** — the single biggest saving in the design.
+**Acceptance:** both ports vet a full instance valid and every
+negative invalid; both hash the vocabulary identically; a document
+that merely includes it generates nothing of its own.
+
+### Phase 2 — `join` (S)
+
+`JoinFuncVal` beside `PickFuncVal` in ts/src/val/AggFuncVal.ts and
+`joinBag` in go/agg.go, reusing `bagChildren` and `unpref`. Registry:
+`funcMap`, `funcArity` `[1,2]`, `POSITIONAL_ARG_FUNCS` in TypeScript;
+`funcSet`, `stagedFuncs`, `positionalArgFuncs`, `funcArity` and the
+`resolve` arm in Go. `generatorFuncs` and `boundArgStart` are NOT
+touched — `join` holds no template and binds no `_`, so a `_` inside
+it belongs to the enclosing generator, which is what makes
+`pack($.rows, join(_, ","))` work.
+
+Both grammars' `name` rule, both LSP lists, and — **a repair that must
+happen with the first new builtin** — extending
+`ts/test/grammar.test.ts` to compare the lark grammar's `name`
+alternation LITERALS against `BUILTIN_FUNCS`. The gbnf list is
+set-equality checked both ways; the lark test compares only RULE
+names, and `grammar/aontu.lark` is consequently already missing
+`acyclic`, `inverse` and `rel`. Five lines, and it would have caught
+that.
+
+*Files:* ts/src/val/AggFuncVal.ts, ts/src/lang.ts, ts/src/lsp.ts,
+ts/test/lsp.test.ts, ts/test/grammar.test.ts; go/agg.go, go/func.go;
+grammar/aontu.gbnf, grammar/aontu.lark; docs/reference-language.md
+(the function table, and the stale "thirty-seven built-in functions"
+count at :1291 which docs/tutorial.md:440 repeats).
+*Spec:* new `gen-join.tsv`, ~34 rows — order for lists and maps
+(including the astral-key row that would have caught Phase 0's
+defect), the `+` fold, the empty identity, member and separator
+refusals, the settled/unsettled member split, staging, canon and
+hcanon of an unfired call, composition with `pick`/`each`, arity;
+`errcodes.tsv` +1 (`join_member`, conflict).
+**Acceptance:** `join([8080, 443], "-")` is `"8080-443"` in both
+ports; an unfired `join` canons as its call and reparses; the lark
+literal check is green after the three missing names are added.
+
+### Phase 3 — `form`, the order-preserving map (S/M)
+
+`ts/src/val/FormFuncVal.ts` and `formFunc` in go/generate.go,
+importing `each`'s exported ordering helper so the two can never
+disagree about order. The five registries in both ports, **plus
+`boundArgStart` in ts/src/val/PlaceVal.ts and go/place.go** — the
+site whose omission is silent.
+
+*Files:* ts/src/val/FormFuncVal.ts (new), ts/src/lang.ts,
+ts/src/val/PlaceVal.ts; go/generate.go, go/func.go, go/place.go.
+*Spec:* new `gen-form.tsv`, ~30 rows — order, replacement versus
+meet (the paired `form-vs-each-same-template` rows that document the
+whole distinction), identity non-carry, `key()` as index, relative
+references resolving at the destination, the hidden-capture idiom
+reading source fields, `_` binding under nesting, arity, canon,
+hcanon; `place.tsv` +4 cross-referencing the binding rows;
+`errcodes.tsv` +1 (`form_data`, parse — matching `each_data`'s class,
+with two sentences in the registry prose reconciling it against
+`aggregate_data`'s `conflict`, which will otherwise be reopened by
+the next reviewer).
+**Acceptance:** `form($.n, upper(_))` is `["A","B"]` where
+`each($.n, upper(_))` is `scalar_value`; source order survives; the
+service-catalog units come out `payments, ledger, risk`.
+
+### Phase 4 — the renderer core and the first two profiles (M)
+
+`ts/src/render.ts`: `renderValue(model, profile, opts)` implementing
+the indentation algorithm, the per-code-point escaper, the ASCII word
+splitter and case styles, the `prec`/`child_prec` type expression, the
+reserved-word escaper and the banner. No engine, no I/O: the profile
+arrives as a plain object. Then `go/render.go` as its twin, function
+for function, as `go/jsonschema.go` mirrors `ts/src/jsonschema.ts` —
+and the parity probe run on every case before a single expectation is
+recorded. Profiles `std/lang/ts` and `std/lang/go` bundled in
+ts/src/std.ts and go/std.go, byte-identical, pinned by a `hash` row
+each.
+
+*Files:* ts/src/render.ts (new), ts/src/std.ts; go/render.go (new),
+go/std.go; ts/test/render.test.ts and go/render_test.go for the two
+arms no TSV cell can reach (a lone surrogate; a lone carriage return —
+the escape table is exactly `\n`, `\t`, `\\`).
+*Spec:* new `render.tsv`, ~35 rows in a new four-column mode
+(`name <TAB> render <TAB> src <TAB> {profile, opts} <TAB> expect`) —
+indentation and nest depth, blank lines and trailing-whitespace
+trimming, `raw` with and without reindent, the empty unit, all case
+styles, the per-profile acronym override, reserved-word escaping in
+both profiles, string escaping, the `(string | null)[]` paren rule,
+and the `render_*` refusals. Newlines in expectations are written
+`\n`, which the runner's escape pass expands — the format supports it,
+contrary to an earlier draft's claim that it does not; only a carriage
+return is unspellable. Plus `errcodes.tsv` +8.
+**Acceptance:** worked examples 1 and 2 render byte-for-byte from
+both ports; `grep -n 'range ' go/render.go` shows ranges over slices
+only.
+
+### Phase 5 — the reflection sidecar (M)
+
+The four invisible facts close here, with **zero language change**,
+via the `$name` host-variable mechanism both ports already have
+(`ctx.vars` in TypeScript, `GenerateVars` with
+`NewMap`/`NewList`/`NewString` in Go). But the Go half must be built
+first and is not a footnote: `go/val.go` has no reflection surface at
+all to inject FROM, so exported accessors mirroring what
+`ts/src/val/MapVal` already exposes land as an ADR-001 parity item in
+their own right, with shared rows, BEFORE the injection.
+
+The injected `$model` carries, per named node: source key order (which
+survives on the Val tree and is destroyed only by canon and gen —
+the cheapest high-value item on the whole list), `optional`, `closed`,
+disjunction `arms`, `checks` already in `%Check` shape (not a canon
+string, or every transform reimplements a parser), the public kind
+label including bare `number` (Go already computes it in
+`valKind`, go/check.go — promote it; a transform must never switch on
+`constructor.name`), `entity`, `link` and `deprecated`.
+
+*Files:* go/val.go, go/mapval.go, go/listval.go (exported accessors);
+ts/src/reflect.ts and go/reflect.go (new); ts/src/render.ts,
+go/render.go (injection).
+*Spec:* new `reflect.tsv`, ~25 rows — `order` is source order not
+code-point, `optional` is true for a `?:` key, `closed` is true only
+under `close()`, `arms` enumerates a disjunction, `checks`
+round-trips into `%Check` shape, `kind` reports `number` for a bare
+`number`.
+**Acceptance:** worked example 1's transform, rewritten against
+`$model`, produces `email?`, `ledgerId: number | bigint`,
+`lines: OrderLine[]`, source field order and every `re()`/`min()`
+carried as a check — in both ports.
+
+### Phase 6 — `walk`, the manifest, and the verb (M)
+
+`walk(data, tmpl)` in both ports: arity `[2,2]`, staged, positional,
+in `generatorFuncs` and `boundArgStart`, producing a pre-order list
+with `_` bound to the node, descending `peg` only. Codes `walk_data`
+(parse, by `each_data`'s precedent), `walk_cycle` (conflict — refuse
+on revisit, never skip) and `walk_budget` (budget, by
+`recursion_budget`'s precedent, so "retry with a larger budget" is a
+valid agent response signalled by the class). It must NOT reuse
+`empty`.
+
+Then `aontu render` in both CLIs, the manifest, the provenance trace,
+the coverage report, and one MCP tool over the plan half only.
+
+```
+aontu render [--profile <name|file>] [--at <path>]
+             [--out <dir> | --stdout | --check]
+             [--manifest <file>] [--strict] <file>
+```
+
+Exit codes mirror `jsonschema` exactly — 0 ok, 1 lossy under
+`--strict` or drift under `--check`, 2 usage or I/O, 4 the document
+does not stand up — and `finish()` sets `process.exitCode` rather than
+calling `process.exit`, so a large piped unit is not truncated at the
+pipe buffer.
+
+**A write posture is specified here, and docs/trust.md is amended**,
+because this is the first verb with a write effect: `--out` is
+realpath-confined below the given directory, a unit `path` that is
+absolute or contains `..` is refused, and the trust contract gains one
+paragraph saying that `render` is confined by PATH, not by the include
+profile. `render` and `renderValue` are exported from the
+`ts/src/aontu.ts` barrel — do not repeat the `jsonSchema` mistake, the
+one emitter reachable only by deep import.
+
+*Files:* ts/src/val/WalkFuncVal.ts, ts/src/render.ts, ts/src/cli.ts,
+ts/src/mcp.ts, ts/src/aontu.ts; go/generate.go, go/func.go,
+go/place.go, go/render.go, go/cmd/aontu/render.go,
+go/cmd/aontu/main.go; docs/trust.md.
+*Spec:* new `gen-walk.tsv` ~30 rows; `render.tsv` +10 (manifest and
+coverage); `errcodes.tsv` +3. CLI behaviour is pinned by executable
+transcripts in docs/reference-api.md, run by `ts/test/docs.test.ts`,
+as the `jsonschema` section already is.
+**Acceptance:** worked example 2's three units are produced by one
+`aontu render --manifest` invocation in both ports; the coverage
+report names `$.customers`, `$.orders` and `$.invoices` as consumed by
+no output; a manifest whose third output fails writes nothing.
+
+### Phase 7 — the Jostraca bridge (M)
+
+The exact pins, the pin-equality guard (with its explicit shared set
+and exhaustive exclusion list), `ts/src/emit-jostraca.ts` with the
+`require` inside the function body, `go/emit/` as its own package, and
+the LSP isolation assertions in both ports. Blocking on the other
+repository: lazy `memfs`, `shape` moved to `dependencies`, and
+`ContentProps.raw`.
+
+*Spec:* no shared rows — this is cross-repository. Byte-exact fixture
+directories under `test/spec/files/render-jostraca/<case>/` with a
+README naming the pinned Jostraca version and the redactions, read by
+one test per port with a count assertion so deleting a case on one
+side fails the other. That is the `test/spec/files/vet-sarif/`
+pattern, and it fits here because the goldens are valid
+only for the pin and a directory with a README can say so where a TSV
+row cannot.
+**Acceptance:** worked example 2 written to disk through one
+`generate()` call; a second run with one file hand-edited inside a
+`JOSTRACA_PROTECT` region leaves it alone; a conflicted merge is a
+first-class verdict at exit 1.
+
+### Phase 8 — string interpolation (M/L, the parser phase)
+
+Last, alone, and behind a version gate, for the reasons in
+[§4](#4-the-language-additions-d4). Named deliverables include the
+`spanHolds` refusal for interpolated spans, the `compat`-class
+migration finding, and `edge.tsv` rows pinning the backtick lexer so a
+@tabnas bump in one port cannot move it silently.
+
+*Files:* ts/src/lang.ts, go/lang.go, ts/src/patch.ts, go/patch.go,
+both grammars, both LSP tokenizers.
+*Spec:* new `interp.tsv`, ~40 rows — delimiter, `$${` escape, nesting
+refusal, canon-is-concatenation, hcanon round-trip, multi-line, every
+other quote style inert, the migration finding; `errcodes.tsv` +2.
+**Acceptance:** `` `a${$.b}c` `` and `"a" + $.b + "c"` have the same
+canon, the same hash and the same value in both ports; `patch
+--in-place` REFUSES an interpolated span with a located code rather
+than degrading.
+
+### Documentation and register obligations
+
+In the landing commit of each phase, per CLAUDE.md and AGENTS.md:
+`docs/design/EMISSION.0.md` for the design note;
+`docs/how-to/generate-code.md` as a Diátaxis how-to with every fenced
+block tagged and executed by `ts/test/docs.test.ts`;
+`docs/reference-api.md` for the verb and the library functions;
+`docs/shared-spec.md` and AGENTS.md's mode table for the `render`
+mode; a `use-cases/15-generate/` directory following the
+`14-jsonschema-export` pattern with `check.sh` and `expected/`; and
+the phase's row in
+[`docs/capability-review/progress.md`](progress.md) changing in the
+**same commit** that changes its status. **ADR-012** is required —
+"Aontu depends on Jostraca, and the dependency is data" — because this
+is a cross-repository coupling that changes the install story and adds
+a dependency to a project that has taken seven in its life; without an
+ADR a future maintainer will reverse it in good faith. ADR.md's index
+table is also stale, stopping at ADR-008 while ADR-009, ADR-010 and
+ADR-011 exist; fix it in the same commit.
+
+## Open questions
+
+- **The discriminated-disjunct diagnostic.** When every arm of a
+  disjunction of closed maps fails and exactly one arm's
+  DISCRIMINATOR key — a key present in every arm with a single
+  literal value — matched, report inside that arm instead of dumping
+  all arms. Diagnostics only, no semantics change, and it would
+  improve every discriminated-union schema in the language, not just
+  this one. It is the single change that would most improve this
+  vocabulary's ergonomics and it is an engine change. Decided by:
+  whether the renderer's own `ir_*` codes prove sufficient in
+  practice once Phase 4 exists.
+- **A `kindof(x)` builtin.** Bare `number` cannot be discriminated by
+  `match`, because `match` selects by unifiability and `number`
+  unifies with all four numeric leaves — VERIFIED, and no re-ordering
+  fixes it. `kindof(x)` returning the kind name as a string would
+  make it exact: arity `[1,1]`, one `funcMap` entry, no grammar
+  change, squarely inside "prefer functions over new tokens", and Go
+  already computes the label in `valKind`. This design proceeds
+  without it (the vocabulary has no `prim:"number"`, and the
+  reflection sidecar reports the true kind), but it would remove the
+  sidecar's `kind` field for the common case.
+- **A `doc(x, "text")` builtin.** Aontu has no comment recovery and
+  never will without a CST, so doc comments in generated code must be
+  MODEL DATA. `%Doc` is in the vocabulary but today a transform can
+  only supply doc text it wrote itself. A `doc()` builtin mirroring
+  `deprecate(x, {...})` — which already has the whole rider, clone
+  and canon machinery — would let a model carry its own documentation
+  and the transform lift it. One `funcMap` entry, one arity entry, no
+  grammar change. Decided by: whether the first two backends want it
+  before Phase 5 lands, since the sidecar could carry it instead.
+- **Whether `func` belongs in the core vocabulary at all.** It is
+  kept, with a structured signature and an opaque body, on the
+  argument that signatures are where symbols and imports pay off. The
+  honest counter-argument is that a transform cannot compute a body,
+  so a `func` decl is always a signature wrapped around a text blob,
+  and the whole thing could be one `{k:"text"}` decl. Decided by:
+  whether the first two backends ever use a body that is not
+  `{k:"abstract"}`.
+- **Whether the `{k:"lit"}` / `enum` split is the author's decision
+  or the backend's.** An inline literal union stays inline unless
+  someone names it; this design says the transform author decides by
+  emitting an `enum` declaration plus a `{k:"ref"}`, and the renderer
+  never promotes an inline `lit` on its own. A backend wanting
+  auto-naming does it behind an `x` flag. Decided by: whether two
+  backends independently want the same promotion.
+- **Which target ships third.** TypeScript and Go ship first because
+  they are the two ports and both profiles can be validated against
+  this repository's own source. SQL is the more interesting stress
+  test — it is where `union`, function bodies and half the checks
+  fall off, and worked example 2 already found a reserved-word defect
+  with it. YAML is the acid test of the indentation design, because
+  it is the first target where structural indentation IS the
+  language's syntax. Decided by: whether the goal is to demonstrate
+  the design or to stress it.
+- **Whether `x` should be shape-constrained.** `x?: {}` is an open
+  map by convention keyed by backend name. Spelling it `x?: {&: {}}`
+  costs nothing and makes a stray `x: {tag: "..."}` a vet error
+  rather than a rider no backend reads — but a backend that publishes
+  a schema CLOSING its own `x` key would then refuse another
+  backend's riders under the same `x`, destroying the
+  multi-backend-in-one-instance property the single-vocabulary
+  decision is built on. Decided by: whether a second backend schema
+  is ever written.
+- **Fragment and Copy reads.** `%Fragment.from` and `%Copy.from` on
+  the Jostraca side are filesystem READS performed outside
+  `trust.include`'s confinement. Phase 7 does not use them, but a
+  later phase that does needs a `--templates <dir>` root with the
+  same realpath confinement `--out` gets, or the trust contract
+  acquires a fifth input nobody declared. Decided by: the first
+  transform that wants a hand-written template file.
+- **Whether the render mode should read its expectation from a
+  fixture FILE.** `__FIXTURES__` feeds only the `src` column today.
+  Extending it to the expectation would give whole-file goldens that
+  are reviewable `.go` and `.ts` files a compiler can be run over,
+  while keeping the no-skip-list guarantee every TSV row has and a
+  fixture pair does not. It widens what a spec row can do, and a row
+  that reads a file can fail for a filesystem reason. Decided by:
+  whether Phase 4's `\n`-escaped rows prove unreviewable at the
+  eight-line cap.

--- a/docs/capability-review/index.md
+++ b/docs/capability-review/index.md
@@ -68,6 +68,13 @@ infrastructure around the lattice, not syntax on top of it.
 
 ## The eight fundamental gaps
 
+> **A ninth was opened later.** G1–G8 are the August 2026 survey.
+> [G9](g9-transformation.md) was opened on 2026-08-30, after all eight
+> had landed, and asks a question the survey did not: once a model is
+> trustworthy, how does the CODE come from it? Its companion for the
+> non-declarative forms is
+> [docs/design/GENERATION-FORMS.0.md](../design/GENERATION-FORMS.0.md).
+
 | # | Gap | Why it changes what the language is | Design doc |
 |---|-----|-------------------------------------|------------|
 | G1 | A real constraint algebra | Makes "type safety through unification" true beyond five kinds; everything else is downstream | [g1-constraint-algebra.md](g1-constraint-algebra.md) |
@@ -78,6 +85,7 @@ infrastructure around the lattice, not syntax on top of it.
 | G6 | A distribution layer | Versioned, integrity-hashed, pinnable modules; truth must be shareable and tamper-evident | [g6-distribution.md](g6-distribution.md) |
 | G7 | A machine-facing access surface | Query, provenance, patch, MCP — agents consume slices, not whole evaluated blobs | [g7-machine-access.md](g7-machine-access.md) |
 | G8 | Generation, on the total side of the fork | N children from data without copies that drift — and without losing the termination guarantee | [g8-generation.md](g8-generation.md) |
+| G9 | Declarative transformation | The model is the source of the CODE — one model, many generated artifacts, each over part of it | [g9-transformation.md](g9-transformation.md) |
 
 ## What Aontu already has right
 

--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -125,7 +125,8 @@ could not see the defect.
 | [G6](g6-distribution.md) | Distribution | B/C | 5 | 0 | 0 |
 | [G7](g7-machine-access.md) | Machine access | B | 7 | 0 | 0 |
 | [G8](g8-generation.md) | Generation | C | 5 | 0 | 0 |
-| | | **total** | **48** | **1** | **0** |
+| [G9](g9-transformation.md) | Declarative transformation | D | 0 | 0 | 9 |
+| | | **total** | **48** | **1** | **9** |
 
 Against the review's own [sequencing](index.md#sequencing):
 
@@ -1443,6 +1444,43 @@ this phase does not carry the fix.
    `pipe.tsv:pipe-into-built-atom`.
 
 
+
+## G9 — declarative transformation
+
+Opened 2026-08-30, after G1–G8 landed. Design is
+[g9-transformation.md](g9-transformation.md); forms (a) and (b) — the
+host program and the Jostraca path — are
+[docs/design/GENERATION-FORMS.0.md](../design/GENERATION-FORMS.0.md).
+**Nothing has landed.** Every row below is NOT STARTED, and the
+document is a design proposal, not a commitment.
+
+Baseline at drafting, for protocol rule 5: `ls test/spec/*.tsv | wc -l`
+= **97**, `awk -F'\t' 'NF>2 && $0 !~ /^#/' test/spec/*.tsv | wc -l` =
+**3755** (both re-derived 2026-08-30).
+
+| Phase | Size | Status | Pin |
+|-------|------|--------|-----|
+| **0** — the gating defects | S | **NOT STARTED** | Six defects found while surveying for this capability and recorded in [use-cases/BUGS.md](../../use-cases/BUGS.md) §57–§62, each with a minimal repro under `use-cases/repros/`. Three are non-termination or crash (§57 recursive spread + map conjunct, both ports; §58 `id()` naming its own descendant, both ports, Go unrecoverable), three are ADR-001 parity breaks (§59 `vet --at` and aliases; §61 Go's `trialUnify` never setting `ctx.trial`, so `match`/`filter` answer differently; §62 `pick` ordering an astral-keyed map by UTF-16 code units in TypeScript), and one is a silent pin failure (§60 the canon-hash blind to an alias used as a spread template). §61 and §62 are in the primitives this design depends on for selection and for line order. |
+| **1** — the vocabulary as a bundled schema | S | **NOT STARTED** | `@"std/code"` served beside `@"std/system"` |
+| **2** — `join` | S | **NOT STARTED** | The string fold; `funcMap` entry, no grammar change |
+| **3** — `form`, the order-preserving map | S/M | **NOT STARTED** | `each` meets and cannot transform; `pack` keys by data and reorders |
+| **4** — the renderer core and the first two profiles | M | **NOT STARTED** | `render` verb; Go and TypeScript profiles |
+| **5** — the reflection sidecar | M | **NOT STARTED** | The view forms (a), (b) and (c) share; an ADR-001 question first (GENERATION-FORMS.0.md §2) |
+| **6** — `walk`, the manifest, and the verb | M | **NOT STARTED** | `aontu gen`, the `std/gen` manifest, one run over N outputs |
+| **7** — the Jostraca bridge | M | **NOT STARTED** | Phases 1–5 carry no Jostraca dependency, so this cannot block the language work |
+| **8** — string interpolation | M/L | **NOT STARTED** | The parser phase; deferred behind evidence that `join` did not suffice |
+
+**Read before starting phase 1.** Every one of the seven parallel
+specifications behind this design was returned SERIOUS or FATAL by an
+adversarial review, and the rule layer — the heart of the XSLT
+analogue — was FATAL for a reason that is a property of the language
+rather than of the design: **Aontu evaluates data where it sits**, so
+a rule set holding a template with a relative reference fails
+`no_path` before any dispatch happens (VERIFIED). The design's answer
+is the `&:` spread and the hidden-capture idiom, both of which work
+today and neither of which needs new grammar. That answer should be
+re-tested against a real transform corpus before phases 6–8 are
+committed to.
 
 ## Corrections outstanding in the gap documents
 

--- a/docs/design/GENERATION-FORMS.0.md
+++ b/docs/design/GENERATION-FORMS.0.md
@@ -1,0 +1,262 @@
+# Generation forms (a) and (b): the host program, and the Jostraca path
+
+*Design note, 2026-08-30. Companion to
+[G9](../capability-review/g9-transformation.md), which is the plan for
+form (c), the declarative transformation layer. This note covers the
+other two forms an Aontu model can become output code — a host program
+reading the model directly, and driving
+[jostraca](https://github.com/jostraca/jostraca) as a library — and
+argues that both are nearer than they look, with one exception that is
+nearer to a defect than to a feature. Every claim marked VERIFIED was
+run against the built CLIs and, for the Go embedding claims, against a
+real external Go module. This note is design; status lives in the
+[progress register](../capability-review/progress.md).*
+
+## Why the two forms share one layer
+
+The three forms are not three products. They differ only in who walks
+the model:
+
+```
+  model.aon
+     │
+     ▼  unify()                        exists, both ports
+  the Val tree                         the only complete view
+     │
+     ├──► generate()  ──► JSON         exists; LOSSY (§1)
+     │
+     └──► a reflection view            MUST BE BUILT
+              │
+    ┌─────────┼──────────────┐
+    ▼         ▼              ▼
+  (a) host  (b) Jostraca   (c) transform
+   program    driver         (G9)
+```
+
+Form (c) is a transform whose source tree is that view. Form (b) is a
+walk over it ending in Jostraca. Form (a) is the author writing that
+walk. **There is one layer, and it is a data record rather than an
+object graph** — which is what makes it portable to Go, testable by a
+shared TSV mode, and re-usable by all three.
+
+## 1. What `generate()` deletes
+
+`generate()` is the JSON projection, and JSON cannot carry a lattice.
+VERIFIED, both ports, on this document:
+
+```aon
+schema: type(close({
+  id: string & re("^c-")
+  port?: *8080 | integer
+  tags: [&: string]
+}))
+```
+
+```
+$ aontu p1.aon
+{}
+
+$ aontu -c p1.aon
+{"schema":{"id":re("^c-"),"port"?:*8080|integer,"tags":[&:string]}}
+```
+
+`generate()` returns **`{}`**. A `type()`-marked subtree — which is
+precisely the schema, the thing a generator generates *from* — is
+skipped by generation. Even unmarked, the projection would have
+dropped closedness, the `?`, the default's *defaultness*, the
+disjunction, the `re` residual, source key order and every site.
+
+None of it is lost from the tree; it is simply not in the JSON. So a
+code generator that consumes `generate()` output is working from the
+one view that deleted everything it needs, and a generator that
+consumes the `Val` tree is working from internals.
+
+## 2. The asymmetry that decides the design
+
+**In TypeScript it works today, as internals.** `walkBagVals` is
+exported from `ts/src/utility.ts` but is *not* in the barrel export
+block of `ts/src/aontu.ts`, so a host deep-imports
+`aontu/dist/utility`. And a value's kind lives in two different fields
+depending on class — a concrete scalar carries `.kind`, a bare kind
+carries `.peg`. Nothing about that is documented and nothing pins it.
+
+**In Go it does not work at all.** VERIFIED with an external module
+(`replace github.com/aontu-lang/aontu/go => …`), compiler output
+quoted verbatim:
+
+```
+./main.go:16:8: m.Keys undefined (type *aontu.MapVal has no field or
+    method Keys, but does have unexported field keys)
+./main.go:17:8: m.Closed undefined (… unexported field closed)
+./main.go:18:8: m.Optional undefined (… unexported field optional)
+```
+
+The type assertion `v.(*aontu.MapVal)` **succeeds** — VERIFIED, prints
+`MapVal assertion ok: true` — and then there is nothing on it. The
+exported `Val` interface carries five exported methods (`Canon`,
+`Gen`, `Unify`, `Dc`, `Nil`, `go/val.go`); `MapVal`'s `keys`, `peg`,
+`closed`, `spread`, `optional` and `aliasKeys` are all lower-case
+(`go/mapval.go`). What a Go host can obtain is a canon *string* it
+would have to re-parse, and a `Gen()` that answers `map[]` for the
+schema above.
+
+> **Form (a) is a TypeScript-only capability in this repository today,
+> and nothing says so.** That is the most important fact in this note.
+> It is not a feature request; it is an ADR-001 question — does the
+> parity obligation cover the *embedding surface*, or only the
+> language? — and it is unanswered in
+> [`ADR.md`](../../ADR.md), [`DIVERGENCE.md`](../../DIVERGENCE.md) and
+> [`docs/reference-api.md`](../reference-api.md) alike.
+
+Three answers are available and only the third is honest for long:
+
+1. **Language only.** Say so in `DIVERGENCE.md`: the Go port evaluates
+   and validates; it does not expose the model. Cheap, and it tells a
+   Go embedder the truth on day one.
+2. **Full parity.** Export ~12 accessors on the Go side. Freezes a
+   large surface forever.
+3. **The split.** Land one reflection view in both ports as an
+   ADR-001 obligation, pinned byte-for-byte by a shared TSV mode, and
+   simultaneously demote the raw TypeScript `Val` fields in the
+   documentation to "internals, may change". Go gets parity where it
+   matters, no accessor set is frozen, and TypeScript hosts stop
+   writing against unpinned internals.
+
+The third is the recommendation, and it is the same artifact G9's
+transform layer needs, which is why it is not a detour.
+
+## 3. What a reflection view must carry
+
+The list is not speculative — it is what the JSON projection drops,
+and each item is already on the tree:
+
+| fact | why a generator needs it |
+|---|---|
+| kind, over the numeric tower | `int64` vs `float64` vs a decimal type |
+| closedness | `additionalProperties`, a sealed struct, a strict decoder |
+| optionality (key presence) | `field?:`, `*T`, `omitempty`, SQL `NULL` |
+| defaults, and their rank | an initialiser, and whether it is one |
+| disjunction arms | a union type, an enum, a `oneOf` |
+| constraint atoms | what the target's type system *cannot* say, and so what the emitted validator must |
+| entity id / relations | foreign keys, references, a graph edge |
+| deprecation | a `@deprecated` tag |
+| marks (`type`, `hide`) | what is schema and what is data |
+| source key order | field order a reader can diff against the model |
+| site | a generated line traced back to the model line |
+
+**Three of these are already extracted, in both ports, by shipped
+code.** VERIFIED over `use-cases/10-data-model/domain.aon`:
+
+```
+$ aontu jsonschema --at schema use-cases/10-data-model/domain.aon
+  "additionalProperties": false                      <- closedness
+  "required": [country,currency,id,ledgerId,name]    <- optionality
+  "ledgerId": { "anyOf": [ … ] }                     <- disjunction arms
+  "pattern" / "minimum" / "maximum" / "minLength" / "not"
+                                                     <- the atoms
+```
+
+`email` and `creditLimitCents` are correctly absent from `required`.
+So a reflection surface is an extension of `jsonschema`'s existing
+projection, not a new subsystem — and `ts/src/jsonschema.ts`'s
+`SchemaLoss` record (`{path, construct, reason}`) is the loss
+discipline to reuse rather than reinvent: what a target cannot express
+is **reported**, never silently dropped.
+
+## 4. Form (a) is often the right answer, and should be said so
+
+A host program is not the poor relation of a declarative transform. It
+is the right choice whenever the target's shape is decided by the host
+language anyway:
+
+- the output is one artifact, and the emitter is fifty lines;
+- the target has a real AST library (`ts-morph`, `go/ast`, JavaPoet)
+  and the honest move is to use it;
+- naming, imports and reserved-word escaping dominate the work — the
+  "symbol provider" layer that Smithy makes explicit and that no
+  template language has ever expressed well;
+- the generation is one step in a pipeline the host already owns.
+
+What makes it *native* rather than internals-poking is small and
+concrete: the view in the barrel export of both ports, documented in
+`docs/reference-api.md`, pinned by shared rows, addressed by the same
+path syntax as `get`/`why`, and carrying sites so a generator can
+attribute its output. None of that is a language change.
+
+## 5. Form (b): the Jostraca path
+
+Jostraca is by the same author, ships TypeScript-canonical with a Go
+port in feature parity, and pins behaviour with a shared cross-stack
+corpus — the same discipline as this repository. It already owns
+everything Aontu should not build: file writing, folder structure,
+three-way merge against the previous generate, `Slot`/`Inject`,
+protected regions, exclusion, and an in-memory mode
+(`{mem: true}` with `result.vol()`) that makes a generation testable
+without touching disk.
+
+**The seam is narrower than it looks.** A Jostraca model is a plain
+untyped object read through its `getx` path mini-language, and Go
+narrows it to `map[string]any` — so what crosses is ordinary JSON.
+`Jostraca({model: aontu.generate(src)})` is close to working today.
+
+Two things are genuinely needed:
+
+1. **Exact numerics.** `generate()` can return `bigint` and `Decimal`
+   for the exact leaves, and Jostraca's substitution `JSON.stringify`s
+   an object-valued match. Either Aontu offers a plain projection that
+   downgrades the exact leaves, or Jostraca learns the two types. The
+   former is cleaner: the lossiness decision belongs where the type
+   information is.
+2. **A schema for the Jostraca model.** This is the strongest argument
+   for the pairing and it should lead the story. Jostraca's model is
+   untyped and its failure mode is *silent* — an unmatched `$$a.b.c$$`
+   is left verbatim in the emitted file. An Aontu document that both
+   computes the model and constrains it turns "a literal `$$app.name$$`
+   shipped to production" into a unification error before any file is
+   written.
+
+Under [G9's D7](../capability-review/g9-transformation.md) the driver
+hands Jostraca **one** `Project` containing all N outputs in a single
+`generate()` call, so its merge and exclusion logic sees the whole
+tree and one consistent snapshot of the model backs every file.
+
+**Where the ownership line falls.** Aontu renders the output
+vocabulary to text and never touches the filesystem — the engine
+returns units and the CLI writes them, which is the rule
+`aontu set` already follows for the same reason (an engine that
+touched the filesystem could not be used by a server). Jostraca owns
+bytes-to-disk and everything about re-running over hand-edited files.
+
+**One caution worth inheriting rather than rediscovering.** Jostraca's
+merge is explicitly not "every generated line survives": a region the
+user deleted and the generator did not touch stays deleted, and a file
+still holding conflict markers is skipped entirely on the next run.
+A driver should surface a conflicted file as a first-class outcome
+rather than swallowing it. Where Aontu only partly owns a file,
+`Inject` — marker-scoped and deterministic — is the right primitive
+and `merge` is not.
+
+## 6. What must be built, and what already exists
+
+| | exists | must be built |
+|---|---|---|
+| (a) | `unify`, `generate`, `get`, `why`, `jsonschema`'s projection and its loss record, sites, `canonHash` | the reflection view, in **both** ports; its barrel export; its documentation; its shared rows |
+| (b) | all of Jostraca; `generate()` as a model source; in-memory generation for tests | the driver; the exact-leaf projection; the Jostraca-model schema; the dependency and release contract |
+
+Neither list contains a language change. That is the point of this
+note: **forms (a) and (b) are tooling, and they are close.** Form (c)
+is where the language questions live, and they are in
+[G9](../capability-review/g9-transformation.md).
+
+## 7. Open, and owner-level
+
+- Does ADR-001 cover the embedding surface, or only the language?
+  (§2. Nothing currently says.)
+- Does the Go root module take the Jostraca dependency, or does the
+  driver live in a separate package inside it? A separate package is
+  enough — Go's linker drops it from binaries that never import it —
+  and it avoids a second module's version matrix.
+- Does ADR-002's 100 % floor extend to the code that overwrites
+  hand-edited files? It should; it is the last place to want a
+  carve-out. That makes an injectable filesystem a design requirement
+  of the driver rather than a testing convenience.

--- a/use-cases/10-data-model/xf.aon
+++ b/use-cases/10-data-model/xf.aon
@@ -1,0 +1,23 @@
+@"./domain.aon"
+
+step: hide(pack($.schema, { d: {
+  k: "record"
+  name: key(2)
+  fields: pick(pack(_, { f: {
+    name: key(2)
+    type: match(_,
+      integer,    { k: "prim", prim: "int" },
+      float,      { k: "prim", prim: "float" },
+      biginteger, { k: "prim", prim: "bigint" },
+      bigdecimal, { k: "prim", prim: "decimal" },
+      string,     { k: "prim", prim: "string" },
+      boolean,    { k: "prim", prim: "bool" },
+      [],         { k: "list", of: { k: "prim", prim: "any" } },
+      {},         { k: "map", key: { k: "prim", prim: "string" },
+                    of: { k: "prim", prim: "any" } },
+      { k: "prim", prim: "any" })
+    default?: _
+  }}), f)
+}}))
+
+units: [ { path: "domain.ts", lang: "typescript", decls: pick($.step, d) } ]

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -2087,6 +2087,61 @@ Repro:
 [`repros/hash/alias-spread-hash-blind.aon`](repros/hash/alias-spread-hash-blind.aon)
 with its `-2` and `-longhand` companions.
 
+## trials — the flag one port sets and the other does not
+
+### 61. Go's `trialUnify` never sets `ctx.trial`, so `match` and `filter` answer differently in the two ports [critical]
+
+Found 2026-08-30 by an adversarial reviewer of the transform-layer
+design, while checking whether unifiability-matching could carry a
+rule layer. It cannot yet: the two ports disagree about what unifies.
+
+| source | TypeScript | Go |
+|---|---|---|
+| `match([1,2], [], "hit", "miss")` | `"miss"` | **`"hit"`** |
+| `match([1], [], "hit", "miss")` | `"miss"` | **`"hit"`** |
+| `filter([[1],[1,2]], [])` | `[]` | **`[[1],[1,2]]`** |
+| `a: *[]` / `a: [1]` | `[aontu/empty]`, exit 1 | **`{"a":*[1]}`, exit 0** |
+| `a: *[1]` / `a: [1,2]` | `[aontu/empty]`, exit 1 | **`{"a":*[1,2]}`, exit 0** |
+
+`match` selects the other arm and `filter` makes the **opposite**
+selection — TypeScript drops every element, Go keeps every element —
+and neither port raises anything. This is the silent-wrong-output
+class, in the two combinators a transform layer would dispatch on.
+
+The agreeing cases draw the boundary and confirm the cause:
+`a: [] a: [1]` merges to `[1]` in both (no trial); `a: *[] a: []`
+gives `*[]` in both (same length); `match([],[],…)` is `"hit"` in both
+(same length); and `match([1,2],[&:integer],…)` is `"hit"` in both (a
+spread makes the pattern variadic).
+
+**Root cause — a one-line omission.** Both ports carry the same gate,
+with the same comment, for the rule §52 regime 4 introduced:
+
+- [`ts/src/val/ListVal.ts`](../ts/src/val/ListVal.ts): `if (true === ctx._trialMode && … this.peg.length !== peer.peg.length) return makeNilErr(ctx, 'list_length', …)`
+- [`go/listval.go`](../go/listval.go): `if pl, ok := peer.(*ListVal); ok && nil != ctx && ctx.trial && … len(l.peg) != len(pl.peg)`
+
+TypeScript's `trialUnify`
+([`ts/src/val/FuncBaseVal.ts`](../ts/src/val/FuncBaseVal.ts)) saves,
+**sets** and restores `ctx._trialMode`. Go's `trialUnify`
+([`go/generate.go`](../go/generate.go)) swaps `ctx.err` and **never
+sets `ctx.trial`**, so the gate it shares with TypeScript can never
+fire from a combinator trial. Go's flag is set on the disjunct-member
+path instead, which is why `[] | [&: T]` behaves and `match`/`filter`
+do not.
+
+**The fix is one line; its blast radius is not.** `go/pref.go` calls
+the same `trialUnify` three times (`:158`, `:200`, `:227`) for the
+`*x & peer` distribution, so setting the flag there changes every
+default meet in Go — ADR-004 and ADR-011 territory, with ~190 lines of
+`test/spec/pref.tsv` behind it. That the suite is green today means it
+does not cover this, not that the change is small: **pref-side rows
+for a trial peer of a different length should land before the fix
+does.**
+
+Repro:
+[`repros/trial/go-trial-flag-unset.aon`](repros/trial/go-trial-flag-unset.aon)
+and its `-pref` companion.
+
 ## Elsewhere in this review
 
 Defects verified earlier in the effort and recorded in

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -2142,6 +2142,60 @@ Repro:
 [`repros/trial/go-trial-flag-unset.aon`](repros/trial/go-trial-flag-unset.aon)
 and its `-pref` companion.
 
+## ordering — the one call site that does not use cmpCodePoint
+
+### 62. `pick` orders an astral-keyed map by UTF-16 code units in TypeScript [critical]
+
+Found 2026-08-30 while checking that a transform's generated line order
+is stable across ports. It is not.
+
+```aon
+m: {"\u{1F600}": {v:"astral"}, "\uFFF0": {v:"bmp"}}
+p: pick($.m, v)
+```
+
+| | result |
+|---|---|
+| canon of `m`, both ports | `{"\uFFF0":…,"\u{1F600}":…}` — U+FFF0 first |
+| `each($.m, integer)`, both ports | `[2,1]` — same order |
+| `pick`, **TypeScript** | `["astral","bmp"]` — **U+1F600 first** |
+| `pick`, **Go** | `["bmp","astral"]` — matches canon |
+
+So the map's own order agrees, `each` agrees, and only `pick` moves —
+which means the two functions the language documents as sharing one
+order do not. `go/agg.go` states the contract: "sorted-key order for a
+map — `each`'s order, and for the same reason (a map has no order of
+its own, so the language picks one and states it)". Go honours it;
+TypeScript does not.
+
+**Cause, one line.** `bagChildren` in
+[`ts/src/val/AggFuncVal.ts`](../ts/src/val/AggFuncVal.ts) does
+
+```js
+return Object.keys(data.peg).sort().map((k) => data.peg[k])
+```
+
+A bare `.sort()` is JavaScript's **UTF-16 code-unit** order. U+1F600
+is the surrogate pair `D83D DE00`, and `D83D` sorts below `FFF0`, so
+TypeScript reverses the pair. Go sorts UTF-8 bytes, which *is*
+code-point order. Every other ordering site in the port imports
+`cmpCodePoint` from [`ts/src/keyorder.ts`](../ts/src/keyorder.ts) —
+`agentsmd.ts`, `diff.ts`, `exactjson.ts` and `graph.ts` all do. This
+one call site does not. The fix is `.sort(cmpCodePoint)`.
+
+`bagChildren` also feeds `sum`, `least` and `greatest`, but those fold
+order-insensitively, so `pick` is the only observable divergence.
+
+**Why it matters beyond Unicode.** `pick` is the order-preserving
+projection — the primitive that turns a bag of records into an ordered
+list of generated lines, and the one a code generator leans on for
+exactly that. Two ports, two orders, means one model producing two
+different generated files: an ADR-001 break in the primitive the
+generation story depends on.
+
+Repro:
+[`repros/order/pick-astral-key-order.aon`](repros/order/pick-astral-key-order.aon).
+
 ## Elsewhere in this review
 
 Defects verified earlier in the effort and recorded in

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -12,8 +12,9 @@ or spec rows.
 
 Minimal reproductions live under [`repros/`](repros/), one directory
 per family; each `.aon` carries an `# expected:` / `# actual:` header.
-The one nontermination repro is marked in-file to be run under
-`timeout`. Severity: **critical** = silent wrong output, unsound vet
+The nontermination repros (§57 and
+`refer-cycles/refer-in-type-hang.aon`) are marked in-file to be run
+under `timeout`. Severity: **critical** = silent wrong output, unsound vet
 verdict, or nontermination; **major** = a documented capability fails;
 **minor** = papercut.
 
@@ -1836,6 +1837,129 @@ template crosses as `additionalProperties`/`items` only when it is a
 bare kind; list `length()` exports `minItems`/`maxItems` yet still
 reports a domain-less loss. The case's `check.sh` pins today's
 behaviour; fixing any of these means re-pinning there and in the guide.
+
+### 57. A recursive spread conjoined with a map does not terminate at depth two, in both ports [critical]
+
+Found 2026-08-30 while surveying what a declarative code-generation
+layer could be built on. Recursion through a **list spread** works,
+and so does conjoining anything at a recursive position -- until the
+two meet at depth two, where both engines run unbounded:
+
+```aon
+%T: {name: string, kids?: [&: %T & {}]}
+d: %T & {name: a, kids: [{name: b, kids: [{name: c}]}]}
+```
+
+| spelling | depth 1 | depth 2 |
+|---|---|---|
+| `[&: %T]` | 0.11 s | **0.15 s** |
+| `[&: %T & top]` | 0.11 s | **0.14 s** |
+| `[&: %T & {}]` | 0.13 s | **no answer** |
+| `[&: %T & {tag: X}]` | 0.14 s | **no answer** |
+| `[&: $.schema.T & {tag: X}]` (path form) | 0.15 s | **no answer** |
+| `{name: string, tag?: X, kids?: [&: %T]}` (conjunct OUTSIDE the spread) | 0.16 s | 0.16 s |
+
+(Wall clock for the whole CLI run, node 24, this tree; the point is
+three orders of magnitude, not the third digit.)
+
+So it is not the recursion, not the spread, and not the conjunct's
+content -- `& {}`, which adds nothing, is enough. `& top` is fine
+because top is absorbed rather than kept as a conjunct. Both ports
+behave identically: TypeScript and the Go CLI each answer depth one in
+a sixth of a second and are still running when killed at 20 s on depth two.
+
+It is an ALLOCATION explosion, not a spin: TypeScript holds 563 MB of
+resident memory 21 s in and 700 MB 41 s in, growing steadily at about
+one core. That is the clone-graph signature -- the recursive residual
+and its conjunct being re-instantiated per pass per destination -- and
+not a loop that fails to advance.
+
+**Why this is critical rather than a performance note.**
+[`docs/trust.md`](../docs/trust.md) clause 2 promises that evaluation
+terminates, and the budget taxonomy in
+[`test/spec/budget.tsv`](../test/spec/budget.tsv) promises that giving
+up is *reported* (`budget_passes`, `recursion_budget`, `unify_cycle`)
+rather than silent. Neither holds here, and the reason is structural:
+the pass budget (`maxcc = 9`, `ts/src/unify.ts:545`) bounds the NUMBER
+of fixpoint passes, not the work inside one. The explosion happens
+within a single pass, so no budget code can fire. A document like this
+one hangs the CLI, the LSP, and any agent harness that evaluates
+untrusted input -- which is the case G5 exists to rule out.
+
+The recursion machinery is a week old (§52, fixed 2026-08-29 by
+[`docs/design/RECURSION.0.md`](../docs/design/RECURSION.0.md) P0+P1),
+and the shape here is regime 4's neighbour: `test/spec/recursion.tsv`
+pins `list-depth-*` for the bare spread, and no row conjoins anything
+with the recursive position inside a spread.
+
+**It also blocks the transform layer.** A recursive reference is the
+natural home for an apply-templates analogue -- descent bounded by the
+data, which is exactly the termination argument G8 asks for -- and
+per-node computation at a recursive position is precisely
+`[&: %T & {...}]`. A second, milder defect sits beside it: computation
+written INSIDE a recursive definition is evaluated at the definition
+rather than per instance, so `up: upper(.name)` in
+`hide({T: {name: string, up: upper(.name), kids?: [&: $.schema.T]}})`
+refuses with `[aontu/invalid-arg]` at `$.schema.T.up`, `.name` having
+resolved to `string`. Per-destination instantiation (ADR-005) reaches
+`pack` templates and `&:` spreads but not recursive expansion.
+
+Repro:
+[`repros/recursion/recursive-spread-conjunct-hangs.aon`](repros/recursion/recursive-spread-conjunct-hangs.aon)
+-- run it under `timeout`, as its header says.
+
+## identity — id() at its own boundary
+
+### 58. An `id()` naming a node and its own descendant crashes both engines on the host stack [critical]
+
+Found 2026-08-30, same survey as §57, while asking whether the
+evaluated value graph is a tree (a transform layer that walks children
+needs to know). It is not, and one construct makes it cyclic:
+
+```aon
+a: id(x) & { b: id(x) }
+```
+
+| port | outcome |
+|---|---|
+| TypeScript | `Aontu: unexpected error: Maximum call stack size exceeded`, exit 1 — **no `[aontu/…]` marker**, so a harness that greps for one sees nothing |
+| Go | `runtime: goroutine stack exceeds 1000000000-byte limit` / `fatal error: stack overflow`, exit 2 — Go stack overflow is **not recoverable**, so an embedding server cannot catch it |
+
+Identity merge means every node carrying a name unifies with every
+other node carrying it ([`docs/reference-language.md`](../docs/reference-language.md#identity-idname)),
+so naming a node and its own descendant the same entity asks for a
+value that contains itself, and `a.peg.b === a`. What is missing is
+the refusal, not the detection: the merge has both sites in hand.
+
+The boundary is exactly ancestor-to-descendant. Everything adjacent
+works, which is why this has not been seen:
+
+| spelling | outcome |
+|---|---|
+| `{p: id(x) & {c:1}, q: id(x) & {d:2}}` (siblings) | merges — the feature working |
+| `a: id(x) & {b: id(y) & {c:1}}` (distinct names) | fine |
+| `a: id(x) & {b: {c: 1}}` (id on the node alone) | fine |
+| `a: id(x) & {b: id(x)}` | **crash, both ports** |
+| `a: id(x) & {b: {c: id(x) & {d: 1}}}` (deeper) | **crash, both ports** |
+
+Three things follow. First, it is a
+[trust-contract](../docs/trust.md) breach of the plainest kind: a
+22-character document takes down the CLI, the LSP and the MCP server,
+and the Go side cannot be defended against by the host. Second, the
+error taxonomy has a hole the registry cannot see —
+[`test/spec/errcodes.tsv`](../test/spec/errcodes.tsv) carries
+`id_name`, `id_conflict` and `id_spread`, and this failure has no code
+at all, so `codeClasses` set-equality stays green while a whole class
+of input is unhandled. An `id_ancestor` conflict (or `id_conflict`
+reused, the two sites being exactly what it reports) closes it. Third,
+it bounds what a transform layer may assume: **the evaluated structure
+is a DAG with sharing, and one construct can make it cyclic**, which
+is why [`ts/src/walk.ts`](../ts/src/walk.ts) calls its `seen` set "a
+termination guard, not an optimisation". Any walk primitive that
+recurses on `peg` inherits this crash until the refusal lands.
+
+Repro:
+[`repros/identity/id-names-own-descendant-crashes.aon`](repros/identity/id-names-own-descendant-crashes.aon).
 
 ## Elsewhere in this review
 

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -2017,6 +2017,76 @@ Repro:
 [`repros/anchor/vet-at-loses-aliases-in-go.aon`](repros/anchor/vet-at-loses-aliases-in-go.aon)
 with its `-data` companion.
 
+## hashing — what `aon1-` can still see
+
+### 60. The canon-hash is blind to an alias used as a spread template [critical]
+
+Found 2026-08-30, by an adversarial reviewer checking a
+code-generation vocabulary\'s anti-drift story and finding that the pin
+proving it did not discriminate. Both ports, identically — a shared
+defect, not a divergence.
+
+```aon
+# A          %A: close({ n: string })          box: [&: %A]
+# B          %A: close({ n: integer, EXTRA: string })   box: [&: %A]
+# A-longhand box: [&: close({ n: string })]
+```
+
+| document | hash |
+|---|---|
+| A | `aon1-ZaobmDyyIw5ibjA8DREEXj0h7I5SpzZdnSDVE5SGQLM` |
+| B — **different meaning** | `aon1-ZaobmDyyIw5ibjA8DREEXj0h7I5SpzZdnSDVE5SGQLM` — **the same** |
+| A-longhand — **same meaning** | `aon1-p1pejKOs3tEJLbpVHlFa2xXy67X-LwvGI3iK8r0tf74` — **different** |
+
+Backwards on both counts. And A and B really do differ: against
+`box: [{n: "x"}]`, A vets `valid` and B vets `invalid`.
+
+**Root cause, and the exact boundary.** `hcanon` erases alias
+declarations on purpose, and says why
+([`ts/src/hcanon.ts`](../ts/src/hcanon.ts), the `aliasKeys` filter):
+"`aon1-` pins MEANING, so a document written with aliases and the same
+document written longhand must hash to one string". That is
+[`docs/design/ALIASES.0.md`](../docs/design/ALIASES.0.md)\'s own
+sharpest requirement. The erasure is correct **wherever unification
+consumes or substitutes the alias**, and that is every case the suite
+covers:
+
+| use site | canon | erasure |
+|---|---|---|
+| scalar, consumed (`listen: %p` / `listen: 8080`) | `{"listen":8080}` | correct — this is `alias.tsv:alias-hash-erases` and its longhand twin |
+| map, substituted (`a: %A`) | `{"a":{"n":string}}` | correct — twin matches, changed meaning moves the hash |
+| **spread template (`box: [&: %A]`)** | `{"box":[&:$.%A]}` | **broken** |
+
+At a spread template the alias stays **symbolic** in canon as
+`$.%A`. The declaration is erased from the hash form while the
+*reference* survives, so the hash form carries a dangling name with no
+content behind it. Erasure and symbolic survival are each right on
+their own; together they lose the meaning. The fix is to expand the
+alias at its use site when building the hash form, rather than
+dropping the declaration and keeping the reference.
+
+The two `hash` rows in [`test/spec/alias.tsv`](../test/spec/alias.tsv)
+cannot see this: both use the scalar-consumed spelling, where the
+alias is gone before canon runs.
+
+**What it costs.** `aontu hash` is the drift check, and
+[`ts/src/agentsmd.ts`](../ts/src/agentsmd.ts) writes the claim into
+every generated AGENTS.md stanza in the user\'s own repository — "the
+canon-hash: it survives reformatting and **moves on any change of
+meaning**". For any document whose schema is spelled with aliases at a
+spread — the idiom the alias feature exists for — that sentence is
+false, and the failure is silent and in the unsafe direction: a real
+change of meaning reports no change. G6 pins modules by the same
+`#aon1-…` fragment.
+
+`subsume` is **not** fooled — `aontu subsume A B` answers
+`does_not_subsume` with `$.%A.n: compat_narrowed` — so the breaking
+check still sees what the pin misses.
+
+Repro:
+[`repros/hash/alias-spread-hash-blind.aon`](repros/hash/alias-spread-hash-blind.aon)
+with its `-2` and `-longhand` companions.
+
 ## Elsewhere in this review
 
 Defects verified earlier in the effort and recorded in

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -1961,6 +1961,62 @@ recurses on `peg` inherits this crash until the refusal lands.
 Repro:
 [`repros/identity/id-names-own-descendant-crashes.aon`](repros/identity/id-names-own-descendant-crashes.aon).
 
+## anchoring — what `--at` can still see
+
+### 59. `vet --at` loses `%alias` references in the Go port [critical]
+
+Found 2026-08-30 while specifying a code-generation vocabulary as an
+Aontu schema — the vocabulary is alias-heavy, and `--at` is how you
+point a validation at one part of a document. The two engines return
+**opposite verdicts and opposite exit codes** for the same inputs:
+
+```aon
+# schema
+%F: close({ n: string })
+%U: close({ p: string, fs: [&: %F] })
+%C: close({ units: [&: %U] })
+code: type(%C)
+
+# data
+units: [ { p: "a", fs: [ {n:"x"} ] } ]
+```
+
+```
+$ aontu      vet --at code schema.aon data.aon    verdict: valid     exit 0
+$ aontu-go   vet --at code schema.aon data.aon    verdict: invalid   exit 1
+                                                  $.code.units.0: no_path [reference]
+                                                  schema: schema.aon:3:24 ($.%U)
+```
+
+Isolated to `--at` alone: removing `type()` still breaks in Go, one
+alias level instead of three still breaks in Go, and dropping `--at`
+(wrapping the data in a `code:` key instead) makes **both** ports say
+valid. The likely cause is that Go's anchor re-roots the schema subtree
+while `%alias` declarations live at the document root (`$.%U`), so
+after anchoring the alias is unreachable; TypeScript's `anchorAt`
+keeps root context.
+
+`--at` is a shared seam, but the break is not, and this was probed
+rather than assumed: `jsonschema --at code` **agrees** between the
+ports over the same document (both render `"items": {}`), and `diff`
+takes no `--at` at all. So it is vet's anchor, not every anchor.
+
+The direction matters. Go REFUSES a document TypeScript ACCEPTS, so a
+pipeline running the Go CLI fails builds the canonical implementation
+passes — and `vet` is the verb whose whole purpose is to be that gate
+(ADR-007, and the `vet ≡ eval` differential in
+[`AGENTS.md`](../AGENTS.md#the-vet--eval-differential)). It is in no
+debt register: not here, not
+[`test/spec/divergent.tsv`](../test/spec/divergent.tsv), not
+[`DIVERGENCE.md`](../DIVERGENCE.md). By the ledger's own rule it does
+not belong in `divergent.tsv` either — that register is for
+divergences that cannot be fixed from this repository right now, and
+this one is Go's `anchorAt`.
+
+Repro:
+[`repros/anchor/vet-at-loses-aliases-in-go.aon`](repros/anchor/vet-at-loses-aliases-in-go.aon)
+with its `-data` companion.
+
 ## Elsewhere in this review
 
 Defects verified earlier in the effort and recorded in

--- a/use-cases/repros/README.md
+++ b/use-cases/repros/README.md
@@ -12,8 +12,11 @@ node ../../ts/bin/aontu.js <file>       # or the command in # run:
 Two cautions:
 
 - `refer-cycles/refer-in-type-hang.aon` (with its `-schema` companion)
-  does not terminate in any practical time — run it under
-  `timeout 10` as its header says. `run-all.sh` never executes
+  and `recursion/recursive-spread-conjunct-hangs.aon` do not terminate
+  in any practical time — run them under `timeout` as their headers
+  say. `identity/id-names-own-descendant-crashes.aon` terminates, but
+  by overflowing the host stack: in Go that is a `fatal error` the
+  embedding program cannot recover from. `run-all.sh` never executes
   anything in this tree.
 - Some entries reproduce **by-design** behaviour whose consequence is
   the finding (marked in their headers and in BUGS.md), and

--- a/use-cases/repros/anchor/vet-at-loses-aliases-in-go-data.aon
+++ b/use-cases/repros/anchor/vet-at-loses-aliases-in-go-data.aon
@@ -1,0 +1,2 @@
+# The data document for 59. See vet-at-loses-aliases-in-go.aon.
+units: [ { p: "a", fs: [ {n:"x"} ] } ]

--- a/use-cases/repros/anchor/vet-at-loses-aliases-in-go.aon
+++ b/use-cases/repros/anchor/vet-at-loses-aliases-in-go.aon
@@ -1,0 +1,39 @@
+# 59: `vet --at <path>` loses %alias references in the GO port. An
+# ADR-001 parity break: the two engines return OPPOSITE VERDICTS and
+# opposite exit codes for the same schema and the same data.
+#
+# This file is the SCHEMA. The data is its `-data` companion.
+#
+# run: node ../../../ts/bin/aontu.js vet --at code vet-at-loses-aliases-in-go.aon vet-at-loses-aliases-in-go-data.aon
+# run: aontu-go vet --at code vet-at-loses-aliases-in-go.aon vet-at-loses-aliases-in-go-data.aon
+#
+# expected: one verdict, whichever is right
+# actual (TypeScript): verdict: valid                        exit 0
+# actual (Go):         verdict: invalid                      exit 1
+#                      $.code.units.0: no_path [reference]
+#                      [aontu/no_path]: Cannot resolve value at
+#                        path $.code.units.0
+#                      schema: ...:3:24 ($.%U)
+#
+# ISOLATED to `--at` alone:
+#   - remove type()                 -> still breaks in Go
+#   - one alias level instead of 3  -> still breaks in Go
+#   - drop --at, wrap the data in a `code:` key -> BOTH say valid
+#
+# The likely cause is that Go's anchor re-roots the schema subtree
+# while %alias declarations live at the document root ($.%U), so after
+# anchoring the alias is unreachable. TypeScript's anchorAt keeps root
+# context.
+#
+# `--at` is a SHARED seam, but the break is not: probed the same way,
+# `jsonschema --at code` AGREES between the ports (both render
+# `"items": {}`), and `diff` takes no --at at all. So this is vet's
+# anchor, not every anchor.
+#
+# Direction matters for a CI gate: Go REFUSES a document TypeScript
+# accepts, so a pipeline that runs the Go CLI fails builds the
+# canonical implementation passes.
+%F: close({ n: string })
+%U: close({ p: string, fs: [&: %F] })
+%C: close({ units: [&: %U] })
+code: type(%C)

--- a/use-cases/repros/hash/alias-spread-hash-blind-2.aon
+++ b/use-cases/repros/hash/alias-spread-hash-blind-2.aon
@@ -1,0 +1,4 @@
+# 60, second document: a DIFFERENT meaning that hashes the same as
+# alias-spread-hash-blind.aon. See that file's header.
+%A: close({ n: integer, EXTRA: string })
+box: [&: %A]

--- a/use-cases/repros/hash/alias-spread-hash-blind-longhand.aon
+++ b/use-cases/repros/hash/alias-spread-hash-blind-longhand.aon
@@ -1,0 +1,4 @@
+# 60, third document: the expanded twin of alias-spread-hash-blind.aon.
+# ALIASES.0.md requires it to hash IDENTICALLY to that file. It does
+# not. See that file's header.
+box: [&: close({ n: string })]

--- a/use-cases/repros/hash/alias-spread-hash-blind.aon
+++ b/use-cases/repros/hash/alias-spread-hash-blind.aon
@@ -1,0 +1,27 @@
+# 60: the `aon1-` canon-hash is BLIND to an alias used as a SPREAD
+# TEMPLATE. Two documents with different meanings hash the same, in
+# both ports, and neither matches its own longhand twin -- which is
+# the one property docs/design/ALIASES.0.md calls "the sharpest single
+# row in this list".
+#
+# This file is the FIRST of four; run all four and compare.
+#   alias-spread-hash-blind.aon          this file      %A: n is a string
+#   alias-spread-hash-blind-2.aon        different meaning: n is an integer, plus EXTRA
+#   alias-spread-hash-blind-longhand.aon the expanded twin of THIS file
+#
+# run: node ../../../ts/bin/aontu.js hash alias-spread-hash-blind.aon
+# run: node ../../../ts/bin/aontu.js hash alias-spread-hash-blind-2.aon
+# run: node ../../../ts/bin/aontu.js hash alias-spread-hash-blind-longhand.aon
+#
+# expected: this file and -longhand share a hash (the ALIASES.0.md
+#           rule); -2 has a different one (different meaning)
+# actual (both ports, identically):
+#   this file  aon1-ZaobmDyyIw5ibjA8DREEXj0h7I5SpzZdnSDVE5SGQLM
+#   -2         aon1-ZaobmDyyIw5ibjA8DREEXj0h7I5SpzZdnSDVE5SGQLM   <- SAME, different meaning
+#   -longhand  aon1-p1pejKOs3tEJLbpVHlFa2xXy67X-LwvGI3iK8r0tf74   <- DIFFERENT, same meaning
+#
+# Exactly backwards on both counts. And the two documents really do
+# differ: against `box: [{n: "x"}]`, this file vets `valid` and -2
+# vets `invalid`.
+%A: close({ n: string })
+box: [&: %A]

--- a/use-cases/repros/identity/id-names-own-descendant-crashes.aon
+++ b/use-cases/repros/identity/id-names-own-descendant-crashes.aon
@@ -1,0 +1,25 @@
+# 58: an id() naming a node AND one of its own descendants makes the
+# evaluated value graph cyclic, and both engines die on the host stack
+# rather than reporting anything.
+#
+# Identity merge means every node carrying a name unifies with every
+# other node carrying it. Naming a node and its own descendant the
+# same entity therefore asks for a value that CONTAINS ITSELF. The
+# honest answer is a located refusal (an `id_ancestor` conflict, or
+# `id_conflict` reused); what happens instead is a stack overflow.
+#
+# run: node ../../../ts/bin/aontu.js id-names-own-descendant-crashes.aon
+# run: aontu-go id-names-own-descendant-crashes.aon
+#
+# expected: a located [aontu/...] refusal naming the two id() sites
+# actual (TypeScript): "Aontu: unexpected error: Maximum call stack
+#          size exceeded", exit 1 -- and note there is NO [aontu/...]
+#          marker, so a harness grepping for one sees nothing at all
+# actual (Go):         "fatal error: stack overflow", exit 2 --
+#          unrecoverable, so an embedding server cannot catch it
+#
+# Sibling-to-sibling identity merge (`{p: id(x) & {c:1}, q: id(x) &
+# {d:2}}`) is fine, which is the feature working; distinct names are
+# fine; id() on the node alone is fine. Only ancestor-and-descendant
+# crashes, at any nesting distance.
+a: id(x) & { b: id(x) }

--- a/use-cases/repros/order/pick-astral-key-order.aon
+++ b/use-cases/repros/order/pick-astral-key-order.aon
@@ -1,0 +1,34 @@
+# 62: `pick` over a map with an ASTRAL key orders differently in the
+# two ports. The map's own canon agrees and `each` agrees; only `pick`
+# diverges, so the two functions the language documents as sharing one
+# order do not.
+#
+# run: node ../../../ts/bin/aontu.js -c pick-astral-key-order.aon
+# run: aontu-go -c pick-astral-key-order.aon
+#
+# expected: one order, the map's own -- U+FFF0 before U+1F600
+# actual TS: "p":["astral","bmp"]     <- U+1F600 first
+# actual GO: "p":["bmp","astral"]     <- U+FFF0 first, matching canon
+#
+# The canon of `m` is identical in both ports and puts U+FFF0 first,
+# and `each` over the same map answers [2,1] in both. Only pick moves.
+#
+# CAUSE, one line: ts/src/val/AggFuncVal.ts's bagChildren does
+#   Object.keys(data.peg).sort()
+# -- a bare .sort(), which is JavaScript's UTF-16 CODE UNIT order. A
+# high surrogate (U+1F600 -> D83D) sorts BELOW U+FFF0, so TypeScript
+# reverses the pair. Go sorts UTF-8 bytes, which IS code-point order.
+# Everywhere else in the port uses cmpCodePoint from ts/src/keyorder.ts
+# (agentsmd.ts, diff.ts, exactjson.ts and graph.ts all import it); this
+# one call site does not. The fix is `.sort(cmpCodePoint)`.
+#
+# bagChildren also feeds sum/least/greatest, but those are
+# order-insensitive, so `pick` is the only observable divergence.
+#
+# WHY IT MATTERS BEYOND UNICODE: pick is the order-preserving
+# projection -- the primitive that turns a bag of records into an
+# ordered list of generated lines. Two ports, two orders, means two
+# different generated files from one model, which is an ADR-001 break
+# in exactly the primitive a code generator depends on.
+m: {"😀": {v:"astral"}, "￰": {v:"bmp"}}
+p: pick($.m, v)

--- a/use-cases/repros/recursion/recursive-spread-conjunct-hangs.aon
+++ b/use-cases/repros/recursion/recursive-spread-conjunct-hangs.aon
@@ -1,0 +1,33 @@
+# 57: a recursive list spread CONJOINED WITH A MAP does not terminate
+# at depth two, in BOTH ports. Depth one answers in ~0.12 s; depth two
+# runs unbounded, allocating (563 MB at 21 s, 700 MB at 41 s in
+# TypeScript) rather than spinning, so it is a clone-graph explosion
+# and not a tight loop.
+#
+# The conjunct's CONTENT is irrelevant -- `& {}` is enough. `& top` is
+# fine (absorbed), a bare `[&: %T]` is fine, and the same conjunct
+# written OUTSIDE the spread (`tag?: X` as a sibling key) is fine. The
+# path spelling (`$.schema.T`) hangs identically to the alias.
+#
+# RUN UNDER timeout -- like refer-cycles/refer-in-type-hang.aon, this
+# file does not terminate in any practical time. run-all.sh never
+# executes this tree.
+#
+# run: timeout 20 node ../../../ts/bin/aontu.js recursive-spread-conjunct-hangs.aon
+# run: timeout 20 aontu-go recursive-spread-conjunct-hangs.aon
+#
+# expected: {"d":{"kids":[{"kids":[{"name":"c"}],"name":"b"}],"name":"a"}}
+#           -- or, if the evaluator gives up, the budget_passes /
+#           recursion_budget refusal the trust contract promises
+# actual (both ports): no output, no error, no budget refusal;
+#           killed by timeout
+#
+# Why it matters beyond the spelling: docs/trust.md clause 2 says
+# evaluation terminates, and the pass budget (maxcc = 9, ts/src/unify.ts)
+# bounds the NUMBER of fixpoint passes, not the work inside one. The
+# explosion happens within a pass, so no budget code can fire and the
+# guarantee is not enforced here.
+#
+# Removing the `& {}` makes this file answer in 0.12 s.
+%T: {name: string, kids?: [&: %T & {}]}
+d: %T & {name: a, kids: [{name: b, kids: [{name: c}]}]}

--- a/use-cases/repros/trial/go-trial-flag-unset-pref.aon
+++ b/use-cases/repros/trial/go-trial-flag-unset-pref.aon
@@ -1,0 +1,15 @@
+# 61, the preference half. See go-trial-flag-unset.aon.
+#
+# run: node ../../../ts/bin/aontu.js -c go-trial-flag-unset-pref.aon
+# run: aontu-go -c go-trial-flag-unset-pref.aon
+#
+# expected: one answer
+# actual TS: [aontu/empty]: Cannot unify values at path $.a   (exit 1)
+# actual GO: {"a":*[1],"b":*[1,2]}                            (exit 0)
+#
+# `x: *[]` -- a default empty list later given data -- is an ordinary
+# idiom, and the two ports disagree about whether it holds at all.
+a: *[]
+a: [1]
+b: *[1]
+b: [1,2]

--- a/use-cases/repros/trial/go-trial-flag-unset.aon
+++ b/use-cases/repros/trial/go-trial-flag-unset.aon
@@ -1,0 +1,20 @@
+# 61: Go's trialUnify never sets ctx.trial, so the "a literal list
+# admits only a peer of its own length" rule (list_length) fires in
+# TypeScript and never in Go from a combinator or preference trial.
+# The two ports return DIFFERENT VALUES with no error.
+#
+# run: node ../../../ts/bin/aontu.js -c go-trial-flag-unset.aon
+# run: aontu-go -c go-trial-flag-unset.aon
+#
+# expected: one answer
+# actual TS: {"filtered":[],"matched":"miss"}
+# actual GO: {"filtered":[[1],[1,2]],"matched":"hit"}
+#
+# `match` picks the OTHER arm and `filter` makes the OPPOSITE
+# selection -- TypeScript drops every element, Go keeps every element.
+# Neither port raises anything.
+#
+# The preference half is in the -pref companion, where TypeScript
+# ERRORS and Go produces a value.
+matched:  match([1,2], [], "hit", "miss")
+filtered: filter([[1],[1,2]], [])


### PR DESCRIPTION
Opens a ninth capability-review gap for a question the original survey did not ask: once the model is trustworthy, **how does the code come from it?** Three forms — a host program reading the model, driving [jostraca](https://github.com/jostraca/jostraca) as a library, and declarative transformation with XSLT as the inspiration.

Documents only. No engine change; both suites green (4428 TypeScript tests, all Go packages).

## What is here

- **`docs/capability-review/g9-transformation.md`** — the plan for the declarative form, in the g7/g8 shape, with a nine-phase implementation plan.
- **`docs/design/GENERATION-FORMS.0.md`** — forms (a) and (b), which turn out to be tooling rather than language work.
- **`use-cases/BUGS.md` §57–§62** — six verified defects, each with a minimal repro under `use-cases/repros/`.
- Register, index, `AGENTS.md` and `CLAUDE.md` carry G9 with all nine phases NOT STARTED. Suite baseline re-derived for protocol rule 5: 97 files, 3755 rows.

## The owner decisions the design specifies

D1 the transform is Aontu and its **result** is an instance of a target-shaped output vocabulary — so the vocabulary is itself an Aontu schema and a transform result is checked by unification, which is XSLT's literal-result-element trick with a check XSLT never had. D2 text lives in the tooling, not the engine (`jsonschema` and `agentsmd` are the precedent). D3 jostraca is a library dependency. D4 four G8 boundary clauses are opened. D5–D7 one model feeds N outputs in one run, each over a slice that is documentation rather than a capability boundary.

## The finding that matters most

Every one of the seven parallel specifications behind this design came back **serious or fatal** under adversarial review, and the rule layer — the heart of the XSLT analogue — was fatal for a reason that belongs to the language rather than to the design:

**Aontu evaluates data where it sits.** A rule set holding a template with a relative reference fails before any dispatch happens:

```
rules: [{when:{kind:"record"}, emit:{head: "type " + .name + " struct {"}}]
→ [aontu/no_path] at $.rules.0.emit.head
```

XSLT depends on a template being inert until applied. There is no inertness here. The design's answer is the `&:` spread and a hidden-capture idiom, both of which work today in both ports and neither of which needs new grammar:

```
m: {a: {n: "one", t: "T"}}
v: pack($.m, {src: hide(_), d: `x` + .src.n + .src.t})
→ {"a":{"d":"xoneT"}}
```

The register says to re-test that against a real transform corpus before the later phases are committed to.

## Six defects, all reproduced in both ports

| | |
|---|---|
| **57** | A recursive list spread conjoined with a map does not terminate at depth two, both ports. `& {}` — a conjunct that adds nothing — is enough; `& top` is fine. No budget fires and none can: `maxcc` bounds the *number* of passes, not the work inside one. |
| **58** | `a: id(x) & {b: id(x)}` — 22 characters — crashes both engines. TypeScript gives "Maximum call stack size exceeded" with **no `[aontu/…]` marker**; Go gives an unrecoverable `fatal error: stack overflow`. |
| **59** | `vet --at` loses `%alias` references in Go: opposite verdicts *and* exit codes. Probed on the shared seam — `jsonschema --at` agrees, so it is vet's anchor, not every anchor. |
| **60** | The canon-hash is blind to an alias used as a spread template. Two documents with different meanings hash alike; neither matches its own longhand twin. `agentsmd` writes "moves on any change of meaning" into every generated AGENTS.md. |
| **61** | Go's `trialUnify` never sets `ctx.trial`, so `match`/`filter` **answer differently**: `filter([[1],[1,2]], [])` drops every element in TypeScript and keeps every element in Go. One-line cause, non-trivial blast radius through `go/pref.go`. |
| **62** | `pick` orders an astral-keyed map by UTF-16 code units in TypeScript — a bare `.sort()` where every other site uses `cmpCodePoint`. `pick` is the primitive that gives generated lines their order. |

§61 and §62 are in the two primitives this design depends on, for selection and for line order.

## Verified with a compiler, not asserted

An external Go module can assert `*aontu.MapVal` successfully and then reach nothing on it:

```
./main.go:16:8: m.Keys undefined (type *aontu.MapVal has no field or
    method Keys, but does have unexported field keys)
```

`keys`, `peg`, `closed`, `spread`, `optional` are all unexported and `Val` carries five methods. **Form (a) is a TypeScript-only capability today and nothing says so** — an ADR-001 question about whether parity covers the embedding surface.

## Open for the owner

Ten questions are in the design; the two that gate the rest are whether ADR-001 covers the embedding surface, and whether the descent for form (c) lives in the unifier or the tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJtvxtNJbL6M6h9GdoGRfs)_