### PR TITLE
Record the reverted §57 fix, and correct the G9 phase-0 register row

### DIFF
--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -1452,8 +1452,10 @@ Opened 2026-08-30, after G1–G8 landed. Design is
 [g9-transformation.md](g9-transformation.md); forms (a) and (b) — the
 host program and the Jostraca path — are
 [docs/design/GENERATION-FORMS.0.md](../design/GENERATION-FORMS.0.md).
-**Nothing has landed.** Every row below is NOT STARTED, and the
-document is a design proposal, not a commitment.
+**No transformation capability has landed**, and the document is a
+design proposal, not a commitment. Every row below is NOT STARTED
+except phase 0, the gating defects, which the engine work of #99
+moved to PARTIAL.
 
 Baseline at drafting, for protocol rule 5: `ls test/spec/*.tsv | wc -l`
 = **97**, `awk -F'\t' 'NF>2 && $0 !~ /^#/' test/spec/*.tsv | wc -l` =
@@ -1461,7 +1463,7 @@ Baseline at drafting, for protocol rule 5: `ls test/spec/*.tsv | wc -l`
 
 | Phase | Size | Status | Pin |
 |-------|------|--------|-----|
-| **0** — the gating defects | S | **NOT STARTED** | Six defects found while surveying for this capability and recorded in [use-cases/BUGS.md](../../use-cases/BUGS.md) §57–§62, each with a minimal repro under `use-cases/repros/`. Three are non-termination or crash (§57 recursive spread + map conjunct, both ports; §58 `id()` naming its own descendant, both ports, Go unrecoverable), three are ADR-001 parity breaks (§59 `vet --at` and aliases; §61 Go's `trialUnify` never setting `ctx.trial`, so `match`/`filter` answer differently; §62 `pick` ordering an astral-keyed map by UTF-16 code units in TypeScript), and one is a silent pin failure (§60 the canon-hash blind to an alias used as a spread template). §61 and §62 are in the primitives this design depends on for selection and for line order. |
+| **0** — the gating defects | S | **PARTIAL** | Six defects found while surveying for this capability and recorded in [use-cases/BUGS.md](../../use-cases/BUGS.md) §57–§62, each with a minimal repro under `use-cases/repros/`. **Four are fixed**, in both ports and pinned by shared rows: §58 `id()` naming its own descendant, which crashed both engines on the host stack; and the three ADR-001 parity breaks — §59 `vet --at` losing `%alias` references in Go, §61 Go's `trialUnify` never setting `ctx.trial` so `match`/`filter` answered differently, §62 `pick` ordering an astral-keyed map by UTF-16 code units in TypeScript. The last two are in the primitives this design depends on for selection and for line order. **Two remain**: §57, a recursive spread conjoined with a map, non-terminating in both ports — diagnosed to the mechanism, with one fix attempt reverted for holding in TypeScript only; and §60, the canon-hash blind to an alias used as a spread template, a silent pin failure. |
 | **1** — the vocabulary as a bundled schema | S | **NOT STARTED** | `@"std/code"` served beside `@"std/system"` |
 | **2** — `join` | S | **NOT STARTED** | The string fold; `funcMap` entry, no grammar change |
 | **3** — `form`, the order-preserving map | S/M | **NOT STARTED** | `each` meets and cannot transform; `pack` keys by data and reorders |

--- a/use-cases/BUGS.md
+++ b/use-cases/BUGS.md
@@ -2114,6 +2114,53 @@ and NOT `& {tag:1}` -- which is the spelling a transform layer
 actually needs, per this entry's own closing paragraph. It is a
 papering-over, not the fix.
 
+**A FIX THAT PASSED AND WAS WRONG.** The rule above suggests an
+obvious guard: expand at most once per destination, keyed by the
+residual's target and the path it lands on. In
+`ts/src/val/RecurseVal.ts` that is a set of `target + '\0' + path`
+seats carried on the context, checked before an expansion and holding
+the residual beside its peer when the seat is already taken. It works
+-- in TypeScript. All four hanging spellings terminate, `& {tag: 1}`
+stamps the tag on every recursive node, and the suite passes 4500
+tests with the healthy forms unchanged.
+
+The Go port refutes it. Mirrored into `go/recurse.go` and instrumented
+on the same document, the seats are:
+
+    #1  "%T\x00d"
+    #2  "%T\x00d.kids.0"
+    #3  "%T\x00d.kids.0.kids.0"
+    #4  "%T\x00d.kids.0.kids.0.kids"
+    #5  "%T\x00d.kids.0.kids.0.kids.kids"
+    ...
+    #10 "%T\x00d.kids.0.kids.0.kids.kids.kids.kids.kids.kids"
+
+Every seat is distinct, the guard never fires, and Go runs away
+exactly as before. Go does not re-meet at a position the way the
+TypeScript trace above does at `d.kids.0.kids.0` (#3, #4, #5); it
+descends straight into the synthetic `kids` chain, a new position each
+time. The change was reverted rather than landed: a guard that fixes
+one port and no-ops in the other is the divergence ADR-001 exists to
+prevent.
+
+What the failure buys is a sharper reading of the same diagnosis. The
+repeated position is TypeScript's own symptom: its #4 and #5 re-meet
+at `d.kids.0.kids.0`, a path the data does have, and it only reaches
+a synthetic `kids` at #7. Go skips that stall and is past the data by
+#4. What both ports do is the second numbered point above, on its own
+-- **an expansion at a path no data reaches**. A guard keyed on
+position catches the stall, which only one port has, and not the
+expansion, which both have. So the rule stands as written: the fix has
+to recognise template-contributed structure directly.
+
+The marker for that already exists in both ports, and is not usable as
+a gate as it stands. `markSpread` stamps a template's contribution
+`FROM_SPREAD` in TypeScript (`ts/src/provenance.ts`) and `fspr` in Go
+(`go/mapval.go`), which is exactly the origin the rule names -- but
+both are no-ops unless `ctx.prov` holds a recorder, and only `why`
+sets one (`ts/src/query.ts`). Gating expansion on it as written would
+make evaluation depend on whether provenance is being recorded.
+
 Repro:
 [`repros/recursion/recursive-spread-conjunct-hangs.aon`](repros/recursion/recursive-spread-conjunct-hangs.aon)
 -- run it under `timeout`, as its header says.


### PR DESCRIPTION
Documentation only. No engine change, no spec rows, no rebuild.

## §57 — a fix that passed and was wrong

The diagnosis merged in #103 ends with the rule a fix needs:

> Structure contributed by the residual's own template is not a data
> level, and must not license an expansion.

The obvious guard from that rule is positional: expand at most once per
destination, keyed by the residual's target and the path it lands on, held
as a set of seats on the context. In TypeScript it works. All four hanging
spellings terminate, `& {tag: 1}` stamps the tag on every recursive node,
and the suite passes 4500 tests with the healthy forms unchanged.

Mirrored into `go/recurse.go` and instrumented on the same document, every
seat is distinct:

```
#1  "%T\x00d"
#2  "%T\x00d.kids.0"
#3  "%T\x00d.kids.0.kids.0"
#4  "%T\x00d.kids.0.kids.0.kids"
#5  "%T\x00d.kids.0.kids.0.kids.kids"
```

The guard never fires and Go runs away as before. Go does not re-meet at a
position the way the TypeScript trace does at `d.kids.0.kids.0` (#3, #4,
#5); it descends straight into the synthetic `kids` chain, a new position
each time. The change was reverted rather than landed — a guard that fixes
one port and no-ops in the other is the divergence ADR-001 exists to
prevent — and this PR records it so the next attempt does not re-derive it.

What the failure buys is a sharper reading of the same diagnosis. The
repeated position is TypeScript's own symptom; what both ports do is expand
at a path no data reaches. So the rule stands as written: the fix has to
recognise template-contributed structure directly.

The entry also now records why the obvious marker for that is not usable as
a gate as it stands. `markSpread` stamps a template's contribution
`FROM_SPREAD` in TypeScript (`ts/src/provenance.ts`) and `fspr` in Go
(`go/mapval.go`) — exactly the origin the rule names — but both are no-ops
unless `ctx.prov` holds a recorder, and only `why` sets one
(`ts/src/query.ts`). Gating expansion on it would make evaluation depend on
whether provenance is being recorded.

§57 stays open, and its status is unchanged.

## The G9 phase-0 register row

Per CLAUDE.md, a phase's row changes in the same commit that changes its
status; #99 fixed four of the six gating defects without touching the row,
so it is corrected here.

- Status `NOT STARTED` → **`PARTIAL`**. Four named deliverables exist and
  two demonstrably do not, which is the register's own definition.
- The pin now names which four landed in #99, in both ports and pinned by
  shared rows (§58, §59, §61, §62), and which two remain (§57, §60).
- The `Nothing has landed` preamble is narrowed to the transformation
  capability, which is still true, so it no longer contradicts the row.
- A pre-existing miscount is fixed: the row called two
  non-termination-or-crash defects three, so its 3+3+1 breakdown did not
  add to the six it claimed.

## Verification

`make test` — 4500 TypeScript tests, 0 failures; Go suite PASS; exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6JJFKLqr2Ci1HwWTSK7iZ)_