### PR TITLE
Repair the diagram tool for path addressing (ADR-014)

### DIFF
--- a/use-cases/01-service-catalog/README.md
+++ b/use-cases/01-service-catalog/README.md
@@ -7,23 +7,23 @@ and pinned as goldens by `check.sh`.
 
 ```mermaid
 graph LR
-  n_svc_auth["svc_auth"]
-  n_svc_directory["svc_directory"]
-  n_svc_email["svc_email"]
-  n_svc_gateway["svc_gateway"]
-  n_svc_ledger["svc_ledger"]
-  n_svc_notify["svc_notify"]
-  n_svc_payments["svc_payments"]
-  n_svc_risk["svc_risk"]
-  n_svc_auth -->|"dependsOn"| n_svc_directory
-  n_svc_gateway -->|"dependsOn"| n_svc_auth
-  n_svc_gateway -->|"dependsOn"| n_svc_payments
-  n_svc_notify -->|"dependsOn"| n_svc_email
-  n_svc_payments -->|"dependsOn"| n_svc_auth
-  n_svc_payments -->|"dependsOn"| n_svc_ledger
-  n_svc_payments -->|"dependsOn"| n_svc_notify
-  n_svc_payments -->|"dependsOn"| n_svc_risk
-  n_svc_risk -->|"dependsOn"| n_svc_directory
+  n___catalog_domains_identity_services_auth["auth"]
+  n___catalog_domains_identity_services_directory["directory"]
+  n___catalog_domains_payments_services_ledger["ledger"]
+  n___catalog_domains_payments_services_payments["payments"]
+  n___catalog_domains_payments_services_risk["risk"]
+  n___catalog_domains_platform_services_email["email"]
+  n___catalog_domains_platform_services_gateway["gateway"]
+  n___catalog_domains_platform_services_notify["notify"]
+  n___catalog_domains_identity_services_auth -->|"dependsOn"| n___catalog_domains_identity_services_directory
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_identity_services_auth
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_payments_services_ledger
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_payments_services_risk
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_platform_services_notify
+  n___catalog_domains_payments_services_risk -->|"dependsOn"| n___catalog_domains_identity_services_directory
+  n___catalog_domains_platform_services_gateway -->|"dependsOn"| n___catalog_domains_identity_services_auth
+  n___catalog_domains_platform_services_gateway -->|"dependsOn"| n___catalog_domains_payments_services_payments
+  n___catalog_domains_platform_services_notify -->|"dependsOn"| n___catalog_domains_platform_services_email
 ```
 
 The same graph as a **dependency-structure matrix**, where a mark at

--- a/use-cases/01-service-catalog/expected/diagram-graph.mmd
+++ b/use-cases/01-service-catalog/expected/diagram-graph.mmd
@@ -1,18 +1,18 @@
 graph LR
-  n_svc_auth["svc_auth"]
-  n_svc_directory["svc_directory"]
-  n_svc_email["svc_email"]
-  n_svc_gateway["svc_gateway"]
-  n_svc_ledger["svc_ledger"]
-  n_svc_notify["svc_notify"]
-  n_svc_payments["svc_payments"]
-  n_svc_risk["svc_risk"]
-  n_svc_auth -->|"dependsOn"| n_svc_directory
-  n_svc_gateway -->|"dependsOn"| n_svc_auth
-  n_svc_gateway -->|"dependsOn"| n_svc_payments
-  n_svc_notify -->|"dependsOn"| n_svc_email
-  n_svc_payments -->|"dependsOn"| n_svc_auth
-  n_svc_payments -->|"dependsOn"| n_svc_ledger
-  n_svc_payments -->|"dependsOn"| n_svc_notify
-  n_svc_payments -->|"dependsOn"| n_svc_risk
-  n_svc_risk -->|"dependsOn"| n_svc_directory
+  n___catalog_domains_identity_services_auth["auth"]
+  n___catalog_domains_identity_services_directory["directory"]
+  n___catalog_domains_payments_services_ledger["ledger"]
+  n___catalog_domains_payments_services_payments["payments"]
+  n___catalog_domains_payments_services_risk["risk"]
+  n___catalog_domains_platform_services_email["email"]
+  n___catalog_domains_platform_services_gateway["gateway"]
+  n___catalog_domains_platform_services_notify["notify"]
+  n___catalog_domains_identity_services_auth -->|"dependsOn"| n___catalog_domains_identity_services_directory
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_identity_services_auth
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_payments_services_ledger
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_payments_services_risk
+  n___catalog_domains_payments_services_payments -->|"dependsOn"| n___catalog_domains_platform_services_notify
+  n___catalog_domains_payments_services_risk -->|"dependsOn"| n___catalog_domains_identity_services_directory
+  n___catalog_domains_platform_services_gateway -->|"dependsOn"| n___catalog_domains_identity_services_auth
+  n___catalog_domains_platform_services_gateway -->|"dependsOn"| n___catalog_domains_payments_services_payments
+  n___catalog_domains_platform_services_notify -->|"dependsOn"| n___catalog_domains_platform_services_email

--- a/use-cases/01-service-catalog/expected/diagram-matrix.txt
+++ b/use-cases/01-service-catalog/expected/diagram-matrix.txt
@@ -1,9 +1,9 @@
-                 1 2 3 4 5 6 7 8
-svc_auth       1 \ X . . . . . .
-svc_directory  2 . \ . . . . . .
-svc_email      3 . . \ . . . . .
-svc_gateway    4 X . . \ . . X .
-svc_ledger     5 . . . . \ . . .
-svc_notify     6 . . X . . \ . .
-svc_payments   7 X . . . X X \ X
-svc_risk       8 . X . . . . . \
+             1 2 3 4 5 6 7 8
+auth       1 \ X . . . . . .
+directory  2 . \ . . . . . .
+ledger     3 . . \ . . . . .
+payments   4 X . X \ X . . X
+risk       5 . X . . \ . . .
+email      6 . . . . . \ . .
+gateway    7 X . . X . . \ .
+notify     8 . . . . . X . \

--- a/use-cases/12-relations/README.md
+++ b/use-cases/12-relations/README.md
@@ -10,13 +10,13 @@ nothing else, and both are pinned as goldens by `check.sh`. There is no
 
 ```mermaid
 graph LR
-  n_job_audit["job_audit"]
-  n_job_extract["job_extract"]
-  n_job_load["job_load"]
-  n_job_transform["job_transform"]
-  n_job_extract -->|"feeds"| n_job_transform
-  n_job_transform -->|"feeds"| n_job_audit
-  n_job_transform -->|"feeds"| n_job_load
+  n___pipeline_jobs_audit["audit"]
+  n___pipeline_jobs_extract["extract"]
+  n___pipeline_jobs_load["load"]
+  n___pipeline_jobs_transform["transform"]
+  n___pipeline_jobs_extract -->|"feeds"| n___pipeline_jobs_transform
+  n___pipeline_jobs_transform -->|"feeds"| n___pipeline_jobs_audit
+  n___pipeline_jobs_transform -->|"feeds"| n___pipeline_jobs_load
 ```
 
 **Six written edges, three logical ones.** `graphOf` reports every
@@ -33,9 +33,9 @@ The same edges as an entity-relationship diagram:
 
 ```mermaid
 erDiagram
-  n_job_extract }o--o{ n_job_transform : "feeds"
-  n_job_transform }o--o{ n_job_audit : "feeds"
-  n_job_transform }o--o{ n_job_load : "feeds"
+  n_extract }o--o{ n_transform : "feeds"
+  n_transform }o--o{ n_audit : "feeds"
+  n_transform }o--o{ n_load : "feeds"
 ```
 
 Cardinality is drawn many-to-many throughout because the model does not

--- a/use-cases/12-relations/expected/diagram-er.mmd
+++ b/use-cases/12-relations/expected/diagram-er.mmd
@@ -1,4 +1,4 @@
 erDiagram
-  n_job_extract }o--o{ n_job_transform : "feeds"
-  n_job_transform }o--o{ n_job_audit : "feeds"
-  n_job_transform }o--o{ n_job_load : "feeds"
+  n_extract }o--o{ n_transform : "feeds"
+  n_transform }o--o{ n_audit : "feeds"
+  n_transform }o--o{ n_load : "feeds"

--- a/use-cases/12-relations/expected/diagram-graph.mmd
+++ b/use-cases/12-relations/expected/diagram-graph.mmd
@@ -1,8 +1,8 @@
 graph LR
-  n_job_audit["job_audit"]
-  n_job_extract["job_extract"]
-  n_job_load["job_load"]
-  n_job_transform["job_transform"]
-  n_job_extract -->|"feeds"| n_job_transform
-  n_job_transform -->|"feeds"| n_job_audit
-  n_job_transform -->|"feeds"| n_job_load
+  n___pipeline_jobs_audit["audit"]
+  n___pipeline_jobs_extract["extract"]
+  n___pipeline_jobs_load["load"]
+  n___pipeline_jobs_transform["transform"]
+  n___pipeline_jobs_extract -->|"feeds"| n___pipeline_jobs_transform
+  n___pipeline_jobs_transform -->|"feeds"| n___pipeline_jobs_audit
+  n___pipeline_jobs_transform -->|"feeds"| n___pipeline_jobs_load

--- a/use-cases/tools/diagram.js
+++ b/use-cases/tools/diagram.js
@@ -102,20 +102,77 @@ function edges(val, primary) {
 }
 
 
+// THE NODE SET IS DERIVED FROM THE EDGES, since ADR-014.
+//
+// This used to read `graphOf(val).entities`, the entity index. There is
+// no index any more: a node's address IS its path, so there is nothing
+// left to index and the removal took the field with it. The node set is
+// therefore every path an edge names at either end, deduplicated.
+//
+// That is a real narrowing and it is the right one. The index listed
+// every DECLARED entity, including one nothing links to; this lists the
+// nodes the relation graph actually connects. A diagram of a relation
+// is a diagram of what participates in it, and an isolated vertex was
+// never carrying information the edges did not.
 function nodes(val) {
-  return A.graphOf(val).entities.map((e) => e.id).sort(cmp)
+  const seen = new Set()
+  for (const e of A.graphOf(val).edges) {
+    seen.add(e.from)
+    seen.add(e.to)
+  }
+  return [...seen].sort(cmp)
 }
 
 
 // A Mermaid identifier: letters, digits and underscore only, so an
-// entity name that is legal in Aontu cannot break the diagram.
+// address that is legal in Aontu cannot break the diagram.
 const mid = (s) => 'n_' + String(s).replace(/[^A-Za-z0-9_]/g, '_')
+
+
+// THE SHORTEST SUFFIX THAT IS STILL UNIQUE, as a node's visible label.
+//
+// Since ADR-014 a node's name IS its path, and the paths in a real
+// model are long: eight nodes labelled
+// `$.catalog.domains.identity.services.auth` and its siblings is a
+// correct diagram nobody can read. The label is therefore the fewest
+// trailing segments that still tell this node from every other in the
+// same diagram -- `auth` where that is unambiguous, `identity.auth`
+// where it is not.
+//
+// The IDENTIFIER stays the full path (`mid` above), so shortening can
+// never merge two nodes; only what a reader sees is shortened. And the
+// rule is a function of the node SET, so a diagram is deterministic
+// while two diagrams of different slices may label the same node
+// differently -- which is correct, because uniqueness is a property of
+// the set being drawn.
+function labels(ns) {
+  const segs = new Map(ns.map((n) => [n, n.replace(/^\$\.?/, '').split('.')]))
+  const out = new Map()
+  for (const n of ns) {
+    const parts = segs.get(n)
+    let label = n
+    for (let take = 1; take <= parts.length; take++) {
+      const cand = parts.slice(parts.length - take).join('.')
+      const clash = ns.some((m) =>
+        m !== n &&
+        segs.get(m).slice(Math.max(0, segs.get(m).length - take)).join('.') === cand)
+      if (!clash) {
+        label = cand
+        break
+      }
+    }
+    out.set(n, label)
+  }
+  return out
+}
 
 
 function graph(val, primary) {
   const out = ['graph LR']
-  for (const n of nodes(val)) {
-    out.push('  ' + mid(n) + '["' + n + '"]')
+  const ns = nodes(val)
+  const lab = labels(ns)
+  for (const n of ns) {
+    out.push('  ' + mid(n) + '["' + lab.get(n) + '"]')
   }
   for (const e of edges(val, primary)) {
     out.push('  ' + mid(e.from) + ' -->|"' + e.label + '"| ' + mid(e.to))
@@ -134,7 +191,8 @@ function matrix(val, primary) {
   const es = edges(val, primary)
   const has = new Set(es.map((e) => e.from + '\u0000' + e.to))
 
-  const label = (n) => n
+  const lab = labels(ns)
+  const label = (n) => lab.get(n)
   const w = Math.max(0, ...ns.map((n) => label(n).length))
   const idx = ns.map((_, i) => String(i + 1))
   const iw = Math.max(1, ...idx.map((s) => s.length))
@@ -161,16 +219,22 @@ function er(val, primary) {
   const out = ['erDiagram']
   const ns = nodes(val)
   const es = edges(val, primary)
+  const lab = labels(ns)
+  // An erDiagram has no separate label: the identifier IS what the
+  // reader sees. So this uses the short form, sanitised -- safe because
+  // `labels` guarantees the short forms are distinct within the set,
+  // which is exactly the uniqueness an identifier needs.
+  const eid = (n) => mid(lab.get(n))
   const joined = new Set()
   for (const e of es) {
     joined.add(e.from)
     joined.add(e.to)
-    out.push('  ' + mid(e.from) + ' }o--o{ ' + mid(e.to) + ' : "' + e.label + '"')
+    out.push('  ' + eid(e.from) + ' }o--o{ ' + eid(e.to) + ' : "' + e.label + '"')
   }
-  // An entity in no relationship still belongs in the diagram.
+  // A node in no relationship still belongs in the diagram.
   for (const n of ns) {
     if (!joined.has(n)) {
-      out.push('  ' + mid(n) + ' {')
+      out.push('  ' + eid(n) + ' {')
       out.push('  }')
     }
   }


### PR DESCRIPTION
**`main` is red without this.** Use cases 01 and 12 fail on `eb0c877`,
and did on `cd3231b` before it — verified by running the suite in a
clean worktree of `main`, not inferred.

ADR-014 removed the entity mark, and with it the entity **index**: a
node's address is its path, so there is nothing left to index.
`use-cases/tools/diagram.js` read `graphOf(val).entities`, so it crashes
on a field that no longer exists —

```
diagram: Cannot read properties of undefined (reading 'map')
FAIL: graph diagram did not render
```

— taking both cases down with it. #102 converted the two use cases it
touched but not the tool that draws them.

## The node set now comes from the edges

Every path an edge names at either end, deduplicated. That is a real
narrowing and the right one: the index listed every *declared* node,
including one nothing links to, while this lists the nodes the relation
actually connects. An isolated vertex was never carrying information the
edges did not.

## Captions: the shortest suffix that is still unique

Addresses being paths made the output unreadable — eight nodes captioned
`$.catalog.domains.identity.services.auth` and its siblings is a correct
diagram nobody can read. A node is now captioned with the fewest
trailing segments that still tell it from every other node **in the same
diagram**: `auth` where that is unambiguous, `identity.auth` where it is
not.

```
             1 2 3 4 5 6 7 8
auth       1 \ X . . . . . .
directory  2 . \ . . . . . .
ledger     3 . . \ . . . . .
payments   4 X . X \ X . . X
risk       5 . X . . \ . . .
email      6 . . . . . \ . .
gateway    7 X . . X . . \ .
notify     8 . . . . . X . \
```

The Mermaid **identifier** stays the full path, so shortening can never
merge two nodes — only what a reader sees is shortened. Uniqueness is a
property of the set being drawn, so two diagrams over different slices
may caption one node differently; that is correct, not a bug.

The `erDiagram` kind is the one exception and uses the short form as the
identifier too, because there the identifier *is* the caption — safe
precisely because the short forms are distinct within the set.

## Verification

Goldens regenerated; the READMEs' inline copies refreshed from them. The
inverse-pair collapse still holds — `12-relations` still draws 3 logical
edges from the 6 written ones, which its `check.sh` asserts by count
rather than by golden.

Use cases **13/15**, up from 11/15 on `main`. TypeScript 4472 tests, 0
fail; all Go packages pass.

## The two still red, and why they are not in here

`05-rbac-policy` and `10-data-model` address entities by bare global
name — `role: owner`, `grants: ["admin_all"]` — which ADR-014 removed.
They fail identically on `main` with `refer_address`:

```
[aontu/refer_address]: Cannot refer values at path $.tenant.members.role
                               ^ value was: refer()&string
```

#102 converted `01` and `12` and left these two. Converting them means
rewriting the models' addresses and the READMEs that explain the entity
concept behind them — a model rewrite, not a diagram fix — so folding it
in here would widen this PR past what it is for. Happy to take it as the
next change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJtvxtNJbL6M6h9GdoGRfs)_