### PR TITLE
Make the use-case corpus a CI gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,3 +102,46 @@ jobs:
             exit 1
           fi
       - run: make cov
+
+  # THE USE CASES ARE A GATE NOW, AND THIS IS WHY.
+  #
+  # `use-cases/run-all.sh` drives the real CLI end to end over fifteen
+  # worked models -- the only check here that exercises the engine the
+  # way a user does, through files, includes, data merges and exit
+  # codes, rather than through a spec row. It is therefore the only one
+  # that can notice a removed language feature still being used by a
+  # model.
+  #
+  # It ran on contributors' machines and nowhere else, and the cost
+  # arrived: ADR-014 (#102) removed id() with every suite green and
+  # every gate passing, and left four use cases broken on main -- 01,
+  # 05, 10 and 12. Nothing in CI evaluated a model that used the feature
+  # it removed, so the corpus stayed red across four merges until #107
+  # and #109 repaired it. The engine was right; the corpus was never
+  # asked.
+  #
+  # One job, on ubuntu: like the coverage gate, this is a property of
+  # the code rather than of the platform the matrix above covers.
+  # python3 is preinstalled and is what the JSON and SQLite assertions
+  # use (sqlite3 through the stdlib module, not the CLI).
+  use-cases:
+    name: Use cases
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - run: npm install
+        working-directory: ts
+      # The checks run ts/bin/aontu.js, which loads the COMMITTED
+      # ts/dist. Build first for the same reason the coverage gate does:
+      # an unbuilt tree would grade this branch's models against the
+      # previous branch's engine. Whether the committed build is itself
+      # current is the coverage gate's assertion, not this job's -- one
+      # check, one owner.
+      - run: npm run build
+        working-directory: ts
+      - run: ./run-all.sh
+        working-directory: use-cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ which implementation each change affects.
 
 ## Unreleased
 
+### The use-case corpus is a CI gate
+
+No engine change; one job added to `.github/workflows/build.yml`.
+
+`use-cases/run-all.sh` drives the real CLI end to end over fifteen
+worked models — through files, includes, data merges and exit codes —
+which makes it the only check here that can notice a removed language
+feature still being used by a model. It ran on contributors' machines
+and nowhere else.
+
+The cost arrived with [ADR-014](ADR.md), which removed `id()`: four use
+cases — 01-service-catalog, 05-rbac-policy, 10-data-model and
+12-relations — were left broken on main while every suite stayed green
+and every gate passed, and stayed broken across four merges until #107
+and #109 repaired them. The engine was right; the corpus was never
+asked. This is the job that asks it.
+
 ### `join(coll, sep?)` — the fold to a string
 
 Both ports. The one primitive between a model and a generated file. A


### PR DESCRIPTION
**Rebased and reduced.** This PR originally carried both halves — converting the four broken use cases *and* adding the gate. While it was in review, [#107](https://github.com/aontu-lang/aontu/pull/107) and [#109](https://github.com/aontu-lang/aontu/pull/109) landed the conversion independently, and their diagram labelling (shortest unique suffix) is better than mine was (strip the common ancestor). So the conversion is dropped and this is now **the one thing nobody else did**: two files, +60 lines, no deletions.

## Why

`use-cases/run-all.sh` drives the real CLI end to end over fifteen worked models — through files, includes, data merges and exit codes. That makes it **the only check in this repository that can notice a removed language feature still being used by a model**. A spec row exercises the engine; a use case exercises the engine the way a user does.

It ran on contributors&#39; machines and nowhere else, and the cost arrived. [ADR-014](https://github.com/aontu-lang/aontu/pull/102) removed `id()` with every suite green and every gate passing, and left four use cases broken on main — 01-service-catalog, 05-rbac-policy, 10-data-model and 12-relations. Nothing in CI evaluated a model that used the feature it removed, so **the corpus stayed red across four merges** (#102, #104, #105, #106) until #107 and #109 repaired it.

The engine was right throughout. The corpus was never asked. This is the job that asks it.

## Shape

One job on ubuntu, for the coverage gate&#39;s own stated reason — this is a property of the code, not of the platform the matrix already covers.

`python3` is preinstalled and is what the JSON and SQLite assertions use (`sqlite3` through the stdlib module, not the CLI), so no extra provisioning.

The job builds `ts/dist` first, because the checks run `ts/bin/aontu.js` against the committed build and an unbuilt tree would grade this branch&#39;s models against the previous branch&#39;s engine. Whether the committed build is *itself* current stays the coverage gate&#39;s assertion rather than this job&#39;s — one check, one owner.

The job comment names the incident, so the next person to wonder why the job exists does not have to reconstruct it from four merge commits.

## Verification

- `use-cases/run-all.sh` on this head — **15/15, exit 0**
- The job passed on the previous head of this branch (run [33342521376](https://github.com/aontu-lang/aontu/actions/runs/33342521376)), where it took 2m26s
- No engine change: the diff is `.github/workflows/build.yml` and `CHANGELOG.md`

## Still unfixed, deliberately

`gofmt -l go/` flags `hints.go`, `listval.go`, `mapval.go`, `unify.go`, `val.go` — map-literal key alignment. It flags **the same five on `main`**, so it is pre-existing and not this PR&#39;s. CI does not gate `gofmt`. Worth a follow-up if you want it gated alongside the corpus.