### PR TITLE
Ready the use cases to be rendered as a site section

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -413,6 +413,17 @@ returns markdown.
 > **OpenAPI** document, and the site-authored pages beyond the landing
 > page (`/why`, comparisons, community).
 >
+> Since then, out of phase 4: the playground, and the `/use-cases`
+> section — a page per executed case, synced from each
+> `use-cases/<dir>/README.md` the way the documentation set is, with
+> the case table in `use-cases/README.md` supplying the metadata and
+> held to the site's manifest in both directions. The diagrams those
+> cases carry are drawn as static SVG at build time by a renderer in
+> the site repository, because Mermaid lays out in a browser and this
+> build deliberately has none. D6 called `use-cases/` "the interesting
+> middle case" and deferred it until the sync machinery had proven
+> itself; it had.
+>
 > One thing the phase list never anticipated, and which cost the most:
 > the site pinned the newest *published* engine while rendering docs
 > from `main`, and for a while those were `0.52.1` and the `0.53.0`

--- a/use-cases/01-service-catalog/README.md
+++ b/use-cases/01-service-catalog/README.md
@@ -1,4 +1,4 @@
-# Use case 01: a company-wide service catalog as system ontology
+# 01 — a company-wide service catalog as system ontology
 
 ## The catalog, drawn
 

--- a/use-cases/02-deploy-config/README.md
+++ b/use-cases/02-deploy-config/README.md
@@ -1,4 +1,4 @@
-# Use case 02: multi-environment deployment configuration
+# 02 — multi-environment deployment configuration
 
 A fleet of four services (`web`, `auth`, `billing`, `reports`) deployed
 to three environments (`dev`, `staging`, `prod`) under four layers of

--- a/use-cases/03-api-contract/README.md
+++ b/use-cases/03-api-contract/README.md
@@ -1,4 +1,4 @@
-# Use case 03: a REST API contract as agent ground truth
+# 03 — a REST API contract as agent ground truth
 
 ## The scenario
 

--- a/use-cases/04-schema-evolution/README.md
+++ b/use-cases/04-schema-evolution/README.md
@@ -1,4 +1,4 @@
-# Use case 04: schema-evolution governance for a shared customer-profile schema
+# 04 — schema-evolution governance for a shared customer-profile schema
 
 ## The release history, drawn — and it is not a chain
 

--- a/use-cases/07-event-contracts/README.md
+++ b/use-cases/07-event-contracts/README.md
@@ -1,4 +1,4 @@
-# Use case 07: event/message contracts (the schema-registry case)
+# 07 — event/message contracts (the schema-registry case)
 
 An order service publishes `order.placed`, `order.paid` and
 `order.cancelled` events to a stream. The contract is what a Kafka

--- a/use-cases/08-feature-flags/README.md
+++ b/use-cases/08-feature-flags/README.md
@@ -1,4 +1,4 @@
-# Use case 08: feature flags / runtime config (the write-path case)
+# 08 — feature flags / runtime config (the write-path case)
 
 ## The arbitration, drawn
 

--- a/use-cases/10-data-model/README.md
+++ b/use-cases/10-data-model/README.md
@@ -115,7 +115,7 @@ for. Money crosses the wire as a **decimal string** validated exactly by
 scale. `money-wire.aon` is the schema, `money-convert.aon` writes the
 crossing point out as theorems, and `check.sh` asserts both, plus the
 exported JSON Schema, against the same records. See
-[docs/how-to.md, "Carry exact money over JSON"](../../docs/how-to.md#carry-exact-money-over-json).
+[the "Carry exact money over JSON" how-to](../../docs/how-to/carry-exact-money-over-json.md).
 The finding below stands exactly as written — it is *why* the
 convention exists, and `exact-money.aon` remains the executable form of
 the dead end it describes.

--- a/use-cases/11-shared-modules/README.md
+++ b/use-cases/11-shared-modules/README.md
@@ -71,7 +71,7 @@ store layout the resolver expects:
 as directories, `@<major>` suffixed to the last one. When we ran this
 that layout was documented nowhere and we read it out of `ts/src/mod.ts`
 (gap 2); it is now in
-[`how-to.md`](../../docs/how-to.md#vendor-a-module-by-hand) and
+[`how-to/vendor-by-hand.md`](../../docs/how-to/vendor-by-hand.md) and
 [`reference-api.md`](../../docs/reference-api.md#aontu-mod).
 
 **3. `aontu mod tidy` then works exactly as documented.** Exit 0, and

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -40,7 +40,7 @@ and, in case 09, `MCP` — to point at a different build.
 
 | Case | Scenario | Aontu surface exercised |
 |------|----------|-------------------------|
-| [01-service-catalog](01-service-catalog/) | Company-wide service catalog as system ontology (two views of the same entities) | `id()`, `refer()`, `relations` (acyclic + inverse), `@"std/system"`, `get`/`why`, vet-gated onboarding |
+| [01-service-catalog](01-service-catalog/) | Company-wide service catalog as system ontology (two views of the same entities) | `refer()` over tree paths, `relations` (acyclic + inverse), `@"std/system"`, `get`/`why`, vet-gated onboarding |
 | [02-deploy-config](02-deploy-config/) | Multi-environment deployment config: org → team → service → env layering | ranked `*`/`**` defaults, includes, `close()`, constraint atoms, `pack`, `filter`, `why` |
 | [03-api-contract](03-api-contract/) | REST API contract as the truth an agent codes against; emit→validate→repair | `vet` (json/sarif/exit classes), `--at`, `--closed`, repair from findings |
 | [04-schema-evolution](04-schema-evolution/) | Governance of a shared schema across v1→v3 | `subsume` profiles, `breaking --against`, `deprecate()`, `aontu_policy.compat`, `hash`, `diff` |


### PR DESCRIPTION
Companion to **aontu-lang/web#15**, which gives every executed case its own page on aontu.dev, synced from these READMEs the way the documentation set is.

Rendering the fifteen as a set surfaced four things that were wrong or stale here. None of them was visible while each file was only ever read on its own.

## Two dangling links

`docs/how-to.md` was split into `docs/how-to/`, and cases 10 and 11 still pointed at the monolith. Same class of break as #108, found the same way — by syncing the site, whose link checker refuses a target that does not exist on disk.

- `10-data-model` → `docs/how-to/carry-exact-money-over-json.md`
- `11-shared-modules` → `docs/how-to/vendor-by-hand.md`

The prose mentions of `docs/how-to.md` inside the findings sections are left alone: they are historical records of what was true when the case was run.

## Fifteen headings, two conventions

Six cases headed themselves `# Use case NN: …` and nine `# NN — …`. Nobody notices reading one README; in a sidebar listing all fifteen side by side it is the first thing you see. The six move to the majority form, which is also how `docs/use-cases.md` already heads its sections (`## 01 — service catalog`).

## One stale table cell

The case table still credited 01 with `id()`, which ADR-014 removed and #109 converted the case off — `grep 'id('` over `01-service-catalog/*.aon` finds nothing. The site renders that cell as the case's "exercises" line, so a mark the language no longer has was about to be published as a feature.

## The plan note

`docs/site/index.md`'s "what actually landed" note records the `/use-cases` section, since D6 deferred `use-cases/` to phase 4 "once the sync machinery has proven itself on the simpler docs".

## Testing

No engine change — documentation only. Nothing here is in the style-gated or example-executed page set: `ts/test/docs.test.ts` covers `docs/*.md` and `docs/how-to/*.md`, not `use-cases/` or `docs/site/`. Every relative link in all fifteen READMEs was checked against a clean checkout by the site's sync (which throws on a target that escapes the root or does not exist), and `npm run check` is green in the web repository against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtRciVTyGBnmBU92yZZKjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtRciVTyGBnmBU92yZZKjQ)_