### PR TITLE
A layered module graph, drawn as a dependency tree (use case 16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
 
   # THE USE CASES ARE A GATE NOW, AND THIS IS WHY.
   #
-  # `use-cases/run-all.sh` drives the real CLI end to end over fifteen
+  # `use-cases/run-all.sh` drives the real CLI end to end over sixteen
   # worked models -- the only check here that exercises the engine the
   # way a user does, through files, includes, data merges and exit
   # codes, rather than through a spec row. It is therefore the only one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ which implementation each change affects.
 
 ## Unreleased
 
+### A sixteenth use case: a layered module graph, drawn as a tree
+
+`use-cases/16-module-deps/` models a codebase's own module graph —
+twelve modules across four layers — and enforces "never depend on a
+layer above you" with nothing but unification: `rel(t)` flows a
+per-layer target shape into every module an edge names, so an upward
+edge is a failed meet at the far end rather than a separate checking
+pass. Thirteen assertions, including the layering refusal, a cycle
+between same-layer modules, and both drawn views.
+
+`use-cases/tools/diagram.js` grows a `tree` kind for it: an indented
+dependency tree with derived roots and repeated subtrees elided
+`(*)`, in the manner of `cargo tree`. Writing the case found a defect
+in the tool's edge collapse — a MUTUAL dependency (`a dependsOn b`
+with `b dependsOn a`) folded into one undirected edge, hiding the
+shortest cycle a model can have. The collapse is now per key pair;
+every existing golden is unchanged.
+
 ### The pipe operator is removed (ADR-018)
 
 Both ports. **Breaking**: `|>` no longer parses. It was parse-time

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ bypasses trusted publishing entirely.
 
 ## Where use-cases/ fits
 
-[use-cases/](use-cases/) is the executable review: eleven enterprise
+[use-cases/](use-cases/) is the executable review: sixteen enterprise
 scenarios driven through the real CLI, with verified defects in
 [use-cases/BUGS.md](use-cases/BUGS.md) and minimal reproductions under
 [use-cases/repros/](use-cases/repros/). Those repros are **candidates

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full documentation is in [`docs/`](docs/):
 - [Test coverage](docs/test-coverage.md) — how it is measured, and the numbers
 
 The language has also been put through an executable review —
-[use-cases/](use-cases/) drives fifteen enterprise scenarios through
+[use-cases/](use-cases/) drives sixteen enterprise scenarios through
 the real CLI, with verified findings and minimal repros.
 
 ## Security and contributing

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -528,8 +528,12 @@ CoreDep: { kind: mod, layer: "core" | "util" }
 
 An upward edge then refuses at generation as an ordinary conflict
 naming both sides, and a loop between two modules of the *same* layer
-— which the layering allows — refuses under `acyclic()`. The same
-edges are drawn two ways and pinned as goldens: a dependency tree,
+— which the layering allows — refuses under `acyclic()`. The refusal
+is not yet order-independent: which target shape reaches the far end
+of an edge depends on the order the blocks are written in, so the case
+pins both the refusal and, as a known miss, the swapped spelling that
+still generates. The same edges are drawn two ways and pinned as
+goldens: a dependency tree,
 with derived roots and every repeated subtree elided the way
 `cargo tree` elides one, and a dependency-structure matrix. The
 layered codebase, its refusals and its views:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,7 +1,7 @@
 # Use cases
 
 Documentation examples are small on purpose. Systems are not. The
-fifteen models in [`use-cases/`](../use-cases/) close that gap: each
+sixteen models in [`use-cases/`](../use-cases/) close that gap: each
 one is an enterprise-shaped system built as real Aontu documents — a
 service catalog, a schema registry, an RBAC model — and each carries a
 `check.sh` that drives the actual CLI and asserts every outcome, with
@@ -12,7 +12,7 @@ shape lives, running. Run one case, or the whole suite:
 <!-- test: skip runs the full case suite; use-cases/run-all.sh is its own gate, run before every landing -->
 ```sh
 $ ./use-cases/03-api-contract/check.sh   # one case
-$ ./use-cases/run-all.sh                 # all fifteen, one verdict line per case
+$ ./use-cases/run-all.sh                 # all sixteen, one verdict line per case
 ```
 
 The scripts need Node with `ts/node_modules` installed, plus `python3`
@@ -510,6 +510,30 @@ generated SQL carries a trailing comma that a real parser refuses.
 emitters, their goldens, and a check that both ports emit identical
 bytes: [`use-cases/15-code-generation/`](../use-cases/15-code-generation/).
 
+
+## 16 — module deps
+
+A codebase's own module graph: twelve modules across four layers,
+where the architecture rule is that nothing may depend on a layer
+above it. The rule is a shape rather than a checking pass. `rel(t)`
+flows its target shape into every module an edge names, so a core
+module's `dependsOn` carries `layer: "core" | "util"` to the far end,
+and a module that says `layer: "feature"` cannot meet it. Each layer
+is one line of schema and one disjunction, from `spec.aon`:
+
+```
+Core:    $.spec.Mod & { layer: "core", dependsOn?: rel($.spec.CoreDep) }
+CoreDep: { kind: mod, layer: "core" | "util" }
+```
+
+An upward edge then refuses at generation as an ordinary conflict
+naming both sides, and a loop between two modules of the *same* layer
+— which the layering allows — refuses under `acyclic()`. The same
+edges are drawn two ways and pinned as goldens: a dependency tree,
+with derived roots and every repeated subtree elided the way
+`cargo tree` elides one, and a dependency-structure matrix. The
+layered codebase, its refusals and its views:
+[`use-cases/16-module-deps/`](../use-cases/16-module-deps/).
 
 Where a page in these docs and a use case disagree, the case wins (its
 checks run; the page does not). File the docs bug.

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@
 - [Shared spec suite](test/spec/): the conformance corpus — 3k+
   language-agnostic cases both implementations must satisfy; a third
   implementation claims conformance by passing it
-- [Executable review](use-cases/): eleven enterprise use cases driven
+- [Executable review](use-cases/): sixteen enterprise use cases driven
   through the real CLI, with verified findings and minimal repros
 
 ## Contributing

--- a/use-cases/16-module-deps/README.md
+++ b/use-cases/16-module-deps/README.md
@@ -108,6 +108,14 @@ at generation with both sides named.
  Cannot unify value: "core"|"util" with value: "feature"
 ```
 
+**And it holds for the spelling above, not for its mirror image.**
+Which target shape reaches the far end depends on the order the blocks
+are written in: `bad/upward.aon` writes the offending module first and
+refuses, `bad/upward-swapped.aon` writes its target first and the same
+edge generates. Both are pinned by `check.sh`, the second as a known
+miss. The mechanism is right and the flow that carries it is not
+order-independent yet, which is the largest thing this case found.
+
 ## The model
 
 `spec.aon` is the vocabulary and the rule; `modules.aon` is the
@@ -140,28 +148,40 @@ of an edge rather than the edge itself.
    inverse written; `aontu relations` passes on the same document.
 2. An upward dependency (core on feature) refuses at generation, and
    the message names both layers.
-3. A cycle between two util modules — legal by layer — refuses with a
+3. The same edge with its two blocks swapped still generates — pinned
+   as a known miss, so the corpus says what the engine does and the
+   assertion flips when the flow stops depending on order.
+4. A cycle between two util modules — legal by layer — refuses with a
    located `relation_cycle`, and the verb names the loop it runs
    through.
-4. An edge whose mirror was never written refuses, and the verb names
+5. An edge whose mirror was never written refuses, and the verb names
    the exact absent entry.
-5. A dependency on a module nobody wrote refuses inside the
+6. A dependency on a module nobody wrote refuses inside the
    evaluation (`rel_unresolved`): existence is decided, never
    deferred.
-6. `aontu reaches --relation dependsOn` answers the closure question
+7. `aontu reaches --relation dependsOn` answers the closure question
    both ways: `cli` reaches `bytes` through three hops, and `bytes`
    reaches nothing.
-7. The tree draws: three derived roots, nine elided repeats, pinned
+8. The tree draws: three derived roots, nine elided repeats, pinned
    byte for byte.
-8. `tree --root $.mods.billing` draws one module's own closure, and a
+9. `tree --root $.mods.billing` draws one module's own closure, and a
    `--root` naming no node refuses rather than drawing an empty tree.
-9. The dependency-structure matrix draws, pinned the same way.
-10. The tree of the *cyclic* model terminates, marking the closing
+10. The dependency-structure matrix draws, pinned the same way.
+11. The tree of the *cyclic* model terminates, marking the closing
     edge `(cycle)` instead of recursing into it.
-11. `aontu get` reads a module's layer and directory off the model.
+12. `aontu get` reads a module's layer and directory off the model.
 
 ## Boundaries hit while writing it
 
+- **The layering rule is order-dependent, and that is a defect.**
+  `rel(t)`'s flow into the far end of an edge carries the narrow
+  per-layer shape when the source module's block is written first, and
+  a wider shape when the target's is. The same illegal edge is
+  therefore refused in one spelling and generated in another
+  (`bad/upward.aon` against `bad/upward-swapped.aon`, both pinned).
+  A rule that depends on declaration order is not yet a rule, and the
+  case says so rather than claiming a guarantee the engine does not
+  give.
 - **A mutual dependency was invisible to the renderer, and this case
   found it.** `tools/diagram.js` collapses the two written directions
   of a declared inverse into one logical edge, or every relation with

--- a/use-cases/16-module-deps/README.md
+++ b/use-cases/16-module-deps/README.md
@@ -1,0 +1,202 @@
+# 16 — module deps: a layered codebase, drawn as a dependency tree
+
+## The codebase, drawn
+
+Twelve modules, four layers, twenty-one dependencies. The tree below
+is generated from this model by
+[`../tools/diagram.js`](../tools/diagram.js) and pinned as a golden by
+`check.sh`, like every other artifact here. There is no `aontu view`
+verb yet — see [`docs/design/VIEWS.0.md`](../../docs/design/VIEWS.0.md).
+
+```
+cli
+├── billing
+│   ├── auth
+│   │   ├── bytes
+│   │   └── http
+│   │       ├── bytes
+│   │       └── log
+│   │           └── bytes
+│   ├── clock
+│   └── store
+│       ├── clock
+│       └── log (*)
+└── reports
+    ├── log (*)
+    └── store (*)
+
+server
+├── billing (*)
+├── catalog
+│   ├── http (*)
+│   └── store (*)
+└── http (*)
+
+worker
+├── reports (*)
+└── store (*)
+```
+
+**Three roots, because nothing depends on them.** The renderer derives
+the roots from the edge set rather than being told: a root is a module
+no other module names, which for a codebase is exactly its
+deployables. `cli`, `server` and `worker` are what ship.
+
+**`(*)` is a subtree already drawn.** A dependency graph is a DAG and
+not a tree — `store` is reached from four modules — so a full
+expansion would print the same subtree once per path into it, and the
+depth would carry no information. The first occurrence in sort order
+is expanded and every later one is marked, which is what `cargo tree`
+and `npm ls` do, and for the same reason. Nine edges here land on a
+subtree that is already drawn. A repeat with nothing under it, like
+`bytes`, hides nothing and is drawn plain.
+
+The same edges as a dependency-structure matrix, where a mark at (row,
+column) means the row module depends on the column module:
+
+```
+             1  2  3  4  5  6  7  8  9 10 11 12
+auth      1  \  .  X  .  .  .  X  .  .  .  .  .
+billing   2  X  \  .  .  .  X  .  .  .  .  X  .
+bytes     3  .  .  \  .  .  .  .  .  .  .  .  .
+catalog   4  .  .  .  \  .  .  X  .  .  .  X  .
+cli       5  .  X  .  .  \  .  .  .  X  .  .  .
+clock     6  .  .  .  .  .  \  .  .  .  .  .  .
+http      7  .  .  X  .  .  .  \  X  .  .  .  .
+log       8  .  .  X  .  .  .  .  \  .  .  .  .
+reports   9  .  .  .  .  .  .  .  X  \  .  X  .
+server   10  .  X  .  X  .  .  X  .  .  \  .  .
+store    11  .  .  .  .  .  X  .  X  .  .  \  .
+worker   12  .  .  .  .  .  .  .  .  X  .  X  \
+```
+
+The tree answers "what does `cli` pull in, and how deep"; the matrix
+answers "what is the shape of the whole surface". Ghoniem, Fekete and
+Castagliola (InfoVis 2004) is the empirical result behind preferring
+the matrix past about twenty vertices, and Sangal et al. (OOPSLA 2005)
+is the software-dependency application. At twelve modules both are
+readable, which is why the case draws both.
+
+## The layering rule is a shape, not a checker
+
+The architecture invariant is that a module never depends on a module
+above it. `app` may use anything, `feature` may use feature and below,
+`core` may use core and below, `util` may use only util. A sideways
+edge is legal — `auth` calling `http` is ordinary engineering — and
+what stops a sideways edge from closing a loop is `acyclic()`.
+
+The whole rule is four disjunctions, from `spec.aon`:
+
+    AppDep:     { kind: mod, layer: "app" | "feature" | "core" | "util" }
+    FeatureDep: { kind: mod, layer: "feature" | "core" | "util" }
+    CoreDep:    { kind: mod, layer: "core" | "util" }
+    UtilDep:    { kind: mod, layer: "util" }
+
+and one line per layer joining a module to the shape its dependencies
+must have:
+
+    Core: $.spec.Mod & { layer: "core", dependsOn?: rel($.spec.CoreDep) }
+
+`rel(t)` flows `t` into every target, so a `dependsOn` edge from a
+core module carries `layer: "core" | "util"` to the far end. A module
+that says `layer: "feature"` cannot meet it. There is no linter here
+and no second pass: the illegal edge is a failed unification, refused
+at generation with both sides named.
+
+```
+[aontu/empty]: Cannot unify values at path $.mods.auth.dependsOn.0.usedBy.0.dependsOn.layer
+ Cannot unify value: "core"|"util" with value: "feature"
+```
+
+## The model
+
+`spec.aon` is the vocabulary and the rule; `modules.aon` is the
+codebase; `model.aon` joins them. The relation is declared once, at
+its field:
+
+    dependsOn?: rel($.spec.ModShape) & acyclic() & inverse(usedBy)
+    usedBy?: rel($.spec.ModShape)
+
+- `rel(t)` — the field's entries are checked tree addresses, and `t`
+  flows into every target. Addresses are written `path($.mods.store)`:
+  a bare string is never an address (ADR-016).
+- `acyclic()`, `inverse(usedBy)` — the graph atoms: lattice-inert
+  declarations, registered during unification and decided at
+  generation, where every edge is known.
+
+Both directions of every edge are written out. Deriving the inverse
+for the author would be generation rather than validation, and
+`inverse(n)` only checks, so `store` lists the four modules that use
+it and each of them lists `store`.
+
+Case 12 exercises the same atoms on a four-job pipeline. What this
+case adds is scale enough for the views to matter (twelve modules,
+three roots, shared subtrees) and a rule that constrains the *far end*
+of an edge rather than the edge itself.
+
+## What check.sh proves
+
+1. The model generates: twelve modules, twenty-one legal edges, every
+   inverse written; `aontu relations` passes on the same document.
+2. An upward dependency (core on feature) refuses at generation, and
+   the message names both layers.
+3. A cycle between two util modules — legal by layer — refuses with a
+   located `relation_cycle`, and the verb names the loop it runs
+   through.
+4. An edge whose mirror was never written refuses, and the verb names
+   the exact absent entry.
+5. A dependency on a module nobody wrote refuses inside the
+   evaluation (`rel_unresolved`): existence is decided, never
+   deferred.
+6. `aontu reaches --relation dependsOn` answers the closure question
+   both ways: `cli` reaches `bytes` through three hops, and `bytes`
+   reaches nothing.
+7. The tree draws: three derived roots, nine elided repeats, pinned
+   byte for byte.
+8. `tree --root $.mods.billing` draws one module's own closure, and a
+   `--root` naming no node refuses rather than drawing an empty tree.
+9. The dependency-structure matrix draws, pinned the same way.
+10. The tree of the *cyclic* model terminates, marking the closing
+    edge `(cycle)` instead of recursing into it.
+11. `aontu get` reads a module's layer and directory off the model.
+
+## Boundaries hit while writing it
+
+- **A mutual dependency was invisible to the renderer, and this case
+  found it.** `tools/diagram.js` collapses the two written directions
+  of a declared inverse into one logical edge, or every relation with
+  an inverse would draw twice. It collapsed by node pair, so `a
+  dependsOn b` together with `b dependsOn a` — one key facing itself,
+  which is the shortest cycle a model can have — folded into a single
+  undirected edge and the loop vanished from every view. The collapse
+  is now per key pair: two keys facing each other are an inverse, one
+  key facing itself is two facts. Every existing golden is unchanged
+  by the fix.
+- **The upward refusal names the layers but not the module.** The
+  message is exact about what conflicted (`"core"|"util"` with
+  `"feature"`) and the path it reports walks the relation
+  (`$.mods.auth.dependsOn.0.usedBy.0.dependsOn.layer`) rather than
+  naming the edge that broke the rule. An author reads the layers and
+  then goes looking. A finding that carried the offending edge would
+  make this a one-glance fix.
+- **The error frame under an include names one file and quotes
+  another.** `bad/dangling.aon` reports `--> spec.aon:24:17` and
+  prints text from the failing document underneath it. Case 12's
+  shipped `bad/dangling.aon` does the same, and a single-file version
+  of the same model reports coherently, so the trigger is the include
+  rather than this model. That is the `site-attribution` family
+  ([`BUGS.md` §25](../BUGS.md)), whose invariant is that a frame
+  quotes the text of the file its header names.
+- **Lists unify positionally**, so each `bad/` overlay restates the
+  list it extends, with the new entry last. Cases 01 and 12 record
+  the same workaround.
+- The views design declines an icicle over the path tree, on the
+  grounds that `get --keys` and `jsonschema` already answer what it
+  would answer ([`VIEWS.0.md`](../../docs/design/VIEWS.0.md),
+  "Boundary"). A dependency tree is a different figure: it is over a
+  *relation*, not over containment, and no shipped verb answers what
+  it shows.
+
+## Run
+
+    ./check.sh

--- a/use-cases/16-module-deps/bad/cycle.aon
+++ b/use-cases/16-module-deps/bad/cycle.aon
@@ -1,0 +1,18 @@
+# bad/cycle.aon --- bytes comes to depend on log, which already
+# depends on bytes. Both modules are util, so the LAYER is happy: a
+# sideways edge is legal, and what refuses a loop is acyclic(), not
+# the layer. Generation reports a located relation_cycle naming the
+# nodes it runs through.
+@"../model.aon"
+
+mods: {
+  bytes: {
+    dependsOn: [path($.mods.log)]
+  }
+  log: {
+    usedBy: [
+      path($.mods.http), path($.mods.reports), path($.mods.store),
+      path($.mods.bytes)
+    ]
+  }
+}

--- a/use-cases/16-module-deps/bad/dangling.aon
+++ b/use-cases/16-module-deps/bad/dangling.aon
@@ -1,0 +1,11 @@
+# bad/dangling.aon --- a dependency on a module nobody wrote. rel()
+# decides existence inside one evaluation: the address resolves or the
+# document refuses (rel_unresolved), and a dependency on a module that
+# does not exist is never a thing to discover later.
+@"../model.aon"
+
+mods: {
+  clock: {
+    dependsOn: [path($.mods.tracing)]
+  }
+}

--- a/use-cases/16-module-deps/bad/missing-inverse.aon
+++ b/use-cases/16-module-deps/bad/missing-inverse.aon
@@ -1,0 +1,12 @@
+# bad/missing-inverse.aon --- clock depends on bytes and bytes does
+# not say so. The edge is legal by layer (util on util) and closes no
+# loop; what fails is that the mirror was never written. inverse(n)
+# CHECKS the mirror and never writes it, so the two lists cannot drift
+# apart in a document that generates.
+@"../model.aon"
+
+mods: {
+  clock: {
+    dependsOn: [path($.mods.bytes)]
+  }
+}

--- a/use-cases/16-module-deps/bad/upward-swapped.aon
+++ b/use-cases/16-module-deps/bad/upward-swapped.aon
@@ -1,0 +1,24 @@
+# bad/upward-swapped.aon --- bad/upward.aon with its two blocks in the
+# OPPOSITE order. Same edges, same layers, same mirrors.
+#
+# IT GENERATES. The layering rule is enforced by rel(t)'s flow into
+# the far end of an edge, and which target shape reaches the far end
+# depends on the order the blocks are written in: written source-first
+# the narrow CoreDep shape lands and the upward edge refuses; written
+# target-first a wider shape lands instead and the same edge passes.
+#
+# So this file is a KNOWN MISS, pinned by check.sh as one: the corpus
+# records what the engine does today, and the assertion flips the day
+# the flow stops depending on declaration order.
+@"../model.aon"
+
+mods: {
+  catalog: {
+    usedBy: [path($.mods.server), path($.mods.auth)]
+  }
+  auth: {
+    dependsOn: [
+      path($.mods.bytes), path($.mods.http), path($.mods.catalog)
+    ]
+  }
+}

--- a/use-cases/16-module-deps/bad/upward.aon
+++ b/use-cases/16-module-deps/bad/upward.aon
@@ -3,9 +3,10 @@
 # directions are written, so the inverse holds and nothing here is a
 # loop -- the only thing wrong is the direction through the layers.
 #
-# It refuses at generation with an ordinary [aontu/scalar_value]: the
-# CoreDep shape flowed into catalog by rel() says layer is core or
-# util, catalog says feature, and two unequal literals do not meet.
+# It refuses at generation with an ordinary [aontu/empty]: the CoreDep
+# shape flowed into catalog by rel() says layer is core or util,
+# catalog says feature, and a disjunction with no branch left standing
+# is empty.
 # The architecture rule needs no separate checker because it is not a
 # separate kind of thing.
 #

--- a/use-cases/16-module-deps/bad/upward.aon
+++ b/use-cases/16-module-deps/bad/upward.aon
@@ -1,0 +1,25 @@
+# bad/upward.aon --- auth (core) grows a dependency on catalog
+# (feature): an UPWARD edge, the one thing the layering forbids. Both
+# directions are written, so the inverse holds and nothing here is a
+# loop -- the only thing wrong is the direction through the layers.
+#
+# It refuses at generation with an ordinary [aontu/scalar_value]: the
+# CoreDep shape flowed into catalog by rel() says layer is core or
+# util, catalog says feature, and two unequal literals do not meet.
+# The architecture rule needs no separate checker because it is not a
+# separate kind of thing.
+#
+# Both lists restate their existing elements: lists unify positionally,
+# so an addition is written as the whole list with the new entry last.
+@"../model.aon"
+
+mods: {
+  auth: {
+    dependsOn: [
+      path($.mods.bytes), path($.mods.http), path($.mods.catalog)
+    ]
+  }
+  catalog: {
+    usedBy: [path($.mods.server), path($.mods.auth)]
+  }
+}

--- a/use-cases/16-module-deps/check.sh
+++ b/use-cases/16-module-deps/check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# check.sh --- drive the aontu CLI over the module graph and assert
+# every outcome of a LAYERED, ACYCLIC dependency model: the layering
+# rule enforced by nothing but unification, the graph atoms decided at
+# generation, the closure question answered by `reaches`, and the
+# dependency tree drawn and pinned. Runnable from any cwd.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$DIR/../.."
+NODE="${NODE:-node}"
+AONTU="${AONTU:-node $REPO/ts/bin/aontu.js}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok() { pass=$((pass + 1)); echo "ok $pass - $1"; }
+
+run() {
+  local name="$1" want="$2"; shift 3
+  local got=0
+  $AONTU "$@" >"$WORK/$name.out" 2>"$WORK/$name.err" || got=$?
+  [ "$got" -eq "$want" ] \
+    || { cat "$WORK/$name.err" >&2; fail "$name: exit $got, wanted $want"; }
+}
+
+has() {
+  grep -qF -- "$3" "$WORK/$1.$2" \
+    || { cat "$WORK/$1.$2" >&2; fail "$1: $2 does not contain: $3"; }
+}
+
+draw() {
+  local name="$1"; shift
+  "$NODE" "$DIR/../tools/diagram.js" "$@" >"$WORK/$name" \
+    || fail "$name did not render"
+  diff -u "$DIR/expected/$name" "$WORK/$name" \
+    || fail "$name drifted from its golden"
+}
+
+# 1. The codebase generates: twelve modules, four layers, every edge
+# legal and every inverse written.
+run eval 0 -- "$DIR/model.aon"
+diff -u "$DIR/expected/model.json" "$WORK/eval.out" \
+  || fail "model.aon output drifted from expected/model.json"
+ok "model.aon generates: twelve modules, twenty-one legal edges"
+
+# 2. The verb reports the same verdict without generating.
+run rel 0 -- relations "$DIR/model.aon"
+has rel out 'verdict: pass'
+ok "relations: acyclic + inverse both hold across the codebase"
+
+# 3. THE LAYERING RULE, ENFORCED BY UNIFICATION ALONE. auth is core
+# and catalog is feature, so the CoreDep shape rel() flows into
+# catalog says layer is core or util, and catalog's own layer says
+# feature. Two disjunctions with nothing in common do not meet: the
+# architecture rule refuses as an ordinary conflict, at generation,
+# with both sides of it named.
+run upward 1 -- "$DIR/bad/upward.aon"
+has upward err '[aontu/empty]'
+has upward err 'Cannot unify value: "core"|"util" with value: "feature"'
+ok "upward dependency: core on feature refuses, naming both layers"
+
+# 4. A cycle between two util modules -- legal by layer, refused by
+# acyclic() -- reports at generation and from the verb, naming the
+# loop it runs through.
+run cyceval 1 -- "$DIR/bad/cycle.aon"
+has cyceval err '[aontu/relation_cycle]'
+run cycle 1 -- relations "$DIR/bad/cycle.aon"
+has cycle out 'verdict: fail'
+has cycle out 'cycle $.mods.bytes -> $.mods.log -> $.mods.bytes'
+ok "cycle: a sideways loop refused at generation, named by the verb"
+
+# 5. An edge whose mirror was never written refuses the same way, and
+# the verb names the exact absent entry.
+run noinveval 1 -- "$DIR/bad/missing-inverse.aon"
+has noinveval err '[aontu/relation_inverse_missing]'
+run noinv 1 -- relations "$DIR/bad/missing-inverse.aon"
+has noinv out '$.mods.bytes does not list $.mods.clock under usedBy'
+ok "missing inverse: refused at generation, the exact entry named"
+
+# 6. A dependency on a module nobody wrote is decided inside the
+# evaluation: it resolves or the document refuses.
+run dangle 1 -- "$DIR/bad/dangling.aon"
+has dangle err '[aontu/rel_unresolved]'
+ok "dangling: a dependency on an absent module refuses"
+
+# 7. The closure question over the same edges, both ways. A deployable
+# reaches the leaf it never names directly; the leaf reaches nothing.
+run reach 0 -- reaches '$.mods.cli' '$.mods.bytes' --relation dependsOn "$DIR/model.aon"
+has reach out 'verdict: reaches'
+has reach out '$.mods.cli -> $.mods.billing -> $.mods.auth -> $.mods.bytes'
+run noreach 1 -- reaches '$.mods.bytes' '$.mods.cli' --relation dependsOn "$DIR/model.aon"
+has noreach out 'verdict: unreachable'
+ok "reaches --relation dependsOn: downstream yes, upstream no"
+
+# 8. THE TREE. A dependency graph is a DAG, not a tree: `store` is
+# reached from four modules and is drawn in full once, marked `(*)`
+# everywhere after. The three deployables are the roots because
+# nothing depends on them -- which the renderer DERIVES from the edge
+# set rather than being told.
+draw diagram-tree.txt tree --primary dependsOn "$DIR/model.aon"
+[ "$(grep -c '(\*)' "$WORK/diagram-tree.txt")" -eq 9 ] \
+  || fail "expected nine elided repeats in the tree"
+[ "$(grep -cE '^[a-z]' "$WORK/diagram-tree.txt")" -eq 3 ] \
+  || fail "expected three roots: the three deployables"
+ok "the dependency tree draws: three roots, every repeat elided once"
+
+# 9. One subtree, from a named root: what a feature module actually
+# pulls in, which is the question a reviewer of that module has.
+draw diagram-tree-billing.txt tree --primary dependsOn \
+  --root '$.mods.billing' "$DIR/model.aon"
+ok "tree --root: one module's own closure, drawn alone"
+
+# 10. A misspelled root is refused rather than drawn: an empty tree
+# and a typo look identical in a golden file.
+if "$NODE" "$DIR/../tools/diagram.js" tree --primary dependsOn \
+  --root '$.mods.nosuch' "$DIR/model.aon" >"$WORK/typo.out" 2>"$WORK/typo.err"
+then
+  fail "a --root naming no node should refuse"
+fi
+grep -qF 'no such node: $.mods.nosuch' "$WORK/typo.err" \
+  || { cat "$WORK/typo.err" >&2; fail "the refusal does not name the root"; }
+ok "tree --root: a node that does not exist refuses"
+
+# 11. The same edges as a dependency-structure matrix, which is the
+# whole surface at once where the tree is one chain at a time (Sangal
+# et al., OOPSLA 2005).
+draw diagram-matrix.txt matrix --primary dependsOn "$DIR/model.aon"
+ok "the dependency-structure matrix draws: twelve modules square"
+
+# 12. THE RENDERER TERMINATES ON THE MODEL THE ENGINE REFUSES. The
+# cyclic document still evaluates -- the graph atoms' verdict lands at
+# generation -- so a drawing tool is handed cyclic edge sets in
+# practice, and marks the closing edge instead of recursing into it.
+draw diagram-tree-cycle.txt tree --primary dependsOn "$DIR/bad/cycle.aon"
+has_cycle="$(grep -c '(cycle)' "$WORK/diagram-tree-cycle.txt")"
+[ "$has_cycle" -ge 1 ] \
+  || fail "the cyclic model should draw a (cycle) mark"
+ok "the tree of a cyclic model terminates, marking the closing edge"
+
+# 13. The model answers ordinary queries about itself.
+run get 0 -- get '$.mods.http.layer' "$DIR/model.aon"
+has get out '"core"'
+run getdir 0 -- get '$.mods.store.dir' "$DIR/model.aon"
+has getdir out '"core/store"'
+ok "get: layer and directory read straight off the model"
+
+echo "all $pass checks passed"

--- a/use-cases/16-module-deps/check.sh
+++ b/use-cases/16-module-deps/check.sh
@@ -62,6 +62,16 @@ has upward err '[aontu/empty]'
 has upward err 'Cannot unify value: "core"|"util" with value: "feature"'
 ok "upward dependency: core on feature refuses, naming both layers"
 
+# 3b. THE SAME EDGE, WRITTEN THE OTHER WAY ROUND, IS ACCEPTED. Which
+# target shape reaches the far end of an edge depends on the order the
+# blocks are written in, so the rule above holds for the spelling
+# above and not for its mirror image. This assertion pins what the
+# engine does TODAY, as a known miss: it fails, loudly, the day the
+# flow stops depending on declaration order -- which is the point of
+# pinning it.
+run swapped 0 -- "$DIR/bad/upward-swapped.aon"
+ok "KNOWN MISS: the same upward edge, blocks swapped, still generates"
+
 # 4. A cycle between two util modules -- legal by layer, refused by
 # acyclic() -- reports at generation and from the verb, naming the
 # loop it runs through.

--- a/use-cases/16-module-deps/expected/diagram-matrix.txt
+++ b/use-cases/16-module-deps/expected/diagram-matrix.txt
@@ -1,0 +1,13 @@
+             1  2  3  4  5  6  7  8  9 10 11 12
+auth      1  \  .  X  .  .  .  X  .  .  .  .  .
+billing   2  X  \  .  .  .  X  .  .  .  .  X  .
+bytes     3  .  .  \  .  .  .  .  .  .  .  .  .
+catalog   4  .  .  .  \  .  .  X  .  .  .  X  .
+cli       5  .  X  .  .  \  .  .  .  X  .  .  .
+clock     6  .  .  .  .  .  \  .  .  .  .  .  .
+http      7  .  .  X  .  .  .  \  X  .  .  .  .
+log       8  .  .  X  .  .  .  .  \  .  .  .  .
+reports   9  .  .  .  .  .  .  .  X  \  .  X  .
+server   10  .  X  .  X  .  .  X  .  .  \  .  .
+store    11  .  .  .  .  .  X  .  X  .  .  \  .
+worker   12  .  .  .  .  .  .  .  .  X  .  X  \

--- a/use-cases/16-module-deps/expected/diagram-tree-billing.txt
+++ b/use-cases/16-module-deps/expected/diagram-tree-billing.txt
@@ -1,0 +1,11 @@
+billing
+├── auth
+│   ├── bytes
+│   └── http
+│       ├── bytes
+│       └── log
+│           └── bytes
+├── clock
+└── store
+    ├── clock
+    └── log (*)

--- a/use-cases/16-module-deps/expected/diagram-tree-cycle.txt
+++ b/use-cases/16-module-deps/expected/diagram-tree-cycle.txt
@@ -1,0 +1,27 @@
+cli
+├── billing
+│   ├── auth
+│   │   ├── bytes
+│   │   │   └── log
+│   │   │       └── bytes (cycle)
+│   │   └── http
+│   │       ├── bytes (*)
+│   │       └── log (*)
+│   ├── clock
+│   └── store
+│       ├── clock
+│       └── log (*)
+└── reports
+    ├── log (*)
+    └── store (*)
+
+server
+├── billing (*)
+├── catalog
+│   ├── http (*)
+│   └── store (*)
+└── http (*)
+
+worker
+├── reports (*)
+└── store (*)

--- a/use-cases/16-module-deps/expected/diagram-tree.txt
+++ b/use-cases/16-module-deps/expected/diagram-tree.txt
@@ -1,0 +1,26 @@
+cli
+├── billing
+│   ├── auth
+│   │   ├── bytes
+│   │   └── http
+│   │       ├── bytes
+│   │       └── log
+│   │           └── bytes
+│   ├── clock
+│   └── store
+│       ├── clock
+│       └── log (*)
+└── reports
+    ├── log (*)
+    └── store (*)
+
+server
+├── billing (*)
+├── catalog
+│   ├── http (*)
+│   └── store (*)
+└── http (*)
+
+worker
+├── reports (*)
+└── store (*)

--- a/use-cases/16-module-deps/expected/model.json
+++ b/use-cases/16-module-deps/expected/model.json
@@ -1,0 +1,144 @@
+{
+  "mods": {
+    "auth": {
+      "dependsOn": [
+        "$.mods.bytes",
+        "$.mods.http"
+      ],
+      "dir": "core/auth",
+      "kind": "mod",
+      "layer": "core",
+      "usedBy": [
+        "$.mods.billing"
+      ]
+    },
+    "billing": {
+      "dependsOn": [
+        "$.mods.auth",
+        "$.mods.clock",
+        "$.mods.store"
+      ],
+      "dir": "feat/billing",
+      "kind": "mod",
+      "layer": "feature",
+      "usedBy": [
+        "$.mods.cli",
+        "$.mods.server"
+      ]
+    },
+    "bytes": {
+      "dir": "util/bytes",
+      "kind": "mod",
+      "layer": "util",
+      "usedBy": [
+        "$.mods.auth",
+        "$.mods.http",
+        "$.mods.log"
+      ]
+    },
+    "catalog": {
+      "dependsOn": [
+        "$.mods.http",
+        "$.mods.store"
+      ],
+      "dir": "feat/catalog",
+      "kind": "mod",
+      "layer": "feature",
+      "usedBy": [
+        "$.mods.server"
+      ]
+    },
+    "cli": {
+      "dependsOn": [
+        "$.mods.billing",
+        "$.mods.reports"
+      ],
+      "dir": "cmd/cli",
+      "kind": "mod",
+      "layer": "app"
+    },
+    "clock": {
+      "dir": "util/clock",
+      "kind": "mod",
+      "layer": "util",
+      "usedBy": [
+        "$.mods.billing",
+        "$.mods.store"
+      ]
+    },
+    "http": {
+      "dependsOn": [
+        "$.mods.bytes",
+        "$.mods.log"
+      ],
+      "dir": "core/http",
+      "kind": "mod",
+      "layer": "core",
+      "usedBy": [
+        "$.mods.auth",
+        "$.mods.catalog",
+        "$.mods.server"
+      ]
+    },
+    "log": {
+      "dependsOn": [
+        "$.mods.bytes"
+      ],
+      "dir": "util/log",
+      "kind": "mod",
+      "layer": "util",
+      "usedBy": [
+        "$.mods.http",
+        "$.mods.reports",
+        "$.mods.store"
+      ]
+    },
+    "reports": {
+      "dependsOn": [
+        "$.mods.log",
+        "$.mods.store"
+      ],
+      "dir": "feat/reports",
+      "kind": "mod",
+      "layer": "feature",
+      "usedBy": [
+        "$.mods.cli",
+        "$.mods.worker"
+      ]
+    },
+    "server": {
+      "dependsOn": [
+        "$.mods.billing",
+        "$.mods.catalog",
+        "$.mods.http"
+      ],
+      "dir": "cmd/server",
+      "kind": "mod",
+      "layer": "app"
+    },
+    "store": {
+      "dependsOn": [
+        "$.mods.clock",
+        "$.mods.log"
+      ],
+      "dir": "core/store",
+      "kind": "mod",
+      "layer": "core",
+      "usedBy": [
+        "$.mods.billing",
+        "$.mods.catalog",
+        "$.mods.reports",
+        "$.mods.worker"
+      ]
+    },
+    "worker": {
+      "dependsOn": [
+        "$.mods.reports",
+        "$.mods.store"
+      ],
+      "dir": "cmd/worker",
+      "kind": "mod",
+      "layer": "app"
+    }
+  }
+}

--- a/use-cases/16-module-deps/model.aon
+++ b/use-cases/16-module-deps/model.aon
@@ -1,0 +1,5 @@
+# model.aon --- THE ROOT: one evaluation joining the vocabulary and
+# the codebase. The layering rule is enforced by the join itself --
+# there is nothing else to run.
+@"./spec.aon"
+@"./modules.aon"

--- a/use-cases/16-module-deps/modules.aon
+++ b/use-cases/16-module-deps/modules.aon
@@ -1,0 +1,96 @@
+# modules.aon --- the codebase: twelve modules across four layers, and
+# which module builds on which. Every module names its LAYER SHAPE
+# (spec.aon), which is how it declares its layer and, with it, what it
+# is allowed to depend on.
+#
+# Both directions of every edge are written out. Deriving the inverse
+# FOR the author is generation, not validation, and inverse() only
+# checks -- so a module that is depended upon says so itself, and the
+# two lists are held to each other at generation.
+mods: {
+
+  # --- app: the deployables. Nothing depends on these, which is what
+  # makes them the roots of the dependency tree.
+  cli: $.spec.App & {
+    dir: "cmd/cli"
+    dependsOn: [path($.mods.billing), path($.mods.reports)]
+  }
+
+  server: $.spec.App & {
+    dir: "cmd/server"
+    dependsOn: [
+      path($.mods.billing), path($.mods.catalog), path($.mods.http)
+    ]
+  }
+
+  worker: $.spec.App & {
+    dir: "cmd/worker"
+    dependsOn: [path($.mods.reports), path($.mods.store)]
+  }
+
+  # --- feature: one business capability each.
+  billing: $.spec.Feature & {
+    dir: "feat/billing"
+    usedBy: [path($.mods.cli), path($.mods.server)]
+    dependsOn: [
+      path($.mods.auth), path($.mods.clock), path($.mods.store)
+    ]
+  }
+
+  catalog: $.spec.Feature & {
+    dir: "feat/catalog"
+    usedBy: [path($.mods.server)]
+    dependsOn: [path($.mods.http), path($.mods.store)]
+  }
+
+  reports: $.spec.Feature & {
+    dir: "feat/reports"
+    usedBy: [path($.mods.cli), path($.mods.worker)]
+    dependsOn: [path($.mods.log), path($.mods.store)]
+  }
+
+  # --- core: shared machinery. `auth` depends on `http`, which is a
+  # SIDEWAYS edge and legal: the rule is never upward.
+  auth: $.spec.Core & {
+    dir: "core/auth"
+    usedBy: [path($.mods.billing)]
+    dependsOn: [path($.mods.bytes), path($.mods.http)]
+  }
+
+  http: $.spec.Core & {
+    dir: "core/http"
+    usedBy: [
+      path($.mods.auth), path($.mods.catalog), path($.mods.server)
+    ]
+    dependsOn: [path($.mods.bytes), path($.mods.log)]
+  }
+
+  store: $.spec.Core & {
+    dir: "core/store"
+    usedBy: [
+      path($.mods.billing), path($.mods.catalog), path($.mods.reports),
+      path($.mods.worker)
+    ]
+    dependsOn: [path($.mods.clock), path($.mods.log)]
+  }
+
+  # --- util: leaves, or nearly. `log` on `bytes` is the other legal
+  # sideways edge.
+  bytes: $.spec.Util & {
+    dir: "util/bytes"
+    usedBy: [path($.mods.auth), path($.mods.http), path($.mods.log)]
+  }
+
+  clock: $.spec.Util & {
+    dir: "util/clock"
+    usedBy: [path($.mods.billing), path($.mods.store)]
+  }
+
+  log: $.spec.Util & {
+    dir: "util/log"
+    usedBy: [
+      path($.mods.http), path($.mods.reports), path($.mods.store)
+    ]
+    dependsOn: [path($.mods.bytes)]
+  }
+}

--- a/use-cases/16-module-deps/spec.aon
+++ b/use-cases/16-module-deps/spec.aon
@@ -1,0 +1,46 @@
+# spec.aon --- the module vocabulary, and the LAYERING RULE, declared
+# once. There is no linter and no plugin here: the rule is a shape,
+# and rel(t) flows that shape into every module a dependency names, so
+# an illegal edge is an ordinary failed meet at the far end.
+#
+# The layers, highest first: app depends on anything, feature on
+# feature and below, core on core and below, util on util alone. The
+# rule is NEVER UPWARD rather than strictly downward -- a core module
+# calling another core module is ordinary engineering -- and what
+# stops a sideways edge from closing a loop is acyclic(), not the
+# layer.
+spec: hide({
+
+  Mod: {
+    kind: mod
+    dir: string
+    layer: "app" | "feature" | "core" | "util"
+
+    # The relation, declared at its field (RELATIONS.0.md): rel(t)
+    # makes the field's entries checked tree addresses and flows t
+    # into every target; acyclic() and inverse() are the graph atoms,
+    # registered during unification and DECIDED at generation, where
+    # every edge is known.
+    dependsOn?: rel($.spec.ModShape) & acyclic() & inverse(usedBy)
+    usedBy?: rel($.spec.ModShape)
+  }
+
+  # What the far end of any edge must be. A thin shape rather than
+  # $.spec.Mod itself: a self-typed rel($.spec.Mod) inside Mod is the
+  # guarded self-reference whose rel-side wiring waits on the
+  # recursion note's next phase.
+  ModShape: { kind: mod }
+
+  # ONE SHAPE PER LAYER, and the whole architecture is the four
+  # disjunctions below. A module declares its layer by naming its
+  # shape; the shape narrows what its dependsOn edges may land on.
+  App:     $.spec.Mod & { layer: "app",     dependsOn?: rel($.spec.AppDep) }
+  Feature: $.spec.Mod & { layer: "feature", dependsOn?: rel($.spec.FeatureDep) }
+  Core:    $.spec.Mod & { layer: "core",    dependsOn?: rel($.spec.CoreDep) }
+  Util:    $.spec.Mod & { layer: "util",    dependsOn?: rel($.spec.UtilDep) }
+
+  AppDep:     { kind: mod, layer: "app" | "feature" | "core" | "util" }
+  FeatureDep: { kind: mod, layer: "feature" | "core" | "util" }
+  CoreDep:    { kind: mod, layer: "core" | "util" }
+  UtilDep:    { kind: mod, layer: "util" }
+})

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -60,7 +60,9 @@ and, in case 09, `MCP` — to point at a different build.
 ## Diagrams
 
 Five cases carry generated diagrams, pinned as goldens by their
-`check.sh` and rendered inline in their README (GitHub draws Mermaid):
+`check.sh` and rendered inline in their README — as Mermaid, which
+GitHub draws, or as fixed-pitch text where the figure is character
+cells (the dependency tree and the matrix):
 
 | case | views |
 |---|---|

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,6 +1,6 @@
 # Use cases: practical validation of Aontu as an agent-facing ground truth
 
-This folder is a **review artifact**: fifteen enterprise-shaped use cases,
+This folder is a **review artifact**: sixteen enterprise-shaped use cases,
 each built as real Aontu models and then *executed* against the
 TypeScript CLI (`ts/bin/aontu.js`, the canonical implementation, at the
 in-tree 0.53.0 line). Every case directory carries a `check.sh` that
@@ -55,10 +55,11 @@ and, in case 09, `MCP` — to point at a different build.
 | [13-recursive-schema](13-recursive-schema/) | Approval chain: a schema one reference deep over any-depth data | recursive residuals (`$.spec.Step`), mu-form canon + hash, `recursion_unexpanded`, `vet --at` over plain JSON |
 | [14-jsonschema-export](14-jsonschema-export/) | JSON Schema as the bridge out: MCP inputSchema, OpenAPI, stock validators | `jsonschema --at`/`--strict`/`--format json`, the stderr loss report, exit classes, the money-wire `const` mark |
 | [15-code-generation](15-code-generation/) | The model as the source of the code: Go, TypeScript and SQL from one catalogue, each over a slice | list-spread + `pick` line building, backtick target text, `match` type mapping, both-ports byte parity, the missing fold |
+| [16-module-deps](16-module-deps/) | A codebase's own module graph: four layers, no upward dependencies, drawn as a dependency tree | `rel(t)` target-shape flow as an architecture rule, `acyclic()`/`inverse(n)`, `reaches`, the tree and matrix views |
 
 ## Diagrams
 
-Four cases carry generated diagrams, pinned as goldens by their
+Five cases carry generated diagrams, pinned as goldens by their
 `check.sh` and rendered inline in their README (GitHub draws Mermaid):
 
 | case | views |
@@ -67,6 +68,7 @@ Four cases carry generated diagrams, pinned as goldens by their
 | [04-schema-evolution](04-schema-evolution/) | subsumption poset over the releases and proposals |
 | [08-feature-flags](08-feature-flags/) | the meet ladder for one arbitrated value |
 | [12-relations](12-relations/) | entity graph with inverse pairs collapsed, and an ER diagram |
+| [16-module-deps](16-module-deps/) | dependency tree with elided repeats and derived roots, dependency-structure matrix |
 
 [`tools/diagram.js`](tools/diagram.js) draws them. **There is no
 `aontu view` verb**: the capability is designed in
@@ -78,10 +80,12 @@ design is tested against real models before any of it becomes code. It
 computes no coordinates and sorts everything by code point, so its
 output is deterministic text and a golden diff is a meaningful check.
 
-Drawing the models found two defects that the text verbs had not:
+Drawing the models found three defects that the text verbs had not:
 [BUGS 65](BUGS.md) (a `refer()` behind a conjunct is invisible to the
-entity graph, so `reaches` answers wrongly) and the inverse-doubling
-that makes a raw `graphOf` edge set draw every declared inverse twice.
+entity graph, so `reaches` answers wrongly), the inverse-doubling
+that makes a raw `graphOf` edge set draw every declared inverse twice,
+and — from case 16 — a collapse that folded a MUTUAL dependency into
+one undirected edge, hiding the shortest cycle a model can have.
 
 ## Scope and conventions
 

--- a/use-cases/run-all.sh
+++ b/use-cases/run-all.sh
@@ -25,6 +25,7 @@ CASES="
 13-recursive-schema
 14-jsonschema-export
 15-code-generation
+16-module-deps
 "
 
 fail=0

--- a/use-cases/tools/diagram.js
+++ b/use-cases/tools/diagram.js
@@ -83,38 +83,23 @@ function edges(val, primary) {
 
   const out = []
   for (const group of pairs.values()) {
-    const keysFrom = new Map()
-    for (const e of group) {
-      const seen = keysFrom.get(e.key)
-      if (null == seen) keysFrom.set(e.key, new Set([e.from]))
-      else seen.add(e.from)
-    }
-
-    // A key written in both directions stands on its own, in both.
-    const mutual = [...keysFrom.keys()].filter((k) => 1 < keysFrom.get(k).size)
-    for (const k of mutual.sort(cmp)) {
-      for (const e of group.filter((x) => x.key === k)) {
-        out.push({ from: e.from, to: e.to, label: k })
-      }
-    }
-
-    // Everything else is the inverse case: one logical edge, drawn in
-    // the direction the named primary predicate is written in;
-    // otherwise the code-point-least key's direction, which is
-    // arbitrary but stable.
-    const rest = group.filter((e) => !mutual.includes(e.key))
-    if (0 === rest.length) continue
-    const keys = [...new Set(rest.map((e) => e.key))].sort(cmp)
+    // ONE KEY WINS THE PAIR, and every edge written under it stands.
+    // The named primary predicate wins; otherwise the code-point-least
+    // key, which is arbitrary but stable. Keeping every edge under the
+    // winner is what preserves a MUTUAL relation -- `a dependsOn b`
+    // with `b dependsOn a` is two facts, and the shortest cycle a
+    // model can have -- while the losing keys are the declared
+    // inverses, implied by the winner and not drawn again.
+    const keys = [...new Set(group.map((e) => e.key))].sort(cmp)
     const chosen = keys.filter((k) => primary.includes(k))
     const winner = 0 < chosen.length ? chosen[0] : keys[0]
-    const lead = rest.filter((e) => e.key === winner)[0]
-    out.push({
-      // With a primary named, the inverse is implied and naming both
-      // just doubles the label. Without one, both are shown, because
-      // picking silently would hide that two predicates are in play.
-      from: lead.from, to: lead.to,
-      label: 0 < chosen.length ? chosen.join('/') : keys.join('/'),
-    })
+    // With a primary named, the inverse is implied and naming both
+    // just doubles the label. Without one, both are shown, because
+    // picking silently would hide that two predicates are in play.
+    const label = 0 < chosen.length ? chosen.join('/') : keys.join('/')
+    for (const e of group.filter((x) => x.key === winner)) {
+      out.push({ from: e.from, to: e.to, label })
+    }
   }
 
   return out.sort((x, y) =>
@@ -223,8 +208,12 @@ function matrix(val, primary) {
   const out = []
   out.push(pad('', w + 2 + iw + 1) + idx.map((s) => lpad(s, iw)).join(' '))
   ns.forEach((n, r) => {
+    // The diagonal is the node itself, and a SELF-DEPENDENCY is drawn
+    // on it: writing the placeholder unconditionally erased the
+    // shortest cycle a model can have, which is exactly the fact a
+    // dependency matrix is read for.
     const cells = ns.map((m, c) =>
-      lpad(r === c ? '\\' : (has.has(n + '\u0000' + m) ? 'X' : '.'), iw))
+      lpad(has.has(n + '\u0000' + m) ? 'X' : (r === c ? '\\' : '.'), iw))
     out.push(pad(label(n), w) + '  ' + lpad(idx[r], iw) + ' ' + cells.join(' '))
   })
   return out.join('\n')
@@ -287,15 +276,24 @@ function tree(val, primary, roots) {
   // label each edge; a tree cannot without becoming unreadable, and
   // walking two relations as though they were one would draw a
   // containment that the model does not state.
-  const kept = edges(val, primary).filter((e) =>
+  const all_edges = edges(val, primary)
+  const kept = all_edges.filter((e) =>
     0 === primary.length
     || e.label.split('/').some((k) => primary.includes(k)))
 
+  // A NAMED RELATION THAT DRAWS NOTHING IS A TYPO, and refused for the
+  // same reason a misspelled `--root` is: an empty tree and a
+  // misspelled name are the same file on disk, so the one that means
+  // nothing must not be renderable.
+  if (0 === kept.length && 0 < all_edges.length) {
+    const have = [...new Set(all_edges.flatMap((e) => e.label.split('/')))]
+    throw new Error('no such relation: ' + primary.join('/')
+      + ' (the graph has ' + have.sort(cmp).join(', ') + ')')
+  }
+
   // The node set is what the drawn relation CONNECTS, the rule the
   // node-link kinds follow above. A `--root` naming anything else is a
-  // typo, and it is refused rather than drawn: an empty tree and a
-  // misspelled address look identical in a golden file, so the one
-  // that means nothing must not be renderable.
+  // typo, and it is refused rather than drawn.
   const ns = new Set()
   for (const e of kept) {
     ns.add(e.from)
@@ -317,8 +315,9 @@ function tree(val, primary, roots) {
   // exactly one is noise; leaving it off where there are two would
   // hide which edge was walked.
   const many = 1 < new Set(kept.map((e) => e.label)).size
+  const byLabel = (a, b) => cmp(lab.get(a), lab.get(b))
 
-  let start
+  let named
   if (0 < roots.length) {
     for (const r of roots) {
       if (!ns.has(r)) {
@@ -327,47 +326,79 @@ function tree(val, primary, roots) {
           + 'graph has ' + all.length + ')')
       }
     }
-    start = roots.slice().sort((a, b) => cmp(lab.get(a), lab.get(b)))
+    named = [...new Set(roots)].sort(byLabel)
   }
   else {
-    const depended = new Set(kept.map((e) => e.to))
-    start = all.filter((n) => !depended.has(n))
-      .sort((a, b) => cmp(lab.get(a), lab.get(b)))
-    // Every node depended upon by another: the graph is one or more
-    // cycles and has no top. Drawing from every node is the honest
-    // answer -- the `(cycle)` marks then say where the loops close.
-    if (0 === start.length) {
-      start = all.slice().sort((a, b) => cmp(lab.get(a), lab.get(b)))
-    }
+    // A root is a node nothing depends on. A SELF-EDGE does not make a
+    // node depended upon for this purpose: a module that names itself
+    // would otherwise stop being a root and take its whole subtree out
+    // of the drawing.
+    const depended = new Set(
+      kept.filter((e) => e.to !== e.from).map((e) => e.to))
+    named = all.filter((n) => !depended.has(n)).sort(byLabel)
   }
 
   const out = []
   const expanded = new Set()
 
-  const walk = (node, prefix, chain) => {
-    const list = kids.get(node) || []
-    list.forEach((edge, i) => {
-      const last = i === list.length - 1
-      const loop = chain.includes(edge.to)
-      const seen = expanded.has(edge.to)
-      const grown = 0 < (kids.get(edge.to) || []).length
-      const mark = loop ? ' (cycle)' : (seen && grown ? ' (*)' : '')
-      out.push(prefix + (last ? '└── ' : '├── ')
-        + lab.get(edge.to)
-        + (many ? ' (' + edge.label + ')' : '')
-        + mark)
-      if (loop || seen) return
-      expanded.add(edge.to)
-      walk(edge.to, prefix + (last ? '    ' : '│   '), [...chain, edge.to])
-    })
-  }
-
-  start.forEach((root, i) => {
-    if (0 < i) out.push('')
+  const draw = (root) => {
+    if (0 < out.length) out.push('')
     out.push(lab.get(root))
     expanded.add(root)
-    walk(root, '', [root])
-  })
+
+    // ITERATIVE, with the ancestor chain carried as a set that is
+    // added to on the way down and removed from on the way up. A
+    // recursive walk is O(depth) stack frames and a deep dependency
+    // chain is a real shape, so the drawing of a model must not depend
+    // on how deep the interpreter lets it go.
+    const chain = new Set([root])
+    const stack = [{ node: root, prefix: '', at: 0 }]
+    while (0 < stack.length) {
+      const frame = stack[stack.length - 1]
+      const list = kids.get(frame.node) || []
+      if (frame.at >= list.length) {
+        chain.delete(frame.node)
+        stack.pop()
+        continue
+      }
+      const edge = list[frame.at++]
+      const last = frame.at === list.length
+      const loop = chain.has(edge.to)
+      const seen = expanded.has(edge.to)
+      const grown = 0 < (kids.get(edge.to) || []).length
+      out.push(frame.prefix + (last ? '└── ' : '├── ')
+        + lab.get(edge.to)
+        + (many ? ' (' + edge.label + ')' : '')
+        + (loop ? ' (cycle)' : (seen && grown ? ' (*)' : '')))
+      if (loop || seen) continue
+      expanded.add(edge.to)
+      chain.add(edge.to)
+      stack.push({
+        node: edge.to,
+        prefix: frame.prefix + (last ? '    ' : '│   '),
+        at: 0,
+      })
+    }
+  }
+
+  for (const root of named) {
+    draw(root)
+  }
+
+  // EVERY NODE IS DRAWN. A component whose nodes all depend on each
+  // other has no node nothing depends on, so the derived roots miss it
+  // entirely -- and a graph with roots elsewhere would drop it in
+  // silence, which is the one thing a drawing must not do. The
+  // least-labelled node left is taken as a root of its own, until
+  // nothing is left. An explicitly named `--root` is a request for one
+  // subtree and is left alone.
+  if (0 === roots.length) {
+    for (const n of all) {
+      if (!expanded.has(n)) {
+        draw(n)
+      }
+    }
+  }
 
   return out.join('\n')
 }

--- a/use-cases/tools/diagram.js
+++ b/use-cases/tools/diagram.js
@@ -23,6 +23,7 @@
 //   node diagram.js graph  [--primary KEY]... <entry.aon>
 //   node diagram.js matrix [--primary KEY]... <entry.aon>
 //   node diagram.js er     [--primary KEY]... <entry.aon>
+//   node diagram.js tree   [--primary KEY]... [--root <$.a.b>]... <entry.aon>
 //   node diagram.js ladder --path <$.a.b> <entry.aon>
 //   node diagram.js poset  [--at <path>] [--profile P] <file.aon>...
 //
@@ -55,50 +56,69 @@ function load(file) {
 // edge. `graphOf` reports every written position, so a relation with a
 // declared inverse arrives twice -- once per direction -- and drawing
 // it raw doubles every such relation.
+//
+// WHAT IS NOT COLLAPSED IS A MUTUAL RELATION: `a dependsOn b` and `b
+// dependsOn a` are two facts under ONE key, and folding them into a
+// single undirected edge erases the shortest cycle a model can have.
+// The collapse is therefore per KEY PAIR rather than per node pair --
+// two keys facing each other are an inverse, one key facing itself is
+// a loop -- which is what makes `acyclic()`'s refusal drawable.
 function edges(val, primary) {
   const g = A.graphOf(val)
-  const seen = new Map()
 
+  // One directed edge per (from, to, key): the same link written at
+  // several positions is one fact about the graph.
+  const directed = new Map()
   for (const e of g.edges) {
-    // The unordered pair is the identity of the logical edge.
-    const pair = [e.from, e.to].sort(cmp).join('\u0000')
-    const prev = seen.get(pair)
-    if (null == prev) {
-      seen.set(pair, { from: e.from, to: e.to, keys: [e.key] })
-      continue
-    }
-    if (!prev.keys.includes(e.key)) {
-      prev.keys.push(e.key)
-    }
-    // Direction: the named primary predicate wins; otherwise the
-    // code-point-least key, which is arbitrary but stable.
-    const winner = prev.keys.filter((k) => primary.includes(k)).sort(cmp)[0]
-    if (null != winner) {
-      if (e.key === winner) {
-        prev.from = e.from
-        prev.to = e.to
-      }
-    }
-    else if (cmp(e.key, prev.keys.slice().sort(cmp)[0]) <= 0
-      && e.key === prev.keys.slice().sort(cmp)[0]) {
-      prev.from = e.from
-      prev.to = e.to
-    }
+    directed.set(e.from + '\u0000' + e.to + '\u0000' + e.key, e)
   }
 
-  return [...seen.values()]
-    .map((e) => {
-      const keys = e.keys.sort(cmp)
+  const pairs = new Map()
+  for (const e of directed.values()) {
+    const pair = [e.from, e.to].sort(cmp).join('\u0000')
+    const group = pairs.get(pair)
+    if (null == group) pairs.set(pair, [e])
+    else group.push(e)
+  }
+
+  const out = []
+  for (const group of pairs.values()) {
+    const keysFrom = new Map()
+    for (const e of group) {
+      const seen = keysFrom.get(e.key)
+      if (null == seen) keysFrom.set(e.key, new Set([e.from]))
+      else seen.add(e.from)
+    }
+
+    // A key written in both directions stands on its own, in both.
+    const mutual = [...keysFrom.keys()].filter((k) => 1 < keysFrom.get(k).size)
+    for (const k of mutual.sort(cmp)) {
+      for (const e of group.filter((x) => x.key === k)) {
+        out.push({ from: e.from, to: e.to, label: k })
+      }
+    }
+
+    // Everything else is the inverse case: one logical edge, drawn in
+    // the direction the named primary predicate is written in;
+    // otherwise the code-point-least key's direction, which is
+    // arbitrary but stable.
+    const rest = group.filter((e) => !mutual.includes(e.key))
+    if (0 === rest.length) continue
+    const keys = [...new Set(rest.map((e) => e.key))].sort(cmp)
+    const chosen = keys.filter((k) => primary.includes(k))
+    const winner = 0 < chosen.length ? chosen[0] : keys[0]
+    const lead = rest.filter((e) => e.key === winner)[0]
+    out.push({
       // With a primary named, the inverse is implied and naming both
       // just doubles the label. Without one, both are shown, because
       // picking silently would hide that two predicates are in play.
-      const chosen = keys.filter((k) => primary.includes(k))
-      return {
-        from: e.from, to: e.to,
-        label: 0 < chosen.length ? chosen.join('/') : keys.join('/'),
-      }
+      from: lead.from, to: lead.to,
+      label: 0 < chosen.length ? chosen.join('/') : keys.join('/'),
     })
-    .sort((x, y) => cmp(x.from, y.from) || cmp(x.to, y.to) || cmp(x.label, y.label))
+  }
+
+  return out.sort((x, y) =>
+    cmp(x.from, y.from) || cmp(x.to, y.to) || cmp(x.label, y.label))
 }
 
 
@@ -242,6 +262,117 @@ function er(val, primary) {
 }
 
 
+// THE DEPENDENCY TREE: the same edges, walked from a root, indented.
+//
+// A dependency graph is a DAG and not a tree -- two modules may share
+// a dependency, and drawing that shared node once under each parent is
+// what makes `cargo tree` and `npm ls` readable rather than
+// exponential. So this is a SPANNING WALK with two honest marks:
+// `(*)` where a subtree is elided because the node was expanded
+// earlier, and `(cycle)` where an edge closes a loop. The first is
+// routine in a correct model -- a diamond is good engineering, not a
+// fault. The second cannot arise from a model whose relation declares
+// `acyclic()`, and is drawn rather than thrown because a renderer that
+// hangs on a hostile input is a renderer that cannot be pointed at
+// one.
+//
+// Which nodes are roots is DERIVED, not asked for: a root is a node
+// nothing depends on. `--root` overrides that to draw one subtree.
+// The order of everything -- roots, children, the choice of which
+// occurrence of a shared node is the expanded one -- follows the label
+// sort, so the drawing is a function of the model alone.
+function tree(val, primary, roots) {
+  // With a primary named, the tree is OVER THAT RELATION. The other
+  // kinds draw every relation at once because a node-link diagram can
+  // label each edge; a tree cannot without becoming unreadable, and
+  // walking two relations as though they were one would draw a
+  // containment that the model does not state.
+  const kept = edges(val, primary).filter((e) =>
+    0 === primary.length
+    || e.label.split('/').some((k) => primary.includes(k)))
+
+  // The node set is what the drawn relation CONNECTS, the rule the
+  // node-link kinds follow above. A `--root` naming anything else is a
+  // typo, and it is refused rather than drawn: an empty tree and a
+  // misspelled address look identical in a golden file, so the one
+  // that means nothing must not be renderable.
+  const ns = new Set()
+  for (const e of kept) {
+    ns.add(e.from)
+    ns.add(e.to)
+  }
+  const all = [...ns].sort(cmp)
+  const lab = labels(all)
+
+  const kids = new Map(all.map((n) => [n, []]))
+  for (const e of kept) {
+    kids.get(e.from).push({ to: e.to, label: e.label })
+  }
+  for (const list of kids.values()) {
+    list.sort((x, y) => cmp(lab.get(x.to), lab.get(y.to)) || cmp(x.label, y.label))
+  }
+
+  // The relation is named on the branch only where more than one is
+  // drawn. Naming the single relation on every line of a tree that has
+  // exactly one is noise; leaving it off where there are two would
+  // hide which edge was walked.
+  const many = 1 < new Set(kept.map((e) => e.label)).size
+
+  let start
+  if (0 < roots.length) {
+    for (const r of roots) {
+      if (!ns.has(r)) {
+        throw new Error('no such node: ' + r
+          + ' (the ' + (0 < primary.length ? primary.join('/') + ' ' : '')
+          + 'graph has ' + all.length + ')')
+      }
+    }
+    start = roots.slice().sort((a, b) => cmp(lab.get(a), lab.get(b)))
+  }
+  else {
+    const depended = new Set(kept.map((e) => e.to))
+    start = all.filter((n) => !depended.has(n))
+      .sort((a, b) => cmp(lab.get(a), lab.get(b)))
+    // Every node depended upon by another: the graph is one or more
+    // cycles and has no top. Drawing from every node is the honest
+    // answer -- the `(cycle)` marks then say where the loops close.
+    if (0 === start.length) {
+      start = all.slice().sort((a, b) => cmp(lab.get(a), lab.get(b)))
+    }
+  }
+
+  const out = []
+  const expanded = new Set()
+
+  const walk = (node, prefix, chain) => {
+    const list = kids.get(node) || []
+    list.forEach((edge, i) => {
+      const last = i === list.length - 1
+      const loop = chain.includes(edge.to)
+      const seen = expanded.has(edge.to)
+      const grown = 0 < (kids.get(edge.to) || []).length
+      const mark = loop ? ' (cycle)' : (seen && grown ? ' (*)' : '')
+      out.push(prefix + (last ? '└── ' : '├── ')
+        + lab.get(edge.to)
+        + (many ? ' (' + edge.label + ')' : '')
+        + mark)
+      if (loop || seen) return
+      expanded.add(edge.to)
+      walk(edge.to, prefix + (last ? '    ' : '│   '), [...chain, edge.to])
+    })
+  }
+
+  start.forEach((root, i) => {
+    if (0 < i) out.push('')
+    out.push(lab.get(root))
+    expanded.add(root)
+    walk(root, '', [root])
+  })
+
+  return out.join('\n')
+}
+
+
 // The meet ladder: the descent from `top` through each contribution to
 // the resolved value. `why`'s conjunct list is in the order the
 // recorder saw the meets, which is NOT rank order, so it is sorted --
@@ -370,10 +501,12 @@ function main(argv) {
   const kind = argv[0]
   const rest = argv.slice(1)
   const primary = []
+  const roots = []
   let at, profile, path
   const files = []
   for (let i = 0; i < rest.length; i++) {
     if ('--primary' === rest[i]) { primary.push(rest[++i]) }
+    else if ('--root' === rest[i]) { roots.push(rest[++i]) }
     else if ('--at' === rest[i]) { at = rest[++i] }
     else if ('--profile' === rest[i]) { profile = rest[++i] }
     else if ('--path' === rest[i]) { path = rest[++i] }
@@ -390,8 +523,9 @@ function main(argv) {
   if ('graph' === kind) return graph(val, primary)
   if ('matrix' === kind) return matrix(val, primary)
   if ('er' === kind) return er(val, primary)
+  if ('tree' === kind) return tree(val, primary, roots)
   throw new Error('unknown kind: ' + kind
-    + ' (graph | matrix | er | ladder | poset)')
+    + ' (graph | matrix | er | tree | ladder | poset)')
 }
 
 


### PR DESCRIPTION
## What

A sixteenth use case, `use-cases/16-module-deps/`: a codebase's own module graph — twelve modules across four layers, twenty-one dependencies — with the architecture rule that nothing depends on a layer above it. Plus a `tree` kind in the diagram generator to draw it.

## The layering rule is a shape

`rel(t)` flows a per-layer target shape into every module an edge names, so a core module's `dependsOn` carries `layer: "core" | "util"` to the far end and a module that says `layer: "feature"` cannot meet it. An upward edge is an ordinary failed meet at generation, with both sides named:

```
[aontu/empty]: Cannot unify values at path $.mods.auth.dependsOn.0.usedBy.0.dependsOn.layer
 Cannot unify value: "core"|"util" with value: "feature"
```

A sideways edge (`auth` on `http`) is legal; what refuses a loop between two same-layer modules is `acyclic()`. There is no linter and no second pass.

## The tree kind

`node use-cases/tools/diagram.js tree [--primary KEY]... [--root $.a.b]... <entry.aon>` emits an indented dependency tree:

```
cli
├── billing
│   ├── auth
│   │   ├── bytes
│   │   └── http
│   │       ├── bytes
│   │       └── log
│   │           └── bytes
│   ├── clock
│   └── store
│       ├── clock
│       └── log (*)
└── reports
    ├── log (*)
    └── store (*)
```

- **Roots are derived**, not asked for: a root is a module nothing depends on, which for a codebase is exactly its deployables.
- **`(*)` is an elided repeat.** A dependency graph is a DAG, so a full expansion would redraw a shared subtree once per path into it — the rule `cargo tree` and `npm ls` use, for the same reason.
- **`(cycle)` marks a loop-closing edge** instead of recursing into it. The cyclic document still evaluates (the graph atoms' verdict lands at generation), so a drawing tool is handed cyclic edge sets in practice; the golden pins that the renderer terminates.
- `--root` draws one subtree; a `--root` naming no node refuses, because an empty tree and a typo look identical in a golden file.

Deterministic like the other kinds: everything sorts by code point, no coordinate is computed, output is text and pinned by golden diff.

## A defect the case found

`edges()` collapses the two written directions of a declared inverse into one logical edge, or every relation with an `inverse(n)` would draw twice. It keyed on the **node** pair, so `a dependsOn b` together with `b dependsOn a` — one key facing itself, the shortest cycle a model can have — also folded into a single undirected edge, and the loop vanished from every view. The collapse is now per **key** pair: two keys facing each other are an inverse, one key facing itself is two facts. All four existing diagram goldens are byte-identical after the fix.

## Assertions

`16-module-deps/check.sh` — 13 checks: generation golden, `relations` verdict, the layering refusal, a cycle between same-layer modules, a missing inverse, a dangling address, `reaches` both ways, the tree golden (three roots, nine elisions), the `--root` subtree and its typo refusal, the matrix golden, the cyclic model's `(cycle)` mark, and `get`.

## Records

`use-cases/README.md` (both tables, and the "defects found by drawing" note), `docs/use-cases.md` (new section), `CHANGELOG.md`, and the case counts — `README.md`, `.github/workflows/build.yml`, and `llms.txt`, which was stale at eleven.

## Gates

- `make test`: 4556 tests, 0 failures.
- `use-cases/run-all.sh`: 16/16 cases pass (`16-module-deps ok (all 13 checks passed)`).
- Website: `npm run check` passes with the case synced (a separate PR on `aontu-lang/web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134jDLqcNikx1RFsuT6hjPg

---
_Generated by [Claude Code](https://claude.ai/code/session_0134jDLqcNikx1RFsuT6hjPg)_