### PR TITLE
G10's artifact channel is superseded, and the phase is not renamed yet

### DIFF
--- a/docs/capability-review/g10-transparency.md
+++ b/docs/capability-review/g10-transparency.md
@@ -191,6 +191,60 @@ the canon-hash locally and fails closed — which
 independent observer; it is to make a claim **permanent, public, and
 impossible to silently retract**.
 
+### The artifact channel is superseded, 2026-09-03
+
+**D's OCI channel is foreclosed by a constraint set after this review:
+the project will not run an OCI registry and will not store module
+bytes, and bytes live on the forge.** The transparency layer above is
+unaffected -- what changes is where the artifact comes from.
+
+Read the paragraph above with that in mind, because half its reasoning
+no longer holds. D was preferred to C partly because "an OCI registry is
+contractually obliged to keep bytes that a forge tag is not"; with bytes
+on a forge, that availability argument is gone and the honest position
+is C's own §60 -- the log can prove what a release was without being
+able to provide it. `aontu mod vendor` is the answer, and it is
+consumer-side discipline rather than an ecosystem guarantee.
+
+The three grounds on which C was rejected do not all survive the change
+either. Ground 3 -- that fetching source is the entire cost -- was an
+objection to **the service** downloading source, and a client fetching
+from a forge while the service records only publisher-asserted claims is
+a different proposition. Ground 2 -- that both ports enforce one pin and
+have no byte-digest verification path -- was an objection to **adding**
+one, and the replacement design adds none: `ts/src/mod.ts` already
+checks meaning alone, and the `oci` field is a registry assertion
+nothing local reads. Ground 1, module paths against forge paths, stands
+unchanged.
+
+The successor design, with the three decisions it turns on and a
+sequence whose first phase is decision-independent, is
+[`aontu-lang/system`'s `docs/design/DISTRIBUTION.0.md`](https://github.com/aontu-lang/system/blob/main/docs/design/DISTRIBUTION.0.md).
+**Nothing here is amended until that design is accepted**, per the
+register's protocol that a status changes in the commit that changes it.
+Two consequences are already certain and are recorded so they are not
+discovered late:
+
+- **`aontu mod manifest` is orphaned.** It builds an OCI manifest, with
+  an OCI config media type and a layer of the module's source tree, for
+  a channel that will not exist. It is repurposed to a forge release
+  manifest or retired; either way its `--against` breaking gate is worth
+  keeping, because that gate is [G3](g3-subsumption-evolution.md) and
+  independent of the channel.
+- **The `oci` digest in `mod-lock.aon`** loses the meaning its own
+  comment gives it, "the bytes the registry served".
+
+One defect surfaced while writing the successor, and it is this
+document's to record because it is about what the pin covers. The
+canon-hash covers the **entry file's** evaluated meaning, but
+`mod vendor` copies the whole source tree and `layerFiles` walks the
+whole source tree. **A file evaluation never reaches is unpinned and
+still lands, committed, in a consumer's repository.** Nothing executes
+it -- the trust contract holds -- but an editor, an agent, a generator
+or a later version of the module may read it. A file manifest recorded
+by `tidy` and checked by `verify` closes it as a list comparison rather
+than a second hashing algebra.
+
 ## Proposed design
 
 ### The leaf

--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -1561,8 +1561,24 @@ permits **once** and bounds with five constraints — no artifacts, no
 log on the path of a locked build, public replicability in a standard
 format, the client half in both ports under ADR-001, and a stated exit.
 
-**Phases 1 and 2 have landed.** Phases 3–6 are NOT STARTED, and the
-a commitment, and phases 2–6 are NOT STARTED.
+**Phases 1 and 2 have landed. Phases 3–6 are NOT STARTED.** The format
+is the commitment rather than the contents, which is why phase 2 is
+useful with no log running: the client verifies checkpoints and proofs a
+lockfile already carries.
+
+**2026-09-03: phase 3's channel is superseded, and the phase is not
+renamed until the successor is accepted.** A constraint set after this
+gap was drafted rules out running an OCI registry or storing module
+bytes, and puts bytes on the forge, so "`mod get` and `mod publish` over
+OCI" names a channel that will not exist. The reasoning is in
+[g10-transparency.md](g10-transparency.md#the-artifact-channel-is-superseded-2026-09-03)
+and the successor design is
+[`aontu-lang/system`'s `DISTRIBUTION.0.md`](https://github.com/aontu-lang/system/blob/main/docs/design/DISTRIBUTION.0.md),
+which turns on three decisions nobody has taken yet. The rows below are
+left as they are on purpose: a status changes in the commit that changes
+it, and no status has changed. What has changed is that phase 3's pin
+describes a plan its own constraints have overtaken, and a reader should
+know that before costing it.
 
 Baseline at drafting, for protocol rule 5: `ls test/spec/*.tsv | wc -l`
 = **97**, `awk -F'\t' 'NF>2 && $0 !~ /^#/' test/spec/*.tsv | wc -l`


### PR DESCRIPTION
## Summary

A constraint set after G10 was drafted rules out running an OCI registry
or storing module bytes: **bytes live on the forge.** That forecloses
design D's artifact channel.

This records the supersession and **amends nothing else.** The successor
design turns on three decisions nobody has taken, so every phase row
keeps its status — a status changes in the commit that changes it. What
a reader gains is knowing that G10 phase 3's pin describes a plan its own
constraints have overtaken, *before* costing it.

## Why half the D-over-C reasoning no longer holds

D was preferred to C partly because "an OCI registry is contractually
obliged to keep bytes that a forge tag is not". With bytes on a forge
that availability argument is gone, and the honest position is C's own
§60: the log can prove what a release was without being able to provide
it. `aontu mod vendor` is the answer, and it is consumer-side discipline
rather than an ecosystem guarantee.

Two of the three rejection grounds also do not survive the change, and
the note says which and why:

- **Ground 3** objected to *the service* downloading source. A client
  fetching from a forge, while the service records only
  publisher-asserted claims, is a different proposition.
- **Ground 2** objected to *adding* a byte-digest verification path. The
  successor adds none: `ts/src/mod.ts` already checks meaning alone, and
  the `oci` field is a registry assertion nothing local reads.
- **Ground 1**, module paths against forge paths, stands unchanged.

## A defect recorded, because it is about what the pin covers

The canon-hash covers the **entry file's** evaluated meaning, but
`mod vendor` copies the whole source tree and `layerFiles` walks the
whole source tree. **A file evaluation never reaches is unpinned and
still lands, committed, in a consumer's repository.** Nothing executes it
— the trust contract holds — but an editor, an agent or a generator may
read it. A file manifest recorded by `tidy` and checked by `verify`
closes it as a list comparison rather than a second hashing algebra.

## Incidental fix

The G10 register section had a garbled paragraph: two sentence fragments
spliced in the original G10 commit (`2a83223`) — "Phases 3–6 are NOT
STARTED, and the / a commitment, and phases 2–6 are NOT STARTED" — whose
second half also stated a phase count that stopped being true when phase
2 landed.

## Test plan

- [x] `make test` — 4979 tests, both ports, exit 0
- [x] `make prose` — 0 errors over 68 files (`docs/capability-review/`
      is outside the gated set by design, but the pages were written to
      the same rules)

The successor design is
[`aontu-lang/system#1`](https://github.com/aontu-lang/system/pull/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcpMaTu6y8EmR3zmCMJBCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcpMaTu6y8EmR3zmCMJBCB)_