### PR TITLE
make install: the clone on PATH, each build by its own toolchain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Both languages at once, from the repo root:
 make build      # build-ts + build-go
 make test       # test-ts  + test-go
 make            # build then test
+make install    # install-ts + install-go: this clone on PATH (npm link, go install)
 make prose      # the Vale prose gate (needs `vale` on PATH)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ which implementation each change affects.
 
 ## Unreleased
 
+### `make install`: the clone on `PATH`
+
+`make install` at the repository root puts both builds on `PATH` from
+the clone, each by its own toolchain: `make install-ts` links the
+checkout as the global npm package (`npm link`, so `make build-ts`
+updates the command in place) and `make install-go` runs `go install`
+for `aontu` and `aontu-lsp`. Both builds provide `aontu`, so `PATH`
+order decides which one answers and `aontu --version` says which did.
+The README, the CLI how-to, the API reference and AGENTS.md name the
+targets. The from-a-clone command in the README and the API reference
+is now `node ts/bin/aontu.js`, the executable entry; the `dist/cli.js`
+they named has no entry guard and printed nothing. Both
+implementations.
+
 ### Generated project state lives under `aontu_meta/`
 
 Everything the tools write into a project now lives in one folder:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all build test clean build-ts build-go test-ts test-go clean-ts clean-go \
+        install install-ts install-go \
         publish publish-go check-go-major tags-go reset cov cov-ts cov-go sig \
         prose
 
@@ -9,6 +10,32 @@ build: build-ts build-go
 test: test-ts test-go
 
 clean: clean-ts clean-go
+
+# INSTALL FROM THE CLONE, EACH BUILD BY ITS OWN TOOLCHAIN.
+#
+#   make install       # both
+#   make install-ts    # npm link: the global `aontu` IS this checkout
+#   make install-go    # go install: a build of ./cmd/aontu and ./cmd/aontu-lsp
+#
+# The two builds ship the same commands under the same names, and each
+# toolchain puts them where it always does -- npm's global bin
+# (`npm prefix -g`/bin, so this needs the write access `npm install -g`
+# needs) and Go's (`go env GOBIN`, else GOPATH/bin). With both installed,
+# PATH order decides which `aontu` answers and `aontu --version` says
+# which did: the npm series or the Go series. The TypeScript install is
+# a LINK, so `make build-ts` updates it in place; the Go install is a
+# build, so rerun `make install-go` after a change. Undo with
+# `npm uninstall -g aontu` and by deleting the two Go binaries.
+install: install-ts install-go
+
+install-ts: build-ts
+	cd ts && npm link --no-audit --no-fund
+	@echo "install-ts: aontu, aontu-lsp and aontu-mcp in $$(npm prefix -g)/bin link to $(CURDIR)/ts"
+
+install-go:
+	cd go && go install ./cmd/aontu ./cmd/aontu-lsp
+	@bin=$$(cd go && go env GOBIN); [ -n "$$bin" ] || bin=$$(cd go && go env GOPATH)/bin; \
+	  echo "install-go: aontu and aontu-lsp built into $$bin"
 
 # The prose gate (see docs/STYLE-GUIDE.md). Vale over the reader-facing
 # pages, at the levels set in .vale.ini, on the same file list

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ implementations). See [AGENTS.md](AGENTS.md) and
 [docs/shared-spec.md](docs/shared-spec.md).
 
 ```sh
-make build   # build both (ts + go)
-make test    # test both against the shared spec
+make build     # build both (ts + go)
+make test      # test both against the shared spec
+make install   # put both builds on PATH from this clone (npm link, go install)
 ```
 
 ### Repository layout
@@ -79,7 +80,10 @@ toolchain; with a package or archive from the
 image `ghcr.io/aontu-lang/aontu`, the Nix flake, or the setup action
 `aontu-lang/aontu/setup-action` in a workflow; or with
 `go install github.com/aontu-lang/aontu/go/cmd/aontu@latest` (Go). From a
-clone: `node ts/dist/cli.js …` or, inside `go/`, `go run ./cmd/aontu …`.
+clone, `make install` puts both builds on `PATH`: `make install-ts` links
+the checkout as the global npm package and `make install-go` runs
+`go install` for the two commands. Without installing:
+`node ts/bin/aontu.js …` or, inside `go/`, `go run ./cmd/aontu …`.
 
 ## Documentation
 

--- a/docs/how-to/run-cli-and-repl.md
+++ b/docs/how-to/run-cli-and-repl.md
@@ -97,8 +97,14 @@ server (the Go builds bring the standalone `aontu-lsp` binary too).
 - `go install github.com/aontu-lang/aontu/go/cmd/aontu@latest` with a
   Go toolchain.
 
-From a clone: `node ts/bin/aontu.js …`, or `go run ./cmd/aontu …`
-inside `go/`. Both accept the same options and print the same bytes.
+From a clone, `make install` puts both builds on `PATH`, each by its
+own toolchain: `make install-ts` links the checkout as the global npm
+package, so `make build-ts` updates the command in place, and
+`make install-go` runs `go install` for `aontu` and `aontu-lsp`. Both
+builds provide `aontu`, so `PATH` order decides which one answers and
+`aontu --version` says which did. Without installing:
+`node ts/bin/aontu.js …`, or `go run ./cmd/aontu …` inside `go/`. Both
+accept the same options and print the same bytes.
 
 The full option, verb and REPL-command tables are in the
 [CLI reference](../reference-api.md#command-line-interface). To keep

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -2146,12 +2146,15 @@ one that does not pays nothing. Diagnostics are unchanged either way.
 **Getting the command**
 
 - **TypeScript:** the npm package declares a `bin` named `aontu`
-  (`dist/cli.js`), so `npm install -g aontu` (or `npx aontu`) provides
-  it. From a clone: `node ts/dist/cli.js …`.
+  (`bin/aontu.js`), so `npm install -g aontu` (or `npx aontu`) provides
+  it. From a clone: `make install-ts`, an `npm link` of the checkout,
+  or `node ts/bin/aontu.js …` without installing.
 - **Go:** `go install github.com/aontu-lang/aontu/go/cmd/aontu@latest`, or
-  from a clone: `go run ./cmd/aontu …` (inside `go/`).
+  from a clone: `make install-go`, a `go install` of `aontu` and
+  `aontu-lsp`, or `go run ./cmd/aontu …` inside `go/`.
 
-Both commands accept the same options and produce the same results.
+`make install` at the root of a clone does both. Both commands accept
+the same options and produce the same results.
 
 ---
 


### PR DESCRIPTION
`make install` at the repository root puts both builds on `PATH` from the clone, each by the toolchain that owns it.

## The targets

- **`make install-ts`** builds (`build-ts`) and then links the checkout as the global npm package with `npm link --no-audit --no-fund`: `aontu`, `aontu-lsp` and `aontu-mcp` in `npm prefix -g`/bin point at `ts/`, so `make build-ts` updates the command in place. The audit is skipped because it is meaningless for a link and, on a slow registry hour, turned a one-second link into a five-minute one (measured here: 5 m with it, 0.4 s without).
- **`make install-go`** runs `go install ./cmd/aontu ./cmd/aontu-lsp` inside `go/`, into `go env GOBIN` or `GOPATH/bin`; it is a build, so rerun it after a change.
- **`make install`** does both. The two builds ship `aontu` under the same name, so `PATH` order decides which one answers and `aontu --version` says which did (the npm series or the Go series). The Makefile comment says so, names the write access `install-ts` needs (the same as `npm install -g`), and how to undo each.

## Docs

The README, the CLI how-to, the API reference and AGENTS.md name the targets beside the from-a-clone commands. The README and the API reference said to run `node ts/dist/cli.js …` from a clone, which prints nothing: `dist/cli.js` has no entry guard, on purpose, so the in-process coverage runs count every line. Both now name the executable entry, `ts/bin/aontu.js`, as the how-to already did. The CHANGELOG records the targets under both implementations.

## Verification

- Both targets were run from a clean checkout of main: the Go build answers `0.1.14` from `GOPATH/bin`; the linked npm build resolves to `/…/aontu/ts`, answers `0.56.0` and evaluates a document.
- The rebuild that `install-ts` runs leaves the committed `ts/dist` unchanged; `npm uninstall -g aontu` removes every link.
- `ts/test/docs.test.ts` passes 20 of 20 and Vale is clean on the three gated pages. No source changed in either port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9)_