### PR TITLE
ADR-022, and the module/package distinction in both guides

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -2286,10 +2286,42 @@ bytes" is no longer a reason it cannot check anything.
    `corp.example/schemas/service`, not `corp.example/schemas/service@1`.
 
 2. **The repository refuses a publish that is not backwards compatible
-   with its predecessor**, decided by subsumption rather than asserted
-   by a version number. A genuine break therefore requires a new name,
-   chosen by the publisher — but only when the break is real and
-   verified, not whenever an author fears one.
+   with its predecessor**, decided rather than asserted by a version
+   number. **Compatibility has three components, and all three must
+   hold:**
+
+   | | Requires | Answered by |
+   |---|---|---|
+   | **Acceptance** | The new version admits every document the old one admitted | Subsumption |
+   | **Determination** | Every position the old version resolved to a value, the new one still resolves | Canonical-form comparison |
+   | **Agreement** | Where both resolve a position, they resolve it to the same value | Canonical-form comparison |
+
+   Together these say what a consumer actually needs: **any document
+   that evaluated successfully under the old version evaluates
+   successfully under the new one, to the same value.**
+
+   Subsumption alone gives only the first, and an earlier draft of this
+   entry stopped there and called it strict. It is not. `a: integer`
+   subsumes `a: 8080` — the check passes — while the old version
+   produces `{"a": 8080}` and the new one refuses with
+   `[aontu/mapval_no_gen]`, so a consumer who supplied nothing had a
+   working build and now has an error. Acceptance and outcome are
+   different questions, and for a language whose payload is a *value*
+   it is outcome that consumers depend on.
+
+   Components 2 and 3 are a structural walk rather than a new theory:
+   evaluate both versions standalone, take `hcanon` of each, and
+   classify every difference as **constraint-only** (outcome-neutral,
+   passes) or **outcome-affecting** (a determined value appeared,
+   vanished or changed). **The check is conservative: where it cannot
+   prove a difference outcome-neutral, it refuses.** For packages with
+   conditional or computed structure, "for every consumer input" is not
+   decidable in general, and refusing is the correct direction for a
+   guarantee that claims to be strict.
+
+   A genuine break therefore requires a new name, chosen by the
+   publisher — but only when the break is real and verified, not
+   whenever an author fears one.
 
 3. **ADR-019's constraint 5 is amended.** The service still **fetches
    nothing** — that is what keeps the ingestion threat model deleted,
@@ -2326,14 +2358,20 @@ is one evaluation per publish rather than per read, and the deterministic
 evaluation budget applies. That budget is therefore now a **server**
 requirement and not only a client one.
 
-**We accept that subsumption does not cover defaults.** If
-`port: integer & *8080` becomes `integer & *9090`, the admitted set is
-unchanged, so the check passes — and every consumer relying on the
-default gets a different value. That is the hostile-value class arriving
-through a compatible release. The publish check needs a defaults report
-alongside subsumption, surfaced and acknowledged rather than silently
-allowed; this is named here because it is the gap a reader would
-otherwise assume closed.
+**Defaults are covered by component 3, not left as a gap.** An earlier
+draft of this entry recorded "subsumption does not cover defaults" as an
+accepted hole: `port: integer & *8080` becoming `integer & *9090` leaves
+the admitted set identical, so a subsumption-only check passes while
+every consumer relying on the default gets a different value. That is
+the hostile-value class arriving through a nominally compatible release,
+and it is not something to accept — it is the reason the definition has
+three parts. Agreement refuses it.
+
+**We accept that "declared" still needs a shape.** A publisher who
+genuinely intends an outcome change has two possible routes — a new
+name, or an acknowledgement that consumers see at resolve time — and
+this entry does not choose between them. What it fixes is that the
+change cannot happen *silently*.
 
 **We accept a migration diagnostic.** With `./` mandatory, a bare
 `@"foo.aon"` classifies as a package and would fail with "package not
@@ -2342,20 +2380,23 @@ mistake. A reference whose final segment carries a known file extension
 and no `./` refuses with *"local files need a `./` prefix"*. Routing
 stays a shape rule; only the error is special-cased.
 
-**Aliased versions must occupy different subtrees, and defaults are
-why.** Constraints meet without trouble — `integer & 8080` is `8080`,
-the narrower — so it is tempting to say two aliased versions can safely
-meet. **They cannot, and the reason is the paragraph above.** Two
-defaults of the same rank do not unify: `*8080 & *9090` refuses with
-`pref_rank_clash`, because defaults are not ordered by subsumption and
-so have no meet. The consumer can rank one (`**9090`) to say
-deliberately which layer is weaker, and otherwise the two versions must
-never meet.
+**Aliased versions may meet, and component 3 is why.** An earlier
+draft required separate subtrees. Constraints meet without trouble —
+`integer & 8080` is `8080`, the narrower — but two aliased versions
+could still clash on a **default**, and under a subsumption-only
+definition nothing prevented it: `*8080 & *9090` refuses with
+`pref_rank_clash`, defaults having no meet of their own.
 
-This is one gap, not two. Defaults sit outside the subsumption order,
-which is both why the publish check cannot see a changed default and why
-two versions carrying different defaults contradict rather than
-combining.
+**Component 3 removes the restriction**: versions
+sharing a name now agree wherever both determine a value, so the clash
+cannot arise between them. A consumer may still rank a default
+(`**9090`) to state deliberately which layer is weaker, but nothing
+forces the separation.
+
+The reasoning here reversed twice while this entry was drafted, and why
+is worth recording: **whether two versions can meet is downstream of
+whether the compatibility check covers outcomes.** It was never an
+independent question about aliases.
 
 **What this supersedes and what survives.** ADR-020's part 2 (two
 admission tiers), part 3 (a host must prove ownership and issue a

--- a/ADR.md
+++ b/ADR.md
@@ -2327,13 +2327,13 @@ evaluation budget applies. That budget is therefore now a **server**
 requirement and not only a client one.
 
 **We accept that subsumption does not cover defaults.** If
-`port: integer = 8080` becomes `= 9090`, the admitted set is unchanged,
-so the check passes — and every consumer relying on the default gets a
-different value. That is the hostile-value class arriving through a
-compatible release. The publish check needs a defaults report alongside
-subsumption, surfaced and acknowledged rather than silently allowed;
-this is named here because it is the gap a reader would otherwise
-assume closed.
+`port: integer & *8080` becomes `integer & *9090`, the admitted set is
+unchanged, so the check passes — and every consumer relying on the
+default gets a different value. That is the hostile-value class arriving
+through a compatible release. The publish check needs a defaults report
+alongside subsumption, surfaced and acknowledged rather than silently
+allowed; this is named here because it is the gap a reader would
+otherwise assume closed.
 
 **We accept a migration diagnostic.** With `./` mandatory, a bare
 `@"foo.aon"` classifies as a package and would fail with "package not
@@ -2342,11 +2342,20 @@ mistake. A reference whose final segment carries a known file extension
 and no `./` refuses with *"local files need a `./` prefix"*. Routing
 stays a shape rule; only the error is special-cased.
 
-**Aliases do not create contradictions.** An earlier draft claimed two
-versions of one package meeting in a document would conflict. They do
-not: with compatibility enforced, `1.2 ∧ 1.4` is simply `1.2`, the
-narrower. Different subtrees is the ordinary usage; meeting is also
-well-defined.
+**Aliased versions must occupy different subtrees, and defaults are
+why.** Constraints meet without trouble — `integer & 8080` is `8080`,
+the narrower — so it is tempting to say two aliased versions can safely
+meet. **They cannot, and the reason is the paragraph above.** Two
+defaults of the same rank do not unify: `*8080 & *9090` refuses with
+`pref_rank_clash`, because defaults are not ordered by subsumption and
+so have no meet. The consumer can rank one (`**9090`) to say
+deliberately which layer is weaker, and otherwise the two versions must
+never meet.
+
+This is one gap, not two. Defaults sit outside the subsumption order,
+which is both why the publish check cannot see a changed default and why
+two versions carrying different defaults contradict rather than
+combining.
 
 **What this supersedes and what survives.** ADR-020's part 2 (two
 admission tiers), part 3 (a host must prove ownership and issue a

--- a/ADR.md
+++ b/ADR.md
@@ -38,6 +38,7 @@ ADR-NNN**, so the reasoning that led there stays readable.
 | [ADR-019](#adr-019--the-project-stores-module-bytes-and-federates-the-log) | The project stores module bytes, and federates the log | Accepted |
 | [ADR-020](#adr-020--a-module-path-is-domainpath-and-the-domain-is-a-proved-namespace) | A module path is `<domain>/<path>`, and the domain is a proved namespace | Accepted |
 | [ADR-021](#adr-021--the-project-hosts-private-packages-with-authenticated-reads) | The project hosts private packages, with authenticated reads | Accepted |
+| [ADR-022](#adr-022--compatibility-is-computed-so-the-major-leaves-the-name) | Compatibility is computed, so the major leaves the name | Accepted |
 
 ---
 
@@ -1837,6 +1838,16 @@ inherits:
    allowlist, no observation queue, no negative caching — and reversing
    it re-opens all of it. A repository that evaluated submissions would
    be running attacker-chosen input through the evaluator on a server.
+   *(Amended same day by
+   [ADR-022](#adr-022--compatibility-is-computed-so-the-major-leaves-the-name):
+   **the fetching half is untouched** and is what deletes the ingestion
+   threat model. Evaluation is now permitted **at publish only** — on
+   authenticated input, under a deterministic budget, once per publish —
+   so that backwards compatibility can be enforced rather than trusted.
+   Never at read, never on unauthenticated input. The concern this
+   clause names is answered rather than dismissed: publication requires
+   a proved namespace, so the input is not attacker-chosen in the sense
+   that mattered when the service also held no bytes.)*
 6. **It operates no transparency log.** Identity, signing and the log
    are Sigstore's: Fulcio for publisher identity, Rekor v2 for the log,
    the Sigstore bundle as the stored proof, the TUF trust root for
@@ -1902,7 +1913,14 @@ in `aontu-lang/system`; status is the
 ## ADR-020 — A module path is `<domain>/<path>`, and the domain is a proved namespace
 
 **Date:** 2026-09-04
-**Status:** Accepted
+**Status:** Superseded in part, same day, by
+[ADR-022](#adr-022--compatibility-is-computed-so-the-major-leaves-the-name).
+**The major version leaves the path**, because subsumption decides
+backwards compatibility and the repository enforces it — so the naming
+scheme no longer has to make the unsafe substitution unspellable. Parts
+2, 3, 4 and 6 are unchanged, and part 1 is reinforced rather than
+disturbed: with the major gone, the last piece of resolution semantics
+leaves the string, and the path is purely a name.
 
 ### Context
 
@@ -2210,3 +2228,139 @@ changes nothing about what they are permitted to do.
 The design, its seven constraints and the four questions it leaves open
 are `REPOSITORY.0.md` §10.6 in `aontu-lang/system`; status is the
 [progress register](docs/capability-review/progress.md).
+
+---
+
+## ADR-022 — Compatibility is computed, so the major leaves the name
+
+**Date:** 2026-09-04
+**Status:** Accepted
+
+### Context
+
+[ADR-020](#adr-020--a-module-path-is-domainpath-and-the-domain-is-a-proved-namespace)
+put the major version in the path, Go-style, and the design note called
+that "what makes MVS sound". **That overstated it**, and the correction
+is the whole of this entry.
+
+Minimum version selection **substitutes upward**: a dependency that asks
+for `core` 1.1.0 is handed 1.3.0 when something else asked for that, and
+it was never tested against it. So MVS is only safe under the *import
+compatibility rule* — a newer version must work wherever an older one
+did. Nor can the claim travel with each requirement, because **MVS has
+no upper bounds**: npm's `^1.1.0` says "and not 2.x", while an MVS
+requirement is a bare minimum. The compatibility claim has to come from
+somewhere else entirely, and putting the major in the name is one way to
+supply it: `@1` and `@2` become different packages, so the unsafe
+substitution is unspellable.
+
+It is not the only way, and for this project it is the weaker one.
+
+**In Go, a SemVer major is a promise the toolchain cannot check.**
+Nothing verifies that v1.3.0 really is compatible with v1.1.0; the
+version number is trusted. Most major bumps are therefore precautionary
+— published because the author *thinks* something broke.
+
+**Here it is decidable.** [G3](docs/capability-review/g3-subsumption-evolution.md)
+subsumption answers exactly the question the rule asks: does every
+instance the old version admits, the new one admit too? Two properties
+make that compose:
+
+- **Subsumption is transitive**, so checking each version against only
+  its immediate predecessor establishes compatibility with *every*
+  predecessor. One check per publish, not one per pair.
+- **Unification is monotone** — loosening a conjunct loosens the meet —
+  so pairwise-enforced compatibility yields **closure-wide**
+  compatibility with no extra work.
+
+One premise also changed underneath the earlier reasoning.
+[ADR-019](#adr-019--the-project-stores-module-bytes-and-federates-the-log)
+made the repository store the source, so "the service does not have the
+bytes" is no longer a reason it cannot check anything.
+
+### Decision
+
+**Compatibility is computed and enforced, so the major leaves the name.**
+
+1. **A package path carries no major version.**
+   `corp.example/schemas/service`, not `corp.example/schemas/service@1`.
+
+2. **The repository refuses a publish that is not backwards compatible
+   with its predecessor**, decided by subsumption rather than asserted
+   by a version number. A genuine break therefore requires a new name,
+   chosen by the publisher — but only when the break is real and
+   verified, not whenever an author fears one.
+
+3. **ADR-019's constraint 5 is amended.** The service still **fetches
+   nothing** — that is what keeps the ingestion threat model deleted,
+   and it is untouched — but it **may evaluate at publish**: on
+   authenticated input only, under a deterministic budget, one
+   evaluation per publish. Never at read, and never on unauthenticated
+   input.
+
+4. **Every reference self-describes**, and nothing is inferred from
+   absence:
+
+   | Form | Means |
+   |---|---|
+   | `corp.example/schemas/service` | a package |
+   | `./f.aon`, `../g.json`, `/abs/h.aon` | a local file |
+   | `alias:legacy` | a package alias |
+
+   A local file reference **must** carry `./`, `../` or `/`. This is
+   what removes the ambiguity the major used to resolve by accident: a
+   bare `foo.aon` is domain-shaped enough to look like a package, and
+   the leading `./` is what tells the two apart.
+
+5. **Coexistence is by alias, declared by the consumer.** A project that
+   genuinely needs two versions of one package names the second itself,
+   rather than every publisher encoding "somebody might need two of me"
+   in their name forever.
+
+### Consequences
+
+**We accept an evaluator on the publish path.** A server-side evaluator
+defect becomes reachable by an authenticated publisher. It is bounded by
+three things — publication requires a proved namespace under ADR-020, it
+is one evaluation per publish rather than per read, and the deterministic
+evaluation budget applies. That budget is therefore now a **server**
+requirement and not only a client one.
+
+**We accept that subsumption does not cover defaults.** If
+`port: integer = 8080` becomes `= 9090`, the admitted set is unchanged,
+so the check passes — and every consumer relying on the default gets a
+different value. That is the hostile-value class arriving through a
+compatible release. The publish check needs a defaults report alongside
+subsumption, surfaced and acknowledged rather than silently allowed;
+this is named here because it is the gap a reader would otherwise
+assume closed.
+
+**We accept a migration diagnostic.** With `./` mandatory, a bare
+`@"foo.aon"` classifies as a package and would fail with "package not
+found", which is the wrong message for what will be the commonest
+mistake. A reference whose final segment carries a known file extension
+and no `./` refuses with *"local files need a `./` prefix"*. Routing
+stays a shape rule; only the error is special-cased.
+
+**Aliases do not create contradictions.** An earlier draft claimed two
+versions of one package meeting in a document would conflict. They do
+not: with compatibility enforced, `1.2 ∧ 1.4` is simply `1.2`, the
+narrower. Different subtrees is the ordinary usage; meeting is also
+well-defined.
+
+**What this supersedes and what survives.** ADR-020's part 2 (two
+admission tiers), part 3 (a host must prove ownership and issue a
+stable identifier), part 4 (the subject is an identifier pair) and part
+6 (renames by one signed forward link) are unchanged. Its part 1 — the
+path is a name and never a fetch instruction — is not merely unchanged
+but reinforced, since dropping the major removes the last piece of
+resolution semantics from the string. Only the major-in-path element
+goes.
+
+**What this does not license.** Evaluation at read, in any tier, for any
+purpose. Evaluation of unauthenticated input. And it does not weaken
+ADR-019's constraint 5 on **fetching**, which is the half that deletes
+the ingestion threat model and is untouched here.
+
+The design is `CLI.0.md` §3.3 and `REPOSITORY.0.md` §3a in
+`aontu-lang/system`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,33 @@ user-facing rules are in
 
 ## Conventions
 
+### Module and package are different words
+
+**A module is imported. A package is published.** They are not
+synonyms, and the codebase currently gets this wrong in one visible
+place — the `aontu mod` verbs operate on packages.
+
+- A **module** is a language element: what `@"acme.example/schema@1"`
+  names, what `resolveModule` resolves, what `canonHash` pins, what
+  unifies into a document.
+- A **package** is a unit of publication: a versioned, signed archive
+  of one or more modules, usually exactly one. It is what a repository
+  stores, what a version and a signature cover, what a quota counts,
+  and what is retracted or tombstoned.
+
+Write "package repository", "publish a package", "the package's
+dependencies". Never "module registry" or "publish a module". The rule
+applies to code comments, identifiers, error messages, commit messages
+and documentation alike; `docs/STYLE-GUIDE.md` carries the same rule
+for published prose.
+
+**Go uses the two words the other way round** — its module is the
+published collection and its package is a directory inside one. Aontu
+cannot follow, because "module" is already the language element in both
+ports, in the import syntax and in `MODULE_RE`. So a phrase that sounds
+right to a Go user may be wrong here: check which side of the
+import/publish line the thing is on rather than trusting the ear.
+
 - Keep new TypeScript code in the style of the surrounding `ts/src` files.
 - Go is `package aontu`; exported API is `New().Parse/Unify/Generate`.
   Run `go vet ./...` and `gofmt` before committing.

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -394,6 +394,19 @@ generated** — declared in `ts/scripts/figures.cjs`, written to
 
 - The language and project are **Aontu** (capital A) in prose; the
   command is `aontu`.
+- **module / package**—these are not synonyms and must never be
+  swapped. A **module** is a language element: what `@"…"` names, what
+  an import resolves, what the canon-hash pins, what unifies into a
+  document. A **package** is a unit of publication: a versioned,
+  signed archive of one or more modules, usually one. So a module is
+  *imported* and a package is *published*; a package is what a
+  repository stores, a version bears, a quota counts and a signature
+  covers. Write "package repository", "publish a package", "the
+  package's dependencies"; never "module registry" or "publish a
+  module". **Go uses the two words the other way round**, so a
+  sentence that reads naturally to a Go user may be wrong here — check
+  which side of the import/publish line the thing sits on rather than
+  trusting the ear.
 - **unification / unify**—the operation. Not "merging" except when
   introducing the idea to newcomers, and then once.
 - **meet**—the operation named as order theory names it. It is a


### PR DESCRIPTION
Four commits. Documentation only — no code, no spec rows, no coverage change.

## ADR-022 — compatibility is computed, so the major leaves the name

ADR-020 put the major version in the path and the design note called that *"what makes MVS sound"*. **That overstated it**, and the correction is the entry.

MVS **substitutes upward** — a dependency asking for `core` 1.1.0 is handed 1.3.0 — so it is only safe under the import compatibility rule. And the claim cannot travel with each requirement, because **MVS has no upper bounds**: npm's `^1.1.0` says "and not 2.x", an MVS requirement says nothing about a ceiling. So the guarantee has to come from outside the requirement. Go puts it in the name, where it is a promise the toolchain cannot check and most major bumps are precautionary.

**Here it is decidable.** So: no major in the path, and the repository **refuses a publish that is not backwards compatible**. A real break still needs a new name, but only when the break is verified rather than feared.

## Compatibility is three components, and subsumption is one

The entry first defined compatibility *as* subsumption and called it strict. It is not, and the counterexample involves no defaults at all — measured against the engine, not reasoned about:

```
subsume("a: integer", "a: 8080")  →  verdict: subsumes      ← PASSES
old, standalone  →  { "a": 8080 }
new, standalone  →  [aontu/mapval_no_gen]: Cannot resolve value at $.a
```

Widening a concrete value to a type passes the check and turns a working consumer build into an error. Subsumption decides **acceptance**; a configuration consumer depends on **outcome**. For a language whose payload is a value, outcome is the question. Decision part 2 now requires all three:

| | Requires | Answered by |
|---|---|---|
| **Acceptance** | New admits every document old admitted | Subsumption |
| **Determination** | Everything old resolved, new still resolves | Canonical-form comparison |
| **Agreement** | Where both resolve, they resolve the same | Canonical-form comparison |

Together: **any document that evaluated successfully under the old version evaluates successfully under the new one, to the same value.** The check is **conservative** — where it cannot prove a difference outcome-neutral it refuses, because "for every consumer input" is not decidable in general.

Two properties keep it cheap rather than quadratic: **subsumption is transitive**, so one check against the immediate predecessor establishes compatibility with every predecessor; and **unification is monotone**, so pairwise compatibility yields closure-wide compatibility for free. No other ecosystem can make that argument.

**Two consequences change with the third component.** The "subsumption does not cover defaults" hole the entry originally *accepted* is no longer a hole — agreement refuses a changed default, so it was never something to accept; it was evidence the definition had too few parts. And the separate-subtrees restriction on aliased versions lifts, since versions sharing a name now agree wherever both determine a value.

## Two review corrections, recorded rather than tidied away

Both were caught in review and verified against the engine:

- **`port: integer = 8080` is not Aontu.** `=` is only for aliases; the engine refuses it with `[aontu/unexpected]: unexpected character(s): =`. A default is written `port: integer & *8080`.
- **"Aliases do not create contradictions" was wrong.** True of *constraints* (`integer & 8080` is `8080`), false of *defaults*: `*8080 & *9090` refuses with `pref_rank_clash`, because defaults are not ordered by subsumption and so have no meet.

The entry records that the aliasing question reversed twice, and why: whether two versions can meet is *downstream* of whether the compatibility check covers outcomes. It was never an independent question about aliases.

## Two records move with ADR-022

**ADR-019's constraint 5 is amended.** Its **fetching** half is untouched and is what deletes the ingestion threat model; evaluation is now permitted **at publish only** — authenticated input, deterministic budget, once per publish. The premise that changed is that ADR-019 stored the bytes: *"the service does not have the source"* had stopped being a reason, and the earlier draft applied the rule without rechecking its ground.

**ADR-020's status** records what survives: parts 2, 3, 4 and 6 unchanged, and part 1 — the path is a name, never a fetch instruction — *reinforced*, since dropping the major removes the last resolution semantics from the string.

### What dropping the major exposed

A job it was quietly doing: **routing**. Measured against the real pattern, without the trailing `@<integer>` the strings `config.json`, `local.aon`, `notes.md` and `my.dir/data.json` all become domain-shaped enough to reach the package resolver — breaking G6's guarantee that a pattern miss falls through unchanged.

The fix is that every reference self-describes: domain-shaped is a package, `./` `../` `/` is a local file, `alias:` is an alias — with the marker on the local case so package imports stay clean, plus a targeted diagnostic so a bare `foo.aon` does not fail with "package not found".

### What remains open

Not the check but the **escape hatch**: a publisher who genuinely intends an outcome change needs either a new name or an acknowledgement consumers see at resolve time. The entry does not choose. What it fixes is that the change cannot happen silently. Also recorded as a cost: a server-side evaluator defect is now reachable by an authenticated publisher — bounded by the proved namespace, the once-per-publish shape and the budget, and not zero.

## The module/package distinction, in both guides

`AGENTS.md` gains a Conventions entry leading with where the codebase currently gets it wrong — **the `aontu mod` verbs operate on packages** — defining both words against things in this repository (a module is what `resolveModule` resolves and `canonHash` pins; a package is what a version, a signature, a quota and a tombstone cover) and applying the rule to code comments, identifiers and error messages, not only prose. `docs/STYLE-GUIDE.md` gains the matching terminology entry so the documentation gate holds published pages to it.

Both carry the trap: **Go uses the two words the other way round**, so a phrase that sounds right to a Go user may be wrong here. Check which side of the import/publish line a thing sits on rather than trusting the ear.

**On enforcement:** this is a vocabulary rule, not a banned-phrase rule. Both words are legitimate and the gate cannot tell which sense a sentence means, so `docs.test.ts` is not extended. The narrow unambiguous constructions ("module registry", "publish a module") are named explicitly so they can be caught by eye.

## Verification

`docs.test.ts` passes (20 tests) after each commit. CI green on the current head.

The design notes — `CLI.0.md` §3.3, §3a and §3b, and the `REPOSITORY.0.md` amendments — are [`aontu-lang/system#4`](https://github.com/aontu-lang/system/pull/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGkXHMPSVdUpUdVM5oD9wd