### PR TITLE
ADR-023: G9 completes at the renderer; phases 5, 7 and 8 retired

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -39,6 +39,7 @@ ADR-NNN**, so the reasoning that led there stays readable.
 | [ADR-020](#adr-020--a-module-path-is-domainpath-and-the-domain-is-a-proved-namespace) | A module path is `<domain>/<path>`, and the domain is a proved namespace | Accepted |
 | [ADR-021](#adr-021--the-project-hosts-private-packages-with-authenticated-reads) | The project hosts private packages, with authenticated reads | Accepted |
 | [ADR-022](#adr-022--compatibility-is-computed-so-the-major-leaves-the-name) | Compatibility is computed, so the major leaves the name | Accepted |
+| [ADR-023](#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired) | G9 completes at the renderer: the reflection sidecar, the Jostraca bridge and string interpolation are retired | Accepted |
 
 ---
 
@@ -2414,3 +2415,106 @@ the ingestion threat model and is untouched here.
 
 The design is `CLI.0.md` §3.3 and `REPOSITORY.0.md` §3a in
 `aontu-lang/system`.
+
+---
+
+## ADR-023 — G9 completes at the renderer: the reflection sidecar, the Jostraca bridge and string interpolation are retired
+
+**Date:** 2026-09-05
+**Status:** Accepted
+
+### Context
+
+[G9](docs/capability-review/g9-transformation.md) — declarative
+transformation, one model and many generated artifacts — was planned in
+nine phases. By 2026-09-05 the rule layer had landed (`emit`, the four
+string builtins, `join`) and the plan for what remained was written as
+[RENDER.0.md](docs/design/RENDER.0.md), with `aontu render` as its
+spine. Three of the nine phases were not on that spine, and each had a
+reason of its own to be questioned:
+
+**Phase 5, the reflection sidecar** — a documented view of the
+evaluated tree (kinds, closedness, optionality, defaults, disjunction
+arms, constraint atoms, sites) in both ports, so that a transform could
+*derive* a field's optionality rather than state it, and so that a Go
+host could read a model at all
+([GENERATION-FORMS.0.md §2](docs/design/GENERATION-FORMS.0.md) found that
+a Go embedder can assert `*aontu.MapVal` and then read nothing). The
+renderer does not need it: it consumes `generate()` output by design.
+What it would settle is an ADR-001 question — whether parity covers the
+embedding surface or only the language — and answering it would freeze a
+reflection surface in both ports for a consumer that does not yet exist.
+
+**Phase 7, the Jostraca bridge** — one `Project`, one `generate()`
+call, three-way merge and protected regions for the repeated run over
+hand-edited files. Two of its prerequisites are changes to another
+repository (lazy `memfs`, `raw: true`); its dependency would be the
+eighth this project has ever taken, and an 11× install growth for a
+capability a normal render never uses. And the write story it was for is
+now `render --out` (all units or nothing, confined below one directory)
+and `render --check` (the CI form): a regenerate-everything lifecycle,
+which is a different product from a merge over hand edits.
+
+**Phase 8, string interpolation** — `` `a${$.b}c` `` as a parser
+phase behind a version gate, "deferred behind evidence that `join` did
+not suffice". The evidence went the other way:
+[TEMPLATE.0.md](docs/design/TEMPLATE.0.md) measured `${expr}` breaking
+on the project's own material (a serverless template that must emit
+`${self:provider.stage}` verbatim; a generated file holding a template
+literal) and chose `replace`, whose canonical form has zero
+concatenations across twelve real handlers.
+
+### Decision
+
+**G9 is complete when `aontu render` and the surface over it are
+complete — RENDER.0.md P0–P8 — and the three phases below are retired,
+not deferred.**
+
+1. **Phase 5 is retired.** A transform states its facts as data
+   (`optional`, a default, a kind) and the vocabulary vets them. Forms
+   (a) and (b) of GENERATION-FORMS.0.md stay what that note found them
+   to be — a host program reads the model in TypeScript through
+   documented-as-internal fields, and not at all in Go — and
+   `DIVERGENCE.md` says so in one entry. ADR-001's parity obligation
+   covers the *language* and the verbs; it does not extend to a
+   reflection surface, and this entry is where that is written down.
+2. **Phase 7 is retired.** aontu owns rendering to bytes and the
+   confined, all-or-nothing write of `render --out`; it owns no merge,
+   no protected region and no record of previous runs. A generation
+   over hand-edited files is a workflow for a tool that owns files,
+   and the hand-off to one is a pipeline step the user runs.
+3. **Phase 8 is retired.** `replace` on a template and `+`/`join` in a
+   body are the two ways a value reaches generated text. No
+   interpolation syntax is added to the grammar.
+
+### Consequences
+
+**We accept that a transform restates schema facts.** Worked example 2
+of the G9 design writes `optional: match(key(2), "email", true, …)` by
+hand where a sidecar would have read it from the schema. That is a
+duplication the vocabulary's vet catches when it drifts, and it is the
+price of not freezing a reflection surface in two ports.
+
+**We accept that Go embedding stays evaluate-and-validate.** A Go host
+can unify, generate, vet, subsume, render and hash; it cannot walk the
+tree. GENERATION-FORMS.0.md's first answer — "language only; say so" —
+is the one taken.
+
+**We accept no merge over hand edits.** A generated file is generated;
+a hand edit to one is drift, and `render --check` reports it. A project
+that wants both generated and hand-written regions in one file splits
+the file, or takes a tool built for that job downstream.
+
+**We accept `+` and `replace` as the only text-composition spellings**,
+and the readability cost `join("…", .x, "…")` carries against an
+interpolated literal, because the alternative was measured to break on
+real material and a delimiter that is safe in every target language does
+not exist.
+
+**Enforcement.** The register's rows for G9 phases 5, 7 and 8 read
+RETIRED with this entry's number, in the commit that records the
+decision; the design's [§7](docs/design/RENDER.0.md) and its fourth
+amendment in the gap document point here; `DIVERGENCE.md` carries the
+embedding-surface entry when P4 lands. A future phase that adds a
+reflection surface, a file-merge dependency or an interpolation syntax
+supersedes this entry rather than amending a row.

--- a/docs/capability-review/g9-transformation.md
+++ b/docs/capability-review/g9-transformation.md
@@ -2772,7 +2772,18 @@ change what a reader of this document would otherwise plan against:
 
 The first usable `aontu render` is P0–P4 — the resolver leg, the
 vocabulary with fragments, the `join` mark fix, the fragment fold with
-the `text` profile, and the verb — and it is the release that ends
-the 0.57.0 documentation skew. Acceptance case 1 is met there; the
+the `text` profile, and the verb. Acceptance case 1 is met there; the
 declaration lowering and the two language profiles follow as P5, and
 the template surface as P8.
+
+**Decided 2026-09-05 (the owner), after the plan was read:** phases 5,
+7 and 8 are RETIRED by
+[ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired)
+— the sidecar outright, not kept as its own note — so G9 completes at
+RENDER P8; and the next release is cut only after the plan's validation
+system, `test/system/rb-solar` (RENDER.0.md §10: a Rails 8
+implementation of the solardemo Solar System API and a human UI,
+rendered from a hand-written aontu model and held to the reference
+app's own validation script), passes. The §5 Jostraca seam and §4's
+interpolation design stay in this document as the record of what was
+considered and why it was not built.

--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -115,9 +115,10 @@ the divergence ledger, `Accepted`/`Superseded` in the ADR register).
 
 ## Summary
 
-Fifty-nine of the sixty-seven phases in the table below have moved;
-fifty-one of those are complete, four are partial, and four were
-landed and then superseded, retired or removed by an ADR. G5 phase 6 is
+Sixty-two of the sixty-eight phases in the table below have moved;
+fifty-one of those are complete, four are partial, four were landed and
+then superseded, retired or removed by an ADR, and three were retired
+by an ADR before they started. G5 phase 6 is
 deliberately held for the next major release, a release act rather
 than an engineering one. **G9 phase 0 became partial on 2026-08-30
 without this register saying so**: #99 fixed two of its four named
@@ -141,14 +142,16 @@ the fix was and why the earlier tests could not see the defect.
 | [G6](g6-distribution.md) | Distribution | B/C | 5 | 0 | 0 | 0 |
 | [G7](g7-machine-access.md) | Machine access | B | 7 | 0 | 0 | 0 |
 | [G8](g8-generation.md) | Generation | C | 6 | 0 | 0 | 1 |
-| [G9](g9-transformation.md) | Declarative transformation | D | 1 | 3 | 5 | 0 |
+| [G9](g9-transformation.md) | Declarative transformation | D | 1 | 3 | 3 | 3 |
 | [G10](g10-transparency.md) | Transparency log | D | 2 | 0 | 3 | 1 |
-| | | **total** | **51** | **4** | **8** | **4** |
+| | | **total** | **51** | **4** | **6** | **7** |
 
 *Retired* counts the rows whose status is SUPERSEDED, RETIRED or
-REMOVED — G4.0 and G4.1 (ADR-014), G8.4 (ADR-018) and G10.5
-(ADR-019). A phase that landed and was then taken out by an ADR is
-neither landed nor not started, and until 2026-09-05 this table
+REMOVED — G4.0 and G4.1 (ADR-014), G8.4 (ADR-018), G10.5 (ADR-019),
+and G9.5, G9.7 and G9.8 (ADR-023, retired before they started). A
+phase that landed and was then taken out by an ADR is neither landed
+nor not started — nor is one an ADR closed before any of it was built
+— and until 2026-09-05 this table
 counted such rows on whichever side kept its total at sixty-five
 while the sections below held sixty-seven rows (G8 alone was listed
 as five where it has seven). The row count is
@@ -1506,9 +1509,11 @@ Opened 2026-08-30, after G1–G8 landed. Design is
 [g9-transformation.md](g9-transformation.md); forms (a) and (b) — the
 host program and the Jostraca path — are
 [docs/design/GENERATION-FORMS.0.md](../design/GENERATION-FORMS.0.md).
-**Phases 0, 4 and 6 are partial and phase 2 has landed; phases 1, 3,
-5, 7, 8 and 9 have not started**, and the rest of the document is a
-design proposal, not a commitment. The corpus the design asks
+**Phases 0, 4 and 6 are partial and phase 2 has landed; phases 1, 3
+and 9 have not started; phases 5, 7 and 8 are RETIRED
+([ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired),
+2026-09-05)**, and the rest of the document is a design proposal, not a
+commitment. The corpus the design asks
 for before its later phases are committed to now exists —
 [use-cases/15-code-generation](../../use-cases/15-code-generation/)
 (#100) — but a corpus is evidence, not a phase, and no row below
@@ -1580,11 +1585,13 @@ mark fix, BUGS §79; the fragment fold with a two-field `text` profile;
 the verb, its MCP tool and the migrated use case 15; the declaration
 lowering with the TypeScript and Go profiles; `replace`/`esc` in `emit`
 and `form`; provenance and coverage), numbers the template surface as
-**phase 9**, and recommends that phases 5, 7 and 8 leave the critical
-path — 5 as its own note behind an ADR-001 decision, 7 and 8 retired by
-ADR. The first usable verb is its P0–P4 and is the release that ends
-the 0.57.0 documentation skew. The rows below keep their statuses: a
-plan changes none of them.
+**phase 9**, and recommended that phases 5, 7 and 8 leave the critical
+path. **The owner decided on 2026-09-05**: all three are retired
+([ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired)),
+and the release is cut only after the plan's validation system —
+`test/system/rb-solar`, a Rails implementation of the solardemo API
+rendered by `aontu render` (RENDER.0.md §10) — passes. G9 therefore
+completes at RENDER P8.
 
 | Phase | Size | Status | Pin |
 |-------|------|--------|-----|
@@ -1593,10 +1600,10 @@ plan changes none of them.
 | **2** — `join` | S | **LANDED** | `JoinFuncVal` (ts/src/val/AggFuncVal.ts) and `joinBag` (go/agg.go), registered in both tables, both grammars' `name` rule and both LSP lists; `test/spec/gen-join.tsv`, **47 rows executed by both runners**; `errcodes.tsv` +1 (`join_member`, conflict). The design's acceptance case holds: `join([8080,443],"-")` is `"8080-443"` in both ports, an unfired call canons as its call and reparses, and the lark literal check is green after the three missing names were added. **Landed as designed, with three things worth recording.** (1) The `+` fold is not a figure of speech: `plusText` was extracted from `PlusOpVal` and `primStr` was already exported in Go, so the fold and the operator SHARE a renderer and cannot drift into two answers to "how does a number become text". (2) **`join` is the first builtin that is both STAGED and DEFERS its resolution**, and that combination needed a `make` override its `AggFuncVal` siblings do not have — without it TypeScript raised `func:join` where Go residuated, on `join($.m,",")` with `m: [string]`. Found by running both engines, not by either test suite. (3) **The ADR-002 gate found dead code that probing then confirmed**: a nil-member guard, written by analogy with `sum`, is unreachable in `join` and was removed in both ports rather than excused. `sum` folds with `arith`, which MINTS a nil part-way through; `join` folds already-unified values, and a nil among a list's elements collapses the list before the call resolves — `join([least([])],",")` reports `aggregate_empty` at the member's own path and never reaches the fold. (4) The separator is a STRING, refused as `invalid-arg` otherwise, though `+` would render a number perfectly well: it is the parameter naming the text between members rather than a member, `pick`'s key draws the same line, and loosening later breaks no document while tightening would. **Item 4 of phase 0 is NOT a prerequisite and did not land here**: `join` reuses `bagChildren`, so it treats `hide`-marked and unfilled optional children exactly as `each` and `pick` do today, and phase 0 will change all four together rather than leaving `join` alone in a new behaviour. **Downstream:** [use-cases/15-code-generation](../../use-cases/15-code-generation/) changed shape — its transforms now compute the whole FILE rather than its lines, the six-line Python fold in `check.sh` is gone, and the check that proved the gap (the SQL golden REFUSED by a real parser for a trailing comma) is inverted: the SQL now parses and `check.sh` opens it in SQLite and asserts the tables and columns exist. |
 | **3** — `form`, the order-preserving map | S/M | **NOT STARTED** | `each` meets and cannot transform; `pack` keys by data and reorders |
 | **4** — the renderer core and the first two profiles | M | **PARTIAL 2026-09-05** | **The four string builtins landed on 2026-09-04, with phase 6 (#148), in both ports** — `ts/src/val/StrFuncVal.ts` and `ts/src/escape.ts`; the `esc`/`usc`/`rep`/`split` arms of `go/func.go` — declared in `test/spec/signature.tsv` and pinned by `test/spec/str.tsv` (99 rows, executed by both runners; `esc("o'brien")`, `split("x,y",",")` and `rep("abc","b","B")` answer identically from both CLIs). This row still read NOT STARTED a day after they landed: protocol rule 1 failing in the direction the G9.0 note describes, work landing under a heading that does not name the phase it discharges. **Not started:** the `render` verb, the profiles and the fragment entry point. As designed: the `render` verb; the Go and TypeScript profiles; and, per the second amendment, a fragment entry point plus a two-field `aontu:lang/text` profile, which is the executable form of "a new language is data". The fold reads a piece's `at` where the design counted recursion depth. Plus the three string builtins of [TEMPLATE.0.md](../design/TEMPLATE.0.md) — `esc(src, variant?)` (escaping is ON for a `replace` value, with `esc:` an optional key naming the variant), its left inverse `usc`, `rep(src, re, sub)` over `re()`'s own portable subset, and `split(src, sep)` — which have no renderer coupling and may land earlier; without them a hand-spelled literal generates broken code, VERIFIED (`tsc` rejects an unescaped `o'brien` with nine errors, and accepts the escaped form). |
-| **5** — the reflection sidecar | M | **NOT STARTED** | The view forms (a), (b) and (c) share; an ADR-001 question first (GENERATION-FORMS.0.md §2) |
+| **5** — the reflection sidecar | M | **RETIRED 2026-09-05 ([ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired))** | Nothing was built. The view forms (a), (b) and (c) were to share is not needed by `render`, which consumes `generate()` output by design; a transform states its schema facts as data and the vocabulary vets them; ADR-001's parity covers the language and the verbs, not an embedding surface, so forms (a) and (b) stay what [GENERATION-FORMS.0.md §2](../design/GENERATION-FORMS.0.md) found them to be and `DIVERGENCE.md` says so (entry lands with RENDER P4). |
 | **6** — `emit`, the manifest, and the verb | M | **PARTIAL 2026-09-04** | **`emit(select, table)` has landed in both ports**; the manifest and the `aontu render` verb have not, so the phase is partial and acceptance case 1 (a target the declaration vocabulary does not fit) waits on them. `ts/src/val/EmitFuncVal.ts` and `go/generate.go`, registered as a staged generator in both (`ts/src/lang.ts`, `go/func.go`), declared in `test/spec/signature.tsv` as `emit(s: map|list, template t: map|list) : list`. `test/spec/gen-emit.tsv` (45 rows) plus six codes in `errcodes.tsv` — `emit_data`, `emit_table`, `emit_template`, `emit_body`, `emit_none`, `emit_ref` — every expectation obtained by running BOTH engines and diffing, error text included. Reference: [Transforming: `emit`](../reference-language.md#transforming-emit); the outcome is recorded in [EMIT.0.md](../design/EMIT.0.md#what-phase-6-established). **Four things the design could not settle from outside the engine.** (1) **A named table is a PLACEHELD `emit`.** The note's decisive fact — a table reached by reference does not re-root its bodies' relative references — is not repaired by binding at the use site, because the DEFINITION site drives the table first and the references have already missed. Nothing in the language holds a value unevaluated at a document position; what does is a call's template argument, so `%wire = emit(_, T)` is that position with the selection left open. `emit($.listen, %wire)` and `$.listen & %wire` are the same dispatch, and D4's "a mode is a named table" survives exactly as written. (2) **A placeheld generator was never filled** — `["a"] & pack(_, {x:1})` answered `*_no_gen` in both ports while the unstaged `"hello" & upper(_)` filled as documented, because `_` is never `done` and the staged readiness gate held the call residual for ever. Fixed for `pack`, `each`, `filter` and `emit` together (`stagedReady` / `stagedDrive`); rows in each combinator's spec file. (3) **A body's relative reference is BOUND to the node, and a miss is `emit_ref`** reported against the node: binding rather than re-pathing is what makes a computed selection work, since the nodes of `filter(…)` live nowhere and there is no position for a dot count to be taken from. The walk stops at a nested generator's binding argument, which is D5's nesting rule. (4) **A nested dispatch is driven where it is met**, or it resolves a pass later and arrives as a list INSIDE the list; driven through `unite`, so a rule set that walks into itself without descending is refused as a spent depth budget. **Fact 4 did not reproduce**: the pass exhaustion was the INLINED expansion's, and the recursive rule set settles inside the default budget, so no flag is needed. **Acceptance case 2 is met** — `emit-recursive` walks a nested model into nested output, the case fact 3 says no amount of user-space work reaches. **The string builtins landed next**, in the same phase: `esc`, `usc`, `rep` and `split` (`ts/src/escape.ts`, `ts/src/val/StrFuncVal.ts`, `go/escape.go`, `go/strfunc.go`), 99 rows in `test/spec/str.tsv` and five more codes — `esc_variant`, `usc_malformed`, `rep_pattern`, `rep_sub`, `split_sep`. Both ports spell every escape convention and both matching loops out BY HAND rather than borrowing a host library, because the hosts disagree about every part of the job: `JSON.stringify` escapes what Go's `encoding/json` does not, `encodeURIComponent` is not RFC 3986, JavaScript's split INSERTS a pattern's capture groups where Go's does not, and the two read a substitution template differently. Two corrections to [TEMPLATE.0.md](../design/TEMPLATE.0.md) fell out of building it: there is no `$<name>` substitution, because the pattern subset refuses named groups and a spelling for one names something that cannot exist; and the note's own `[:,]` is outside the subset, since a class opening `[:` reads as a POSIX class — `re()` refuses it identically, which is the point. **Still not in this landing**: `replace`/`esc` INSIDE `emit`, the manifest under `@"aontu:code"`, and the `render` verb. |
-| **7** — the Jostraca bridge | M | **NOT STARTED** | Phases 1–5 carry no Jostraca dependency, so this cannot block the language work |
-| **8** — string interpolation | M/L | **NOT STARTED** | The parser phase; deferred behind evidence that `join` did not suffice — and [RENDER.0.md §7](../design/RENDER.0.md) reads the evidence the other way: TEMPLATE.0.md D3 measured `${expr}` breaking on the project's own material and chose `replace`, so the recommendation is to retire this phase by ADR |
+| **7** — the Jostraca bridge | M | **RETIRED 2026-09-05 ([ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired))** | Nothing was built, and no dependency was taken. The write story is `render --out` (all units or nothing, confined below one directory) and `render --check` (the CI form), RENDER.0.md D8; a merge over hand-edited files is a different lifecycle and a downstream tool's. The two asks on the Jostraca repository (lazy `memfs`, `raw: true`) are withdrawn. |
+| **8** — string interpolation | M/L | **RETIRED 2026-09-05 ([ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired))** | Nothing was built. It was deferred behind evidence that `join` did not suffice, and the evidence went the other way: [TEMPLATE.0.md](../design/TEMPLATE.0.md) D3 measured `${expr}` breaking on the project's own material and chose `replace`, whose canonical form has zero concatenations across twelve real handlers. `replace` on a template and `+`/`join` in a body are the two ways a value reaches generated text. |
 | **9** — the template surface | M/L | **NOT STARTED** | [TEMPLATE.0.md](../design/TEMPLATE.0.md) as a verb-reachable surface — a generator file in the target language whose `//-` lines carry aontu, desugared to the canonical `emit` form and rendered, with the resugar as the round-trip test. Numbered here on the 2026-09-05 status note's request; it is the third amendment's "new, after 6", and [RENDER.0.md](../design/RENDER.0.md) P8 carries its deliverables. It cannot precede `render` (phase 4), which it renders through, nor `replace`/`esc` in `emit` (RENDER P6), which it desugars to. |
 
 **Read before starting phase 1.** Every one of the seven parallel

--- a/docs/design/GENERATION-FORMS.0.md
+++ b/docs/design/GENERATION-FORMS.0.md
@@ -250,8 +250,13 @@ is where the language questions live, and they are in
 
 ## 7. Open, and owner-level
 
-- Does ADR-001 cover the embedding surface, or only the language?
-  (§2. Nothing currently says.)
+- ~~Does ADR-001 cover the embedding surface, or only the language?
+  (§2. Nothing currently says.)~~ **Answered 2026-09-05 by
+  [ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired):
+  the language and the verbs, not an embedding surface.** The
+  reflection view (§3) is retired unbuilt; forms (a) and (b) stay as
+  §2 found them, and `DIVERGENCE.md` records it. The Jostraca driver
+  (§5) is retired with it.
 - Does the Go root module take the Jostraca dependency, or does the
   driver live in a separate package inside it? A separate package is
   enough — Go's linker drops it from binaries that never import it —

--- a/docs/design/RENDER.0.md
+++ b/docs/design/RENDER.0.md
@@ -614,11 +614,16 @@ whole of that claim.
 
 ## 6. The first release
 
-P0–P4 together are one release, and it should be **0.58.0 / go
-0.1.16**, which is already owed: the shipped 0.57.0 declares aliases
-with a colon and reads `x=y` as text, and the synced documentation
-describes `=` and `bare_punct`. Cutting 0.58.0 at P4 ends that skew and
-ships `render` in the same breath. P5–P8 follow as 0.59.0 and after.
+**Decided 2026-09-05 (the owner): the next release is cut only after
+the validation system of [§10](#10-the-validation-system-testsystemrb-solar)
+renders and passes.** The note had recommended cutting 0.58.0 / go
+0.1.16 at P4 — the shipped 0.57.0 declares aliases with a colon and
+reads `x=y` as text, while the synced documentation describes `=` and
+`bare_punct` — and the owner chose to carry that skew until `render`
+has produced a working system rather than release a verb that has
+generated nothing real. So 0.58.0 ships the alias operator, the
+bare-text rule, `aontu render` through P8, and the first full system
+built with it, together.
 
 ## 7. The rest of the programme
 
@@ -635,7 +640,21 @@ decisions; the recommendations are argued, not assumed.
 | **G10 phases 3, 4, 6** | Out of this repository; tracked in `aontu-lang/system` | The status note records the register's rows lag that repository's seven design notes; the fix is register hygiene, not engine work. |
 | **Register hygiene** (status note §5: numbering the surface phase, SUPERSEDED/RETIRED/REMOVED defined, ADR-022's entries, counts) | Do with the P0 commit | Cheap, and every later phase's row depends on the section being right. This note gives the surface phase its number and row. |
 
+**Decided 2026-09-05 (the owner).** Phases 5, 7 and 8 are **retired**,
+by [ADR-023](../../ADR.md#adr-023--g9-completes-at-the-renderer-the-reflection-sidecar-the-jostraca-bridge-and-string-interpolation-are-retired)
+— phase 5 outright rather than kept as its own note: a transform states
+its facts as data, and forms (a) and (b) stay what GENERATION-FORMS.0.md
+§2 found them to be, with DIVERGENCE.md saying so. The release is cut
+only after the validation system passes ([§6](#6-the-first-release)).
+G9 therefore completes at P8, and the table in [§5](#5-what-done-means-for-g9)
+is the whole of what remains.
+
 ## 8. Open questions
+
+*Each recommendation below was adopted on 2026-09-05 as the working
+answer, so that building could start; none was put to the owner as a
+blocking question, and any may be reopened by saying so. A question a
+phase settles by building is marked in that phase's register row.*
 
 - **X-1 — Does `render --out` refuse to overwrite a file it did not
   write?** Recommendation: no. `render` is the repeated run; the
@@ -702,3 +721,45 @@ touches M0.
 10. **The Jostraca ADR is not ADR-012** — that number is
     [taken](../../ADR.md#adr-012--an-includes-extension-decides-what-the-file-is-aontu-source-config-data-or-refused);
     the bridge, if it proceeds, takes the next free number.
+
+## 10. The validation system: `test/system/rb-solar`
+
+**Decided 2026-09-05 (the owner).** The render plan is validated by a
+full system, not by rows alone: `test/system/` holds complete systems
+whose outline and scaffolding `aontu render` generates, and the first
+is **rb-solar**, a Ruby on Rails implementation of
+[voxgig-sdk/voxgig-solardemo-sdk](https://github.com/voxgig-sdk/voxgig-solardemo-sdk)'s
+Solar System API — the same API the reference Fastify app serves (two
+entities, `Planet` and `Moon` nested under it; `list`/`load`/`create`/
+`update`/`remove`; the `terraform` and `forbid` actions; cascade delete;
+a `{error, message}` envelope with `NotFoundError`, `ValidationError` and
+`ConflictError`) — **and a human UI over the same data**. The
+convention for the folder is [`test/system/README.md`](../../test/system/README.md).
+
+The shape, as decided:
+
+| question | decision |
+|---|---|
+| stack | Rails 8, SQLite, server-rendered ERB with Hotwire (Turbo and Stimulus), Propshaft; no Node toolchain |
+| what is generated | **everything the model decides**: routes, migrations, models with validations and the cascade, API controllers with the envelope and the two actions, UI controllers and views, seeds from the solar data, request specs; only framework boilerplate (`Gemfile`, `config/`, `bin/`) is hand-written, once |
+| the model | a hand-written aontu API model in `test/system/rb-solar/model.aon`, written the way a user of aontu would write it; the OpenAPI spec is vendored beside it as the reference it must agree with |
+| the output | the rendered application is **committed** under `test/system/rb-solar/app/`, each generated file carrying a banner; `aontu render --check` holds it, so a change to the model or the generator is a reviewable diff |
+| validation | `check.sh` renders, boots the app, runs the reference repository's `app/validate.ts` against it, runs the Ruby SDK's tests in live mode against it, and fetches the UI pages; a GitHub Actions job with a Ruby toolchain runs it |
+| release | 0.58.0 / go 0.1.16 is cut when this passes ([§6](#6-the-first-release)) |
+
+**What it validates, phase by phase.** P3 and P4 render the fragment
+units the Ruby files are made of (a Rails file is fragments: the
+declaration vocabulary has no Ruby lowering and needs none). P6's
+`replace`/`esc` and `form` are what a controller template with model
+values in it needs, and `form` is what keeps a migration's columns in
+model order. P7's coverage names any entity field no file consumed. P8
+is how the generator is written — Ruby files with `#-` marker lines
+carrying the aontu — which is the surface's second real corpus after the
+twelve handlers. A phase that rb-solar does not exercise is a phase the
+plan has not proved.
+
+**What it deliberately does not claim.** Rails idiom beyond what the
+model states, a formatter (`rubocop -a` is the hand-off, as `gofmt` is),
+and any change to the reference API: rb-solar is held to the reference
+app's validation script, so the API is theirs and only the
+implementation is ours.

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -1,0 +1,60 @@
+# test/system — full systems generated with `aontu render`
+
+`test/spec/` pins the language row by row. This directory pins the
+other end of the claim: that a model written in aontu, run through
+`aontu render`, produces a **complete working system** — not a file
+that looks right, but an application that boots, serves its API,
+passes an external validation written against a reference
+implementation, and shows a human a page.
+
+Every system here is the validation of a design decision recorded in
+[`docs/design/RENDER.0.md`](../../docs/design/RENDER.0.md) §10, and a
+system that stops passing is a defect in the renderer, the model or
+the generator — never a test to relax.
+
+## Layout
+
+```
+test/system/<name>/
+  README.md        what the system is, what it is held to, how to run it
+  model.aon        the model: the ONE source every generated file reads
+  gen/             the generator: aontu (or the template surface, P8)
+                   producing an @"aontu:code" instance from the model
+  ref/             the reference the system is held to, vendored
+                   (an OpenAPI spec, a validation script), read-only
+  app/             the rendered system, COMMITTED, each generated file
+                   carrying a banner; plus the hand-written framework
+                   boilerplate the model does not decide
+  check.sh         renders (`aontu render --check app`), boots the
+                   system, runs the reference validation against it,
+                   runs any client-side suite in live mode, fetches the
+                   UI pages; exit 1 on any failure
+```
+
+Two rules follow from the layout:
+
+- **The rendered tree is committed and checked, not regenerated
+  silently.** `aontu render --check app` is the first step of every
+  `check.sh`, so a change to the model or the generator shows as a
+  reviewable diff to `app/`, and a hand edit to a generated file is
+  drift the check reports. Boilerplate the model does not decide is
+  hand-written once and is not banner-marked.
+- **The API is the reference's, not ours.** A system implements an
+  existing API and is validated by that API's own script. What is
+  ours is the model, the generator and the framework choice.
+
+## Systems
+
+| system | target | reference | status |
+|---|---|---|---|
+| [`rb-solar`](rb-solar/) | Ruby on Rails 8, SQLite, Hotwire: the Solar System API (Planet, Moon) and a human UI over the same data | [voxgig-sdk/voxgig-solardemo-sdk](https://github.com/voxgig-sdk/voxgig-solardemo-sdk) — its reference app's OpenAPI spec and `app/validate.ts`, and its Ruby SDK's live tests | planned; lands with RENDER P4–P8 |
+
+## Running
+
+Each `check.sh` is runnable from any cwd and honours `AONTU` (the
+engine command; default the TypeScript CLI in this repository) so the
+Go port runs the same check. A system's toolchain (Ruby and Rails for
+`rb-solar`) is installed by the CI job that runs it and documented in
+its README; `check.sh` skips with a note when the toolchain is absent
+rather than failing, so `use-cases/run-all.sh`-style local runs stay
+possible without it.


### PR DESCRIPTION
## Summary

The owner's decisions on the render plan ([aontu-lang/aontu#153](https://github.com/aontu-lang/aontu/pull/153)), recorded where the plan said they would be. Documentation only; no code, no register status other than the three retirements.

- **ADR-023** retires G9 phase 5 (the reflection sidecar), phase 7 (the Jostraca bridge) and phase 8 (string interpolation), with the context, the decision, the consequences accepted and how it is enforced. It also answers GENERATION-FORMS.0.md's open ADR-001 question: parity covers the language and the verbs, not an embedding surface.
- **The register**: the three rows read RETIRED (ADR-023, 2026-09-05) in the same commit; the summary table counts them (G9: 1 landed, 3 partial, 3 not started, 3 retired; 68 rows); the G9 pointer paragraph carries the decision.
- **RENDER.0.md**: §6 — the next release is cut only after the validation system passes; §7 — the decision; §8 — the recommendations adopted as working answers, reopenable; new **§10** — the validation system, `test/system/rb-solar`: a Rails 8 / SQLite / Hotwire implementation of the solardemo Solar System API and a human UI, rendered from a hand-written aontu model, committed and held by `render --check`, validated in CI by the reference app's own `validate.ts`, the Ruby SDK's live tests and a UI smoke.
- **g9-transformation.md** fourth amendment and **GENERATION-FORMS.0.md** §7 record the decision where a reader of those documents would look.
- **test/system/README.md**: the convention for full systems generated with `aontu render` — layout, the two rules (the rendered tree is committed and checked; the API is the reference's), the systems table.

## Checks

Docs gate (`ts/test/docs.test.ts`) green; register row count 68 by its own command; every ADR-023 anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9)_