### PR TITLE
The render synopsis fence carries a language

### DIFF
--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -1298,7 +1298,8 @@ Without `--strict` the same export exits 0.
 Render a document that evaluates to an **`aontu:code`** instance into
 files, and say what the renderer could not check.
 
-```
+<!-- test: skip the synopsis is not a transcript -->
+```sh
 aontu render [--at <path>] [--profile <file>]... [--unit <path>]
              [--stdout | --out <dir> | --check <dir>] [--strict]
              [--format text|json] <file>


### PR DESCRIPTION
## Summary

One fence: the `aontu render` synopsis in `docs/reference-api.md` is tagged `sh` and skipped by the docs gate as a synopsis rather than a transcript. The site's highlight budget (aontu-lang/web `GREY_BUDGET`) counts every uncoloured block and can only shrink, and the untagged synopsis from #158 was one more; the web resync of #158 waits on this.

## Checks

`ts/test/docs.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9)_