### PR TITLE
0.58.0 / go 0.1.16 is published, and the record says so

### DIFF
--- a/docs/capability-review/progress.md
+++ b/docs/capability-review/progress.md
@@ -258,13 +258,22 @@ from commit `2cec558`, over the OIDC trusted-publisher path in
 the MCP server, and all of G3, G4, G6, G7 and G8 are installable for
 the first time. `npm view aontu version` answered `0.53.0` that day, the proxy
 resolves `github.com/aontu-lang/aontu/go@v0.1.11`, and both tags point
-at that one commit. **Four releases have followed** (recorded
-2026-09-05, the first time this paragraph moved since 2026-08-30):
-0.54.0 / go 0.1.12 on 2026-09-02 (tags at `3dbb5ef`), 0.55.0 /
-go 0.1.13 on 2026-09-03 (`69b80b7`), 0.56.0 / go 0.1.14 on
-2026-09-03 (`22a5d31`), and 0.57.0 / go 0.1.15 on 2026-09-05
-(`05a8760`, the merge of #148). `npm view aontu version` answers
-`0.57.0` and the proxy lists `v0.1.15`.
+at that one commit. **Five releases have followed**: 0.54.0 / go 0.1.12
+on 2026-09-02 (tags at `3dbb5ef`), 0.55.0 / go 0.1.13 on 2026-09-03
+(`69b80b7`), 0.56.0 / go 0.1.14 on 2026-09-03 (`22a5d31`), 0.57.0 /
+go 0.1.15 on 2026-09-05 (`05a8760`, the merge of #148), and **0.58.0 /
+go 0.1.16 on 2026-09-06** (`47d36b8`, the merge of #169). `npm view
+aontu version` answers `0.58.0`, the proxy resolves
+`github.com/aontu-lang/aontu/go@v0.1.16` to that commit, and the Go
+release carries its binaries.
+
+**0.58.0 is the release G9 was held for.** RENDER.0.md §6 recorded the
+owner's decision of 2026-09-05 — cut nothing until the validation
+system renders and passes, rather than ship a verb that had generated
+nothing real — and `test/system/rb-solar` passed on 2026-09-06. So
+`aontu render` in full (P0 through P8), the alias operator, the
+bare-text rule and the first complete system built with them are
+installable together, which is the first time any of `render` has been.
 
 What the caveat said before, which was accurate then: **most of the
 work below was not in a released artifact — but not none of it.** The

--- a/docs/design/RENDER.0.md
+++ b/docs/design/RENDER.0.md
@@ -732,6 +732,14 @@ generated nothing real. So 0.58.0 ships the alias operator, the
 bare-text rule, `aontu render` through P8, and the first full system
 built with it, together.
 
+**CUT 2026-09-06.** `test/system/rb-solar` passed — the reference's own
+twenty tests against the generated application — and npm `aontu@0.58.0`
+and `go/v0.1.16` were published from `47d36b8`, the merge of #169, over
+the same OIDC path every release since 0.53.0 has taken. The proxy
+resolves `github.com/aontu-lang/aontu/go@v0.1.16` to that commit. The
+skew the note describes is therefore closed: what the documentation
+says about `=` and `bare_punct` is what the shipped engine does.
+
 ## 7. The rest of the programme
 
 What stands between the last G9 row and "the capability programme is
@@ -1086,7 +1094,7 @@ The shape, as decided:
 | the model | a hand-written aontu API model in `test/system/rb-solar/model.aon`, written the way a user of aontu would write it; the OpenAPI spec is vendored beside it as the reference it must agree with |
 | the output | the rendered application is **committed** under `test/system/rb-solar/app/`, each generated file carrying a banner; `aontu render --check` holds it, so a change to the model or the generator is a reviewable diff |
 | validation | `check.sh` renders, boots the app, runs the reference repository's `app/validate.ts` against it, runs the Ruby SDK's tests in live mode against it, and fetches the UI pages; a GitHub Actions job with a Ruby toolchain runs it |
-| release | 0.58.0 / go 0.1.16 is cut when this passes ([§6](#6-the-first-release)) |
+| release | 0.58.0 / go 0.1.16 is cut when this passes ([§6](#6-the-first-release)) — **CUT 2026-09-06** |
 
 **What it validates, phase by phase.** P3 and P4 render the fragment
 units the Ruby files are made of (a Rails file is fragments: the


### PR DESCRIPTION
The release went out; this is the record of it, written from what was verified rather than from what was intended.

## Verified

| claim | how |
|---|---|
| npm `aontu@0.58.0` | `npm view aontu version` → `0.58.0` |
| `v0.58.0` and `go/v0.1.16` | both at `47d36b80`, the merge of #169 |
| the Go module resolves | `proxy.golang.org` → `v0.1.16`, `Hash: 47d36b80…`, `Ref: refs/tags/go/v0.1.16` |
| the binaries shipped | GitHub Release "aontu 0.1.16 (Go CLI)" at `go/v0.1.16`, published 22:32 UTC |

## What changed

- **`docs/capability-review/progress.md`** — the release paragraph now names five releases since 0.53.0, not four, with 0.58.0 and its verification. Plus a paragraph on what makes this one different: it is the release G9 was held for, so `aontu render` P0–P8, the alias operator, the bare-text rule and the first system built with them became installable together — the first time any of `render` has been.
- **`docs/design/RENDER.0.md`** — §6 and the §10 table row said "0.58.0 is cut when this passes". It passed, so they say **CUT 2026-09-06** and name the commit. A condition left standing after it is met is one a reader has to go and check.

The skew §6 chose to carry is closed with it: 0.57.0 declared aliases with a colon while the synced documentation described `=`. What the documentation says is now what the shipped engine does.

## Not in this PR

The `## Unreleased` heading is not re-added. The next change that earns an entry adds it, which is how it has always worked here — an empty section is a claim that nothing has landed, and it goes stale the moment something does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfXBkch8NQoKuVjSYpRCk9)_