### PR TITLE
rb-solar's entities are a map, and a new guide says why

### DIFF
--- a/AONTU-GUIDE.md
+++ b/AONTU-GUIDE.md
@@ -1,0 +1,135 @@
+# The aontu guide
+
+Tips for writing models, collected from models that exist. This is not
+the language reference — [`docs/reference-language.md`](docs/reference-language.md)
+says what every form means — and it is not a style guide for prose,
+which is [`docs/STYLE-GUIDE.md`](docs/STYLE-GUIDE.md). It is the
+smaller, more useful thing: what experience says to reach for, and what
+it says to avoid.
+
+Each entry states the tip, then why, then the mechanics you need to act
+on it. Every snippet here was run.
+
+## Avoid arrays unless you really need an ordering
+
+**Use a named map.** An array gives every element a number nobody chose,
+and a number is a poor name for a thing that has one.
+
+```aon
+service: {
+  auth: { port: 8001 }
+  billing: { port: 8002 }
+}
+port: $.service.auth.port
+```
+
+```json
+{"port": 8001,
+ "service": {"auth": {"port": 8001}, "billing": {"port": 8002}}}
+```
+
+Four things follow from the key, and all four are lost the moment you
+write `service: [...]` instead:
+
+- **It is an address.** `$.service.auth.port` says what it reaches.
+  `$.service.0.port` says where it happens to sit, which is a different
+  and much weaker claim — and one that stops being true when somebody
+  inserts a service above it.
+- **It is a name other parts of the model can use.** A `parent: "auth"`
+  somewhere else in the document names a key that exists. `parent: 0`
+  names nothing you can check.
+- **Adding one is an insertion, not a renumbering.** A third service goes
+  in wherever it reads best. In an array it either goes last, or it
+  moves every index after it — including the ones written down in
+  another file.
+- **The diff is the change.** Insert into the middle of an array and a
+  review shows every following element as modified. Insert into a map
+  and the review shows one addition.
+
+### The mechanics
+
+A map is walked in **sorted-key order**. A list is walked in **source
+order**. That is the whole of the difference, and it is what the choice
+turns on:
+
+```aon
+step: {
+  deploy: { run: "bin/deploy" }
+  build: { run: "make" }
+  test: { run: "make test" }
+}
+order: [$.step.build $.step.test $.step.deploy]
+by_key: form($.step, _ & { at: key() })
+by_order: form($.order, _ & { at: key() })
+```
+
+`by_key` comes out `make`, `bin/deploy`, `make test` — build, deploy,
+test, alphabetically. `by_order` comes out `make`, `make test`,
+`bin/deploy`, which is what the list says.
+
+Two more facts worth knowing before you convert anything:
+
+- **`form` over a map produces a list**, and `key()` inside its template
+  is the element's POSITION in that list, not the map key. `form` exists
+  precisely to keep an order, so it hands you an ordinal.
+- **`pack` over a map produces a map**, and there `key()` IS the key. It
+  is how you put a name inside the node that carries it:
+  `pack($.service, _ & { id:key() })` gives each service an `id` equal to
+  its own key.
+
+That second one matters more than it looks. A dispatch — `emit`,
+`filter`, `match` — chooses a rule by what the NODE holds, and a node
+does not hold its own key. If a generator needs the name to write a
+filename or a class, the name has to be *in* the node: either stated
+there, or put there by `pack`.
+
+### When you do need the order, say so
+
+Some orders are facts. Migrations run in one. A pipeline's steps run in
+one. A rule table is tried in one, and the first match wins.
+
+Do not smuggle those in as the order somebody happened to type things.
+Keep the map, and state the order beside it as a list of references:
+
+```aon
+entity: {
+  planet: { table: "planets" }
+  moon: { table: "moons" parent: "planet" }
+}
+sequence: [$.entity.planet $.entity.moon]
+```
+
+Now the two claims are separate and both are visible. The map says what
+exists and what it is called. The list says what depends on what, in one
+place, where a reviewer can argue with it. A generator that cares reads
+`$.sequence`; one that does not reads `$.entity` and is spared a
+decision it never needed to make.
+
+### The worked example
+
+[`test/system/rb-solar`](test/system/rb-solar) is a Rails application
+generated from one model, and its entities are a map for exactly these
+reasons. Its `sequence` exists because a moon keys into a planet: the
+migrations must create `planets` first, and the seeds must insert a
+planet before the moon that belongs to it. Five of its nine generators
+write one file per entity, never see an order, and read the map.
+
+The pinned tree in
+[`doc/model-tree.txt`](test/system/rb-solar/doc/model-tree.txt) is the
+argument in miniature. It used to read:
+
+```
+├── entity
+│   ├── 0 (21)
+│   └── 1 (27)
+```
+
+and now reads:
+
+```
+├── entity
+│   ├── moon (27)
+│   └── planet (21)
+```
+
+The second one tells you what the model contains.

--- a/test/system/rb-solar/README.md
+++ b/test/system/rb-solar/README.md
@@ -41,8 +41,16 @@ the error envelope, and it **includes the reference's seed data as
 data** rather than copying it, so the rows this app serves and the
 rows the reference serves cannot drift apart.
 
-Four things in it are worth reading for the reasons behind them:
+Five things in it are worth reading for the reasons behind them:
 
+- **The entities are a map, keyed by their own names.** `$.entity.planet`
+  addresses one, `parent: "planet"` on the moon names a key that exists,
+  and a third entity is an insertion rather than a position. A map is
+  walked in sorted-key order, so where the order is on the page the
+  model states it: `sequence` lists the two in the order the migrations
+  create them and the seeds insert them, because a moon keys into a
+  planet. Five of the nine generators write one file per entity and
+  never see an order at all.
 - **Every field states its JSON name.** The wire says `terraformState`
   where the column says `terraform_state`, and `planet_id` either way.
   What a field is called in a target is a fact about the model, not a

--- a/test/system/rb-solar/check.sh
+++ b/test/system/rb-solar/check.sh
@@ -117,8 +117,8 @@ $AONTU render --marker '%%-' --check "$DIR/doc" "$DIR/gen/erd.mmd" >/dev/null 2>
 pinned=1
 $AONTU view doc --depth 2 --out "$DIR/doc/model-tree.txt" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
 $AONTU view doc --depth 2 --as svg --out "$DIR/doc/model-tree.svg" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
-$AONTU view doc --depth 2 --at '$.entity.0' --out "$DIR/doc/planet-tree.txt" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
-$AONTU view doc --depth 2 --at '$.entity.0' --as svg --out "$DIR/doc/planet-tree.svg" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
+$AONTU view doc --depth 2 --at '$.entity.planet' --out "$DIR/doc/planet-tree.txt" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
+$AONTU view doc --depth 2 --at '$.entity.planet' --as svg --out "$DIR/doc/planet-tree.svg" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
 $AONTU view lattice --out "$DIR/doc/value-lattice.txt" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
 $AONTU view lattice --as svg --out "$DIR/doc/value-lattice.svg" --check "$DIR/model.aon" >/dev/null 2>&1 || pinned=0
 [ "$pinned" = 1 ] \

--- a/test/system/rb-solar/doc/model-tree.svg
+++ b/test/system/rb-solar/doc/model-tree.svg
@@ -1,12 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 220 348" width="220" height="348" role="img" aria-label="Document tree at $: 16 keys to depth 2">
+<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 220 408" width="220" height="408" role="img" aria-label="Document tree at $: 19 keys to depth 2">
 <style>.av{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px}.av-t{fill:var(--av-ink,#1f2328)}.av-m{fill:var(--av-muted,#6e7781)}.av-box{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule,#8c959f);stroke-width:1}.av-cell{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-direct{fill:var(--av-ink,#1f2328);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-closure{fill:var(--av-closure,#9ec5fe);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-unmirrored{fill:var(--av-warn,#e3b341);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-line{stroke:var(--av-rule,#8c959f);stroke-width:1;fill:none}.av-up{stroke:var(--av-alert,#d1242f);stroke-width:1.5;fill:none;stroke-dasharray:4 3}.av-dot{fill:var(--av-ink,#1f2328)}.av-hole{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-bar{fill:var(--av-bar,#57606a)}</style>
 <text x="4" y="14" class="av-t">$</text>
 <path d="M8 20V30H26" class="av-line"/>
 <text x="28" y="34" class="av-t">entity</text>
 <path d="M32 40V50H50" class="av-line"/>
-<text x="52" y="54"><tspan class="av-t">0</tspan><tspan class="av-m"> (21)</tspan></text>
+<text x="52" y="54"><tspan class="av-t">moon</tspan><tspan class="av-m"> (27)</tspan></text>
 <path d="M32 40V70H50" class="av-line"/>
-<text x="52" y="74"><tspan class="av-t">1</tspan><tspan class="av-m"> (27)</tspan></text>
+<text x="52" y="74"><tspan class="av-t">planet</tspan><tspan class="av-m"> (21)</tspan></text>
 <path d="M8 20V90H26" class="av-line"/>
 <text x="28" y="94" class="av-t">error</text>
 <path d="M32 100V110H50" class="av-line"/>
@@ -22,15 +22,21 @@
 <path d="M32 180V210H50" class="av-line"/>
 <text x="52" y="214"><tspan class="av-t">planet</tspan><tspan class="av-m"> (8)</tspan></text>
 <path d="M8 20V230H26" class="av-line"/>
-<text x="28" y="234" class="av-t">service</text>
+<text x="28" y="234" class="av-t">sequence</text>
 <path d="M32 240V250H50" class="av-line"/>
-<text x="52" y="254"><tspan class="av-t">api</tspan><tspan class="av-m"> &quot;/api&quot;</tspan></text>
+<text x="52" y="254"><tspan class="av-t">0</tspan><tspan class="av-m"> (21)</tspan></text>
 <path d="M32 240V270H50" class="av-line"/>
-<text x="52" y="274"><tspan class="av-t">name</tspan><tspan class="av-m"> &quot;solar&quot;</tspan></text>
-<path d="M32 240V290H50" class="av-line"/>
-<text x="52" y="294"><tspan class="av-t">port</tspan><tspan class="av-m"> 8901</tspan></text>
-<path d="M32 240V310H50" class="av-line"/>
-<text x="52" y="314"><tspan class="av-t">root</tspan><tspan class="av-m"> &quot;planets#index&quot;</tspan></text>
-<path d="M32 240V330H50" class="av-line"/>
-<text x="52" y="334"><tspan class="av-t">title</tspan><tspan class="av-m"> &quot;Solar System&quot;</tspan></text>
+<text x="52" y="274"><tspan class="av-t">1</tspan><tspan class="av-m"> (27)</tspan></text>
+<path d="M8 20V290H26" class="av-line"/>
+<text x="28" y="294" class="av-t">service</text>
+<path d="M32 300V310H50" class="av-line"/>
+<text x="52" y="314"><tspan class="av-t">api</tspan><tspan class="av-m"> &quot;/api&quot;</tspan></text>
+<path d="M32 300V330H50" class="av-line"/>
+<text x="52" y="334"><tspan class="av-t">name</tspan><tspan class="av-m"> &quot;solar&quot;</tspan></text>
+<path d="M32 300V350H50" class="av-line"/>
+<text x="52" y="354"><tspan class="av-t">port</tspan><tspan class="av-m"> 8901</tspan></text>
+<path d="M32 300V370H50" class="av-line"/>
+<text x="52" y="374"><tspan class="av-t">root</tspan><tspan class="av-m"> &quot;planets#index&quot;</tspan></text>
+<path d="M32 300V390H50" class="av-line"/>
+<text x="52" y="394"><tspan class="av-t">title</tspan><tspan class="av-m"> &quot;Solar System&quot;</tspan></text>
 </svg>

--- a/test/system/rb-solar/doc/model-tree.txt
+++ b/test/system/rb-solar/doc/model-tree.txt
@@ -1,7 +1,7 @@
 $
 ├── entity
-│   ├── 0 (21)
-│   └── 1 (27)
+│   ├── moon (27)
+│   └── planet (21)
 ├── error
 │   ├── 0 (5)
 │   ├── 1 (5)
@@ -9,6 +9,9 @@ $
 ├── seed
 │   ├── moon (21)
 │   └── planet (8)
+├── sequence
+│   ├── 0 (21)
+│   └── 1 (27)
 └── service
     ├── api "/api"
     ├── name "solar"

--- a/test/system/rb-solar/doc/planet-tree.svg
+++ b/test/system/rb-solar/doc/planet-tree.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 324 808" width="324" height="808" role="img" aria-label="Document tree at $.entity.0: 39 keys to depth 2">
+<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 324 808" width="324" height="808" role="img" aria-label="Document tree at $.entity.planet: 39 keys to depth 2">
 <style>.av{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px}.av-t{fill:var(--av-ink,#1f2328)}.av-m{fill:var(--av-muted,#6e7781)}.av-box{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule,#8c959f);stroke-width:1}.av-cell{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-direct{fill:var(--av-ink,#1f2328);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-closure{fill:var(--av-closure,#9ec5fe);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-unmirrored{fill:var(--av-warn,#e3b341);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-line{stroke:var(--av-rule,#8c959f);stroke-width:1;fill:none}.av-up{stroke:var(--av-alert,#d1242f);stroke-width:1.5;fill:none;stroke-dasharray:4 3}.av-dot{fill:var(--av-ink,#1f2328)}.av-hole{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-bar{fill:var(--av-bar,#57606a)}</style>
-<text x="4" y="14" class="av-t">$.entity.0</text>
+<text x="4" y="14" class="av-t">$.entity.planet</text>
 <path d="M8 20V30H26" class="av-line"/>
 <text x="28" y="34" class="av-t">action</text>
 <path d="M32 40V50H50" class="av-line"/>

--- a/test/system/rb-solar/doc/planet-tree.txt
+++ b/test/system/rb-solar/doc/planet-tree.txt
@@ -1,4 +1,4 @@
-$.entity.0
+$.entity.planet
 ├── action
 │   ├── 0 (11)
 │   └── 1 (11)

--- a/test/system/rb-solar/doc/value-lattice.svg
+++ b/test/system/rb-solar/doc/value-lattice.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 704 222" width="704" height="222" role="img" aria-label="Value lattice at $: 482 value(s) placed">
+<svg xmlns="http://www.w3.org/2000/svg" class="av" viewBox="0 0 704 222" width="704" height="222" role="img" aria-label="Value lattice at $: 805 value(s) placed">
 <style>.av{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px}.av-t{fill:var(--av-ink,#1f2328)}.av-m{fill:var(--av-muted,#6e7781)}.av-box{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule,#8c959f);stroke-width:1}.av-cell{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-direct{fill:var(--av-ink,#1f2328);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-closure{fill:var(--av-closure,#9ec5fe);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-unmirrored{fill:var(--av-warn,#e3b341);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-line{stroke:var(--av-rule,#8c959f);stroke-width:1;fill:none}.av-up{stroke:var(--av-alert,#d1242f);stroke-width:1.5;fill:none;stroke-dasharray:4 3}.av-dot{fill:var(--av-ink,#1f2328)}.av-hole{fill:var(--av-bg,#f6f8fa);stroke:var(--av-rule-faint,#d0d7de);stroke-width:1}.av-bar{fill:var(--av-bar,#57606a)}</style>
 <path d="M368 34V51H64V68" class="av-line"/>
 <path d="M64 94V111H64V128" class="av-line"/>
@@ -19,17 +19,17 @@
 <rect x="348" y="8" width="40" height="26" class="av-cell"/>
 <text x="368" y="26" text-anchor="middle"><tspan class="av-t">top</tspan><tspan class="av-m"></tspan></text>
 <rect x="8" y="68" width="112" height="26" class="av-box"/>
-<text x="64" y="86" text-anchor="middle"><tspan class="av-t">string</tspan><tspan class="av-m"> (372)</tspan></text>
+<text x="64" y="86" text-anchor="middle"><tspan class="av-t">string</tspan><tspan class="av-m"> (618)</tspan></text>
 <rect x="296" y="68" width="64" height="26" class="av-cell"/>
 <text x="328" y="86" text-anchor="middle"><tspan class="av-t">number</tspan><tspan class="av-m"></tspan></text>
 <rect x="520" y="68" width="112" height="26" class="av-box"/>
-<text x="576" y="86" text-anchor="middle"><tspan class="av-t">boolean</tspan><tspan class="av-m"> (48)</tspan></text>
+<text x="576" y="86" text-anchor="middle"><tspan class="av-t">boolean</tspan><tspan class="av-m"> (96)</tspan></text>
 <rect x="640" y="68" width="48" height="26" class="av-cell"/>
 <text x="664" y="86" text-anchor="middle"><tspan class="av-t">null</tspan><tspan class="av-m"></tspan></text>
 <rect x="32" y="128" width="64" height="26" class="av-cell"/>
 <text x="64" y="146" text-anchor="middle"><tspan class="av-t">path()</tspan><tspan class="av-m"></tspan></text>
 <rect x="128" y="128" width="112" height="26" class="av-box"/>
-<text x="184" y="146" text-anchor="middle"><tspan class="av-t">integer</tspan><tspan class="av-m"> (62)</tspan></text>
+<text x="184" y="146" text-anchor="middle"><tspan class="av-t">integer</tspan><tspan class="av-m"> (91)</tspan></text>
 <rect x="252" y="128" width="56" height="26" class="av-cell"/>
 <text x="280" y="146" text-anchor="middle"><tspan class="av-t">float</tspan><tspan class="av-m"></tspan></text>
 <rect x="312" y="128" width="96" height="26" class="av-cell"/>

--- a/test/system/rb-solar/doc/value-lattice.txt
+++ b/test/system/rb-solar/doc/value-lattice.txt
@@ -1,10 +1,10 @@
                                             top
                                              │
        ┌────────────────────────────────┬────┴─────────────────────────┬──────────┐
- string (372)                        number                      boolean (48)   null
+ string (618)                        number                      boolean (96)   null
        │                                │                              │          │
        ├──────────────┬───────────┬─────┴───┬────────────┐             │          │
-    path()      integer (62)    float  biginteger   bigdecimal         │          │
+    path()      integer (91)    float  biginteger   bigdecimal         │          │
        │              │           │         │            │             │          │
        └──────────────┴───────────┴─────────┴┬───────────┴─────────────┴──────────┘
                                             nil

--- a/test/system/rb-solar/gen/erd.mmd
+++ b/test/system/rb-solar/gen/erd.mmd
@@ -48,7 +48,7 @@ erDiagram
 %%-       # decide. `form` keeps the order a `pack` would sort away.
 %%-       {
 %%-         k: "frag"
-%%-         of: emit($.entity, {
+%%-         of: emit($.sequence, {
 %%-           match: class: string
 %%-           replace: ENTITY: upper(.class)
 %%-           body: [

--- a/test/system/rb-solar/gen/migrate.rb
+++ b/test/system/rb-solar/gen/migrate.rb
@@ -1,13 +1,15 @@
 #- # migrate.rb --- one migration per entity, columns in model order.
 #- #
-#- # The entity list's ORDER is the order the migrations run in, so a
-#- # parent's table exists before the child that keys into it. `form`
-#- # makes one element per entity IN THE DATA'S ORDER, where `pack`
-#- # would sort by key and lose exactly that; `key()` at the element is
-#- # its position, and the position is the migration's version.
+#- # READS `$.sequence`, NOT `$.entity`. The entities are a map and a map
+#- # is walked in sorted-key order, which would create `moons` before
+#- # `planets` and leave the child's foreign key pointing at a table that
+#- # does not exist yet. `$.sequence` is the model's list of the two in
+#- # the order they must be created; `form` makes one element per entry
+#- # IN THAT ORDER, and `key()` at the element is its position, which is
+#- # the migration's version.
 #- @"../model.aon"
 #-
-#- ordered: form($.entity, _ & { seq:key() })
+#- ordered: form($.sequence, _ & { seq:key() })
 #-
 #- code: units: emit($.ordered, {
 #-   match: table: string

--- a/test/system/rb-solar/gen/routes.rb
+++ b/test/system/rb-solar/gen/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
 #-       # --- the human pages -----------------------------------------------
 #-       {
 #-         k: "frag"
-#-         of: emit($.entity, {
+#-         of: emit($.sequence, {
 #-           match: controller: string
 #-           # NO KEY IS A SUBSTRING OF ANOTHER, which `replace` checks before it
 #-           # visits a node: `COLLECTION` inside `COLLECTION_HELPER` is refused
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
 #-       # the selection.
 #-       {
 #-         k: "frag"
-#-         of: emit($.entity, {
+#-         of: emit($.sequence, {
 #-           match: controller: string
 #-           replace: {
 #-             API_LIST: .api_collection

--- a/test/system/rb-solar/gen/seeds.rb
+++ b/test/system/rb-solar/gen/seeds.rb
@@ -2,6 +2,11 @@
 #- #
 #- # The rows are the reference's `solar.data.json`, joined to their
 #- # entity in the model so each row carries the class that inserts it.
+#- #
+#- # READS `$.sequence`, NOT `$.entity`, for the reason migrate.rb does:
+#- # a map is walked in sorted-key order, and a moon whose planet has not
+#- # been inserted yet fails `belongs_to`. The planets go in first
+#- # because the model says they do.
 #- @"../model.aon"
 #-
 #- code: units: [
@@ -30,7 +35,7 @@ Planet.delete_all
 #-       # refuses it. One fragment per thing that produces lines.
 #-       {
 #-         k: "frag"
-#-         of: emit($.entity, {
+#-         of: emit($.sequence, {
 #-           match: class: string
 #-           replace: TITLE: .plural
 #-           body: [

--- a/test/system/rb-solar/model.aon
+++ b/test/system/rb-solar/model.aon
@@ -48,10 +48,20 @@ seed: @"./ref/solar.data.json"
 
 # --- the entities ----------------------------------------------------
 #
-# A list, not a map: the order is the order the migrations run in, and
-# a parent's table must exist before the child's foreign key.
-entity: [
-  {
+# A MAP, KEYED BY THE ENTITY'S OWN NAME. These are named things, not a
+# sequence: `$.entity.planet` addresses one, `parent: "planet"` below
+# names a key that exists, and a third entity is an insertion rather
+# than a position. A list would have given every one of them a number
+# nobody chose and nothing reads.
+#
+# `id` REPEATS THE KEY INSIDE THE NODE, because a child cannot read its
+# own key: `emit` and `filter` dispatch on what the node holds, and
+# `form` over a map hands its template the POSITION rather than the
+# name. `model.rb` needs it for a filename and `seeds.rb` for a class,
+# so it is written down, which is what this file does with every other
+# fact a generator reads.
+entity: {
+  planet: {
     id: "planet"
     class: "Planet"
     table: "planets"
@@ -202,7 +212,7 @@ entity: [
     ]
   }
 
-  {
+  moon: {
     id: "moon"
     class: "Moon"
     table: "moons"
@@ -298,7 +308,26 @@ entity: [
 
     action: []
   }
-]
+}
+
+# --- the order, where the order is visible ---------------------------
+#
+# A map is walked in sorted-key order, so `$.entity` gives moon before
+# planet. Five of the nine generators write one file per entity, and
+# for those the order is invisible: a controller is a controller
+# whichever was rendered first, and they read `$.entity`.
+#
+# FOUR GENERATORS PUT THE ENTITIES IN ONE FILE, and there the order is
+# on the page. Two of them need this one: a moon keys into a planet, so
+# the migrations must create `planets` first and the seeds must insert
+# a planet before the moon that belongs to it. The other two only read
+# better for it -- routes and a diagram that name the parent before the
+# child.
+#
+# So the order is stated, once, rather than smuggled in as the order
+# somebody happened to type the entities in. Adding a third entity is
+# an insertion in the map and a decision here.
+sequence: [$.entity.planet $.entity.moon]
 
 # --- the error envelope ----------------------------------------------
 #


### PR DESCRIPTION
The entities in `test/system/rb-solar/model.aon` were a list. So `$.entity.0` was how you addressed a planet, `parent: "planet"` on the moon named something no key matched, and a third entity would have been a position rather than an insertion. They are a map now, keyed by the entity's own name.

## What the order was doing there

The list carried one real fact: **a moon keys into a planet.** The migrations must create `planets` before `moons`, and the seeds must insert a planet before the moon that belongs to it. A map is walked in sorted-key order — moon, planet — which would have done both backwards.

So the order is stated rather than implied. `sequence: [$.entity.planet $.entity.moon]` lists the two in the order they are created, and the generators split by whether the order is on the page:

| generator | reads | why |
| --- | --- | --- |
| `migrate.rb`, `seeds.rb` | `$.sequence` | the order is correctness — the parent table and row must exist first |
| `routes.rb`, `erd.mmd` | `$.sequence` | both entities land in one file, and parent-before-child reads better |
| `model.rb`, `api_base.rb`, `api_controller.rb`, `ui_controller.rb`, `views.aon` | `$.entity` | one file per entity; the order is invisible |

`check.sh` addresses the pinned planet tree as `$.entity.planet` where it said `$.entity.0`, which is the change in one line.

**The generated application is byte for byte what it was.** Only the model, four generators, the pinned trees and the README moved — the trees because `entity` now has named children, and the README because the list was one of the four modelling decisions it explains. The tree is the argument in miniature:

```
├── entity                    ├── entity
│   ├── 0 (21)          ->    │   ├── moon (27)
│   └── 1 (27)                │   └── planet (21)
```

`id` stays inside each entity, repeating its key. A dispatch chooses a rule by what the *node* holds and a node does not hold its own key, so a generator that needs the name for a filename or a class has to find it there. `pack(…, _ & { id:key() })` could supply it, but this model states the facts its generators read, and this is one.

## AONTU-GUIDE.md

New, at the root: tips for writing models, as distinct from the reference (what the forms mean) and the style guide (how prose is written). The first entry is this change generalised — avoid arrays unless you need an ordering, use a named map, and when the ordering is real, state it.

It records the mechanics you need to act on it, all of which I ran rather than recalled:

- a map is walked in sorted-key order, a list in source order;
- `form` over a map yields a **list**, and `key()` in its template is the **position**;
- `pack` over a map yields a **map**, and there `key()` is the **key** — which is how you get a name into a node;
- a node does not hold its own key, so a dispatch cannot read it.

It is not in `gated-docs.cjs` — it is a contributor document, like `ADR.md` — so Vale and the snippet gate do not cover it. I ran every snippet through the CLI by hand instead; one of them (`form($.step, key())`) was wrong when I first wrote it and the engine said so.

## Checks

- `test/system/rb-solar/check.sh`: **all 11 checks pass**, including check 9, the reference's 20 validation tests against the generated Rails app, and check 11, the human pages. Only the SDK check skips, for want of the reference repo.
- `ts/test/docs.test.ts`: **21 pass**, which covers the style rules on the edited `README.md`.

Two notes on the environment this ran in: `ts/node_modules` had to be installed before anything worked, and only Node 22 is available here where `ts/package.json` asks for 24 and CI uses it. The engine ran fine on 22, but CI is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnmSY1iJ2R3SjVvAH3v276

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnmSY1iJ2R3SjVvAH3v276)_