### PR TITLE
release: write down the path for an environment without gh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ Quick reference:
 - Shared behaviour lives in `test/spec/*.tsv` and is run by both
   `ts/test/spec.test.ts` and `go/spec_test.go`.
 - `make test` runs both suites; `make cov` checks the ADR-002 floor.
+- A release publishes over OIDC, by dispatching `publish.yml`, never a
+  local token publish. `make publish` needs the `gh` CLI; without it,
+  run its steps and dispatch through the API. See
+  [docs/release-and-tag.md](docs/release-and-tag.md), "Releasing
+  without `gh`".
 - Documentation edits follow [docs/STYLE-GUIDE.md](docs/STYLE-GUIDE.md)
   (Diátaxis placement, voice, banned phrases, snippet directives);
   `ts/test/docs.test.ts` enforces it — every tagged snippet tested or

--- a/docs/release-and-tag.md
+++ b/docs/release-and-tag.md
@@ -77,6 +77,46 @@ Release only the half that changed. A TypeScript-only change wants
 `go=false`; leaving it ticked with an unchanged `VERSION` is harmless: the
 workflow refuses rather than moving an existing tag.
 
+### Releasing without `gh`
+
+**The dispatch is what publishes**, over OIDC, and it is the only thing
+that may: a local publish goes over a token and bypasses the trusted
+publisher entirely. So an environment without the `gh` CLI (an agent
+session, a container that ships no forge tooling) does not get a
+different release path. It gets the same one, driven through the API.
+
+`make publish` refuses early in that environment, at its `command -v gh`
+guard, and it refuses **before** it bumps anything, so nothing is left
+half-done. Run what it would have run:
+
+1. **Its guards, all of them, first.** On `main`, clean tree, not behind
+   `origin/main`, and neither tag already taken, asked of **origin**,
+   because a clone's tag list is stale exactly when it matters.
+   Everything after them is irreversible.
+2. `cd ts && npm version --no-git-tag-version <V>`, which also rewrites
+   `ts/src/aontu.ts`'s `VERSION` through the `version` lifecycle script,
+   and the `perl` rewrite of `const VERSION` in `go/aontu.go`.
+3. `make all`, both builds and both suites, against the bumped tree.
+4. Stage the four paths the target stages: `ts/package.json`,
+   `ts/src/aontu.ts`, `ts/dist` and `go/aontu.go`. **Three TypeScript
+   paths, not one**: the source constant and the committed build move
+   with the manifest, and `ts/test/version.test.ts` catches it in the
+   publish job if they do not, which is after the tag push.
+5. Commit `release: npm <V> go <GOV>`, and push `main`.
+6. Dispatch `publish.yml` on `main` with `npm`, `go` and
+   `expect_sha=<the commit just pushed>`, through
+   `POST /repos/{owner}/{repo}/actions/workflows/publish.yml/dispatches`
+   or any client for it.
+
+`expect_sha` is the step to not skip. `--ref main` names a moving
+branch, and the guard exists so that a commit landing between the push
+and the run cannot be released under the version just bumped. For the
+same reason, **do not push to `main` while a publish run is in flight**:
+the run resolves the ref more than once, and the tag it writes should be
+the commit it tested.
+
+First driven this way on 2026-09-10, for npm 0.62.0 and go 0.1.20.
+
 ## The trusted-publisher registration
 
 The repository moved from `rjrodger/aontu` to `aontu-lang/aontu`, and **an


### PR DESCRIPTION
## Why

A release publishes over OIDC by dispatching `publish.yml`, and that is the only way it may publish: a local run goes over a token and bypasses the trusted publisher entirely. `make publish` reaches that dispatch through the `gh` CLI, and an environment without `gh` (an agent session, a container that ships no forge tooling) has no different path, only the same one driven through the API.

That was not written down. The 0.62.0 / go 0.1.20 release was cut this way today, and the steps are now in `docs/release-and-tag.md` under **Releasing without `gh`**, beside the two existing ways in.

## What it says

`make publish` refuses at its `command -v gh` guard **before** it bumps anything, so nothing is left half-done. The section lists what it would have run, and calls out the two steps that are easy to get wrong:

- **Stage three TypeScript paths, not one.** `npm version` rewrites `ts/src/aontu.ts`'s `VERSION` through the `version` lifecycle script, and `make all` rebuilds the committed `ts/dist`. `ts/test/version.test.ts` catches a mismatch in the publish job, which is *after* the tag push, so it fails closed and late.
- **Pass `expect_sha`.** `--ref main` names a moving branch, and the guard exists so a commit landing between the push and the run cannot be released under the version just bumped. For the same reason the section says not to push to `main` while a publish run is in flight, since the run resolves the ref more than once and the tag it writes should be the commit it tested.

`CLAUDE.md` gains one line pointing at the section, since that file is what an agent reads first. The detail stays in one place.

## Verification

`ts/test/docs.test.ts` passes (21) with `docs/release-and-tag.md` in the gated set, and `make prose` is clean over all 72 files. The first draft tripped `no-em-dashes-in-prose`; the em dashes are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3zU1V3aTWTUFybD3c54xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3zU1V3aTWTUFybD3c54xe)_