### PR TITLE
Refresh the flake's vendorHash for the current Go dependency set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           src = ./.;
           modRoot = "go";
           subPackages = [ "cmd/aontu" "cmd/aontu-lsp" ];
-          vendorHash = "sha256-Z7wUbXGcP8lDv1lh9JB60mn0qsVQwLTKkTkeW3J4vtc=";
+          vendorHash = "sha256-cOG/iwHodkLC8uYXCgSXpXKINX2oMtP76apzkmSYLdU=";
           CGO_ENABLED = 0;
           ldflags = [ "-s" "-w" ];
           # The suite runs in CI (make test) and takes a minute; the


### PR DESCRIPTION
Fixes the stale `vendorHash` reported in #207, so `nix build` and
`nix run github:aontu-lang/aontu` work again.

One line:

```diff
-          vendorHash = "sha256-Z7wUbXGcP8lDv1lh9JB60mn0qsVQwLTKkTkeW3J4vtc=";
+          vendorHash = "sha256-cOG/iwHodkLC8uYXCgSXpXKINX2oMtP76apzkmSYLdU=";
```

## How the hash was obtained

Nix is not available in the session that found this, and a NAR hash
typed from memory would look authoritative and fail identically if
wrong. So the method was established against a known answer before it
was used to produce an unknown one.

`buildGoModule` hashes the NAR serialisation of `go mod vendor` output
(`outputHashMode = "recursive"`). That serialisation was implemented
and run first against `go.mod`/`go.sum` **as of #148**, the commit that
introduced `flake.nix` and its hash:

```
$ git worktree add --detach wt-old 05a8760
$ (cd wt-old/go && go mod vendor -o vendor-old)
$ narhash vendor-old
sha256-Z7wUbXGcP8lDv1lh9JB60mn0qsVQwLTKkTkeW3J4vtc=
```

That is the committed value, byte for byte. Reproducing it is what
licenses the rest: it confirms the serialisation, the SRI encoding,
and that `go mod vendor` is what gets hashed.

The replacement is the same serialisation over the current tree, and
it is identical across two independent runs:

```
run1: sha256-cOG/iwHodkLC8uYXCgSXpXKINX2oMtP76apzkmSYLdU=
run2: sha256-cOG/iwHodkLC8uYXCgSXpXKINX2oMtP76apzkmSYLdU=
```

## Why it was stale

`flake.nix` has been touched once. `go/go.mod` has changed three times
since, and the vendored module set shows all three:

```
$ diff <(grep '^# ' vendor-old/modules.txt) <(grep '^# ' vendor-new/modules.txt)
> # github.com/tabnas/abnf/go v0.4.13
> # github.com/tabnas/bnf/go v0.1.15
< # github.com/tabnas/parser/go v0.9.0
> # github.com/tabnas/parser/go v0.9.7
```

`abnf` and `bnf` are entirely new in the tree — added by `b5c19ae`,
which is where the hash went stale, two commits before the release
work. A new module cannot leave the vendor hash unchanged.

## Verification beyond the hash

The tree that produces the new hash was then built with the flake's own
settings — `modRoot = "go"`, both `subPackages`, `CGO_ENABLED = 0`,
`ldflags = [ "-s" "-w" ]` — which is what nix does after the vendor
step:

```
$ GOFLAGS=-mod=vendor CGO_ENABLED=0 go build -ldflags "-s -w" \
    -o bin/ ./cmd/aontu ./cmd/aontu-lsp
$ bin/aontu --version
0.1.21
```

Both binaries link, and the version matches the one the flake derives
from `go/aontu.go`.

## What this does not do

**It adds no gate**, so this can go stale again on the next dependency
bump — exactly as it did three times here. No workflow installs nix and
no make target or test reads `flake.nix`, which is why every other gate
stayed green throughout. #207 stays open for that, with a proposed job
keyed on `go/go.mod`, `go/go.sum` and `flake.nix`, and for the question
of whether to commit a `flake.lock` so the hash is a stable fact rather
than one riding an unpinned `nixpkgs`.

Released artifacts are unaffected either way: npm, the Go module, the
container image and the binary channels never read `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPKaf817qavGXeuRARSer6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPKaf817qavGXeuRARSer6)_